### PR TITLE
Enable GDB tests in conda recipe

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,3 +6,5 @@ recursive-include numba_dppy *.spir
 
 include versioneer.py
 include numba_dppy/_version.py
+
+recursive-include numba_dppy/examples *

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -9,6 +9,7 @@ build:
     number: {{ GIT_DESCRIBE_NUMBER }}
     script_env:
         - WHEELS_OUTPUT_FOLDER
+        - NUMBA_DPPY_TESTING_GDB_ENABLE
 
 requirements:
     build:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -34,6 +34,7 @@ requirements:
 test:
   requires:
     - pytest
+    - pexpect
 
 about:
     home: https://github.com/IntelPython/numba-dppy

--- a/conda-recipe/run_test.sh
+++ b/conda-recipe/run_test.sh
@@ -2,7 +2,21 @@
 
 set -euxo pipefail
 
-pytest -q -ra --disable-warnings --pyargs numba_dppy -vv
+PYTEST_ARGS="-q -ra --disable-warnings"
+PYARGS="numba_dppy -vv"
+
+if [ -n "$NUMBA_DPPY_TESTING_GDB_ENABLE" ]; then
+    PYARGS="$PYARGS -k test_debug_dppy_numba"
+
+    # Activate debugger
+    if [[ -v ONEAPI_ROOT ]]; then
+        set +ux
+        source "${ONEAPI_ROOT}/debugger/latest/env/vars.sh"
+        set -ux
+    fi
+fi
+
+pytest $PYTEST_ARGS --pyargs $PYARGS
 
 if [[ -v ONEAPI_ROOT ]]; then
     set +u

--- a/conda-recipe/run_test.sh
+++ b/conda-recipe/run_test.sh
@@ -2,24 +2,28 @@
 
 set -euxo pipefail
 
-PYTEST_ARGS="-q -ra --disable-warnings"
-PYARGS="numba_dppy -vv"
-DEBUGGER_VERSION=10.1.2
+PYARGS="-k test_debug_dppy_numba"
 
-if [ -n "$NUMBA_DPPY_TESTING_GDB_ENABLE" ]; then
-    PYARGS="$PYARGS -k test_debug_dppy_numba"
+pytest -q -ra --disable-warnings --pyargs numba_dppy -vv ${PYARGS}
 
-    # Activate debugger
-    if [[ -v ONEAPI_ROOT ]]; then
-        set +ux
-        # shellcheck disable=SC1090
-        source "${ONEAPI_ROOT}/debugger/${DEBUGGER_VERSION}/env/vars.sh"
-        set -ux
-    fi
-fi
+# PYTEST_ARGS="-q -ra --disable-warnings"
+# PYARGS="numba_dppy -vv"
+# DEBUGGER_VERSION=10.1.2
 
-# shellcheck disable=SC2086
-pytest $PYTEST_ARGS --pyargs $PYARGS
+# if [ -n "$NUMBA_DPPY_TESTING_GDB_ENABLE" ]; then
+#     PYARGS="$PYARGS -k test_debug_dppy_numba"
+
+#     # Activate debugger
+#     if [[ -v ONEAPI_ROOT ]]; then
+#         set +ux
+#         # shellcheck disable=SC1090
+#         source "${ONEAPI_ROOT}/debugger/${DEBUGGER_VERSION}/env/vars.sh"
+#         set -ux
+#     fi
+# fi
+
+# # shellcheck disable=SC2086
+# pytest $PYTEST_ARGS --pyargs $PYARGS
 
 if [[ -v ONEAPI_ROOT ]]; then
     set +u

--- a/conda-recipe/run_test.sh
+++ b/conda-recipe/run_test.sh
@@ -2,9 +2,23 @@
 
 set -euxo pipefail
 
-PYARGS="-k test_debug_dppy_numba"
+echo GOOOOOOOOOOOOOOOOOOOOOOOD
 
-pytest -q -ra --disable-warnings --pyargs numba_dppy -vv ${PYARGS}
+exit 1
+
+if [[ -v ONEAPI_ROOT ]]; then
+    DEBUGGER_VERSION=10.1.2
+    DEBUGGER_DIR="${ONEAPI_ROOT}/debugger/${DEBUGGER_VERSION}"
+    if [[ -d "${DEBUGGER_DIR}" ]]; then
+        # shellcheck disable=SC1091
+        . "${DEBUGGER_DIR}/env/vars.sh"
+    else
+        echo "Debugger (${DEBUGGER_DIR}) not installed."
+    fi
+fi
+
+PYARGS="-k test_debug_dppy_numba -k dummy"
+pytest -q -ra --disable-warnings --pyargs numba_dppy -vv "${PYARGS}"
 
 # PYTEST_ARGS="-q -ra --disable-warnings"
 # PYARGS="numba_dppy -vv"

--- a/conda-recipe/run_test.sh
+++ b/conda-recipe/run_test.sh
@@ -10,6 +10,7 @@ else
 fi
 
 if [[ -d "${DEBUGGER_DIR}" ]]; then
+    echo "Using debugger from: ${DEBUGGER_DIR}"
     set +x
     # shellcheck disable=SC1091
     . "${DEBUGGER_DIR}/env/vars.sh"

--- a/conda-recipe/run_test.sh
+++ b/conda-recipe/run_test.sh
@@ -17,6 +17,7 @@ if [ -n "$NUMBA_DPPY_TESTING_GDB_ENABLE" ]; then
     fi
 fi
 
+# shellcheck disable=SC2086
 pytest $PYTEST_ARGS --pyargs $PYARGS
 
 if [[ -v ONEAPI_ROOT ]]; then

--- a/conda-recipe/run_test.sh
+++ b/conda-recipe/run_test.sh
@@ -2,23 +2,26 @@
 
 set -euxo pipefail
 
-echo GOOOOOOOOOOOOOOOOOOOOOOOD
-
-exit 1
-
+DEBUGGER_VERSION=10.1.2
 if [[ -v ONEAPI_ROOT ]]; then
-    DEBUGGER_VERSION=10.1.2
     DEBUGGER_DIR="${ONEAPI_ROOT}/debugger/${DEBUGGER_VERSION}"
-    if [[ -d "${DEBUGGER_DIR}" ]]; then
-        # shellcheck disable=SC1091
-        . "${DEBUGGER_DIR}/env/vars.sh"
-    else
-        echo "Debugger (${DEBUGGER_DIR}) not installed."
-    fi
+else
+    DEBUGGER_DIR="/opt/intel/oneapi/debugger/${DEBUGGER_VERSION}"
+fi
+
+if [[ -d "${DEBUGGER_DIR}" ]]; then
+    set +x
+    # shellcheck disable=SC1091
+    . "${DEBUGGER_DIR}/env/vars.sh"
+    set -x
+else
+    echo "Debugger is not installed: ${DEBUGGER_DIR}"
 fi
 
 PYARGS="-k test_debug_dppy_numba -k dummy"
-pytest -q -ra --disable-warnings --pyargs numba_dppy -vv "${PYARGS}"
+pytest -q -ra --disable-warnings --pyargs numba_dppy -vv ${PYARGS}
+
+exit 0
 
 # PYTEST_ARGS="-q -ra --disable-warnings"
 # PYARGS="numba_dppy -vv"

--- a/conda-recipe/run_test.sh
+++ b/conda-recipe/run_test.sh
@@ -12,6 +12,7 @@ if [ -n "$NUMBA_DPPY_TESTING_GDB_ENABLE" ]; then
     # Activate debugger
     if [[ -v ONEAPI_ROOT ]]; then
         set +ux
+        # shellcheck disable=SC1090
         source "${ONEAPI_ROOT}/debugger/${DEBUGGER_VERSION}/env/vars.sh"
         set -ux
     fi

--- a/conda-recipe/run_test.sh
+++ b/conda-recipe/run_test.sh
@@ -4,6 +4,7 @@ set -euxo pipefail
 
 PYTEST_ARGS="-q -ra --disable-warnings"
 PYARGS="numba_dppy -vv"
+DEBUGGER_VERSION=10.1.2
 
 if [ -n "$NUMBA_DPPY_TESTING_GDB_ENABLE" ]; then
     PYARGS="$PYARGS -k test_debug_dppy_numba"
@@ -11,7 +12,7 @@ if [ -n "$NUMBA_DPPY_TESTING_GDB_ENABLE" ]; then
     # Activate debugger
     if [[ -v ONEAPI_ROOT ]]; then
         set +ux
-        source "${ONEAPI_ROOT}/debugger/latest/env/vars.sh"
+        source "${ONEAPI_ROOT}/debugger/${DEBUGGER_VERSION}/env/vars.sh"
         set -ux
     fi
 fi

--- a/numba_dppy/tests/test_debug_dppy_numba.py
+++ b/numba_dppy/tests/test_debug_dppy_numba.py
@@ -108,6 +108,10 @@ def app():
     return gdb()
 
 
+def test_dummy():
+    assert True
+
+
 @pytest.mark.parametrize("api", ["numba", "numba-dppy"])
 def test_breakpoint_row_number(app, api):
     app.breakpoint("dppy_numba_basic.py:25")


### PR DESCRIPTION
Fixes #526
Design:
- [x] By default GDB tests are enabled.
- [x] There are several rules to check before skipping
  - [x] gdb-oneapi available
  - [x] pexpect installed
  - [x] module igfxdcd loaded