### PR TITLE
Proposals for improving examples

### DIFF
--- a/numba_dppy/examples/sum.py
+++ b/numba_dppy/examples/sum.py
@@ -42,9 +42,9 @@ def main():
     N = global_size
     print("N", N)
 
-    a = np.array(np.random.random(N), dtype=np.float32)
-    b = np.array(np.random.random(N), dtype=np.float32)
-    c = np.ones_like(a)
+    a = np.arange(N, dtype=np.float32)
+    b = np.arange(N, dtype=np.float32)
+    c = np.empty_like(a)
 
     # Use the environment variable SYCL_DEVICE_FILTER to change the default device.
     # See https://github.com/intel/llvm/blob/sycl/sycl/doc/EnvironmentVariables.md#sycl_device_filter.

--- a/numba_dppy/examples/sum.py
+++ b/numba_dppy/examples/sum.py
@@ -46,23 +46,14 @@ def main():
     b = np.array(np.random.random(N), dtype=np.float32)
     c = np.ones_like(a)
 
-    try:
-        device = dpctl.select_gpu_device()
-        print("Scheduling on ...")
-        device.print_device_info()
-        with dpctl.device_context(device):
-            driver(a, b, c, global_size)
-    except ValueError:
-        print("Failed to schedule on a SYCL GPU device")
+    # Use the environment variable SYCL_DEVICE_FILTER to change the default device.
+    # See https://github.com/intel/llvm/blob/sycl/sycl/doc/EnvironmentVariables.md#sycl_device_filter.
+    device = dpctl.select_default_device()
+    print("Scheduling on ...")
+    device.print_device_info()
 
-    try:
-        device = dpctl.select_cpu_device()
-        print("Scheduling on ...")
-        device.print_device_info()
-        with dpctl.device_context(device):
-            driver(a, b, c, global_size)
-    except ValueError:
-        print("Failed to schedule on a SYCL CPU device")
+    with dpctl.device_context(device):
+        driver(a, b, c, global_size)
 
     print("Done...")
 


### PR DESCRIPTION
- Closes #428 - default device. Fixes #427.
- no `random`, use `arange`
- no `ones_like`, use `empty_like`