### PR TITLE
Register global functions

### DIFF
--- a/numba_dpex/ocl/ocldecl.py
+++ b/numba_dpex/ocl/ocldecl.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from numba import types
+from numba.core import types
 from numba.core.typing.npydecl import parse_dtype, parse_shape
 from numba.core.typing.templates import (
     AbstractTemplate,
@@ -45,11 +45,11 @@ register(dpex.get_global_id, (types.intp, types.uint32))
 register(dpex.get_local_id, (types.intp, types.uint32))
 register(dpex.get_group_id, (types.intp, types.uint32))
 register(dpex.get_num_groups, (types.intp, types.uint32))
-register(dpex.get_work_dim, (types.intp, types.uint32))
+register(dpex.get_work_dim, (types.uint32,))
 register(dpex.get_global_size, (types.intp, types.uint32))
 register(dpex.get_local_size, (types.intp, types.uint32))
-register(dpex.barrier, [(types.intp, types.uint32), (types.void,)])
-register(dpex.mem_fence, (types.intp, types.uint32))
+register(dpex.barrier, [(types.void, types.uint32), (types.void,)])
+register(dpex.mem_fence, (types.void, types.uint32))
 register(dpex.sub_group_barrier, (types.void,))
 
 # dpex.atomic submodule -------------------------------------------------------
@@ -60,7 +60,8 @@ class Ocl_atomic_add(AbstractTemplate):
     key = dpex.atomic.add
 
     def generic(self, args, kws):
-        assert not kws
+        if kws:
+            raise AssertionError("Keyword arguments not supported here.")
         ary, idx, val = args
 
         if ary.ndim == 1:
@@ -74,7 +75,8 @@ class Ocl_atomic_sub(AbstractTemplate):
     key = dpex.atomic.sub
 
     def generic(self, args, kws):
-        assert not kws
+        if kws:
+            raise AssertionError("Keyword arguments not supported here.")
         ary, idx, val = args
 
         if ary.ndim == 1:

--- a/numba_dpex/ocl/ocldecl.py
+++ b/numba_dpex/ocl/ocldecl.py
@@ -25,66 +25,32 @@ intrinsic_global = registry.register_global
 # register_number_classes(intrinsic_global)
 
 
-@intrinsic
-class Ocl_get_global_id(ConcreteTemplate):
-    key = dpex.get_global_id
-    cases = [signature(types.intp, types.uint32)]
+def register(function, args):
+    base = ConcreteTemplate
+    name = f"Ocl_{function.__name__}"
+
+    if isinstance(args, list):
+        cases = [signature(*a) for a in args]
+    else:
+        cases = [signature(*args)]
+
+    dct = {"key": function, "cases": cases}
+    cls = type(base)(name, (base,), dct)
+
+    globals()[name] = intrinsic(cls)
+    intrinsic_global(function, types.Function(cls))
 
 
-@intrinsic
-class Ocl_get_local_id(ConcreteTemplate):
-    key = dpex.get_local_id
-    cases = [signature(types.intp, types.uint32)]
-
-
-@intrinsic
-class Ocl_get_group_id(ConcreteTemplate):
-    key = dpex.get_group_id
-    cases = [signature(types.intp, types.uint32)]
-
-
-@intrinsic
-class Ocl_get_num_groups(ConcreteTemplate):
-    key = dpex.get_num_groups
-    cases = [signature(types.intp, types.uint32)]
-
-
-@intrinsic
-class Ocl_get_work_dim(ConcreteTemplate):
-    key = dpex.get_work_dim
-    cases = [signature(types.uint32)]
-
-
-@intrinsic
-class Ocl_get_global_size(ConcreteTemplate):
-    key = dpex.get_global_size
-    cases = [signature(types.intp, types.uint32)]
-
-
-@intrinsic
-class Ocl_get_local_size(ConcreteTemplate):
-    key = dpex.get_local_size
-    cases = [signature(types.intp, types.uint32)]
-
-
-@intrinsic
-class Ocl_barrier(ConcreteTemplate):
-    key = dpex.barrier
-    cases = [signature(types.void, types.uint32), signature(types.void)]
-
-
-@intrinsic
-class Ocl_mem_fence(ConcreteTemplate):
-    key = dpex.mem_fence
-    cases = [signature(types.void, types.uint32)]
-
-
-@intrinsic
-class Ocl_sub_group_barrier(ConcreteTemplate):
-    key = dpex.sub_group_barrier
-
-    cases = [signature(types.void)]
-
+register(dpex.get_global_id, (types.intp, types.uint32))
+register(dpex.get_local_id, (types.intp, types.uint32))
+register(dpex.get_group_id, (types.intp, types.uint32))
+register(dpex.get_num_groups, (types.intp, types.uint32))
+register(dpex.get_work_dim, (types.intp, types.uint32))
+register(dpex.get_global_size, (types.intp, types.uint32))
+register(dpex.get_local_size, (types.intp, types.uint32))
+register(dpex.barrier, [(types.intp, types.uint32), (types.void,)])
+register(dpex.mem_fence, (types.intp, types.uint32))
+register(dpex.sub_group_barrier, (types.void,))
 
 # dpex.atomic submodule -------------------------------------------------------
 
@@ -227,34 +193,34 @@ class OclModuleTemplate(AttributeTemplate):
     key = types.Module(dpex)
 
     def resolve_get_global_id(self, mod):
-        return types.Function(Ocl_get_global_id)
+        return types.Function(globals()["Ocl_get_global_id"])
 
     def resolve_get_local_id(self, mod):
-        return types.Function(Ocl_get_local_id)
+        return types.Function(globals()["Ocl_get_local_id"])
 
     def resolve_get_global_size(self, mod):
-        return types.Function(Ocl_get_global_size)
+        return types.Function(globals()["Ocl_get_global_size"])
 
     def resolve_get_local_size(self, mod):
-        return types.Function(Ocl_get_local_size)
+        return types.Function(globals()["Ocl_get_local_size"])
 
     def resolve_get_num_groups(self, mod):
-        return types.Function(Ocl_get_num_groups)
+        return types.Function(globals()["Ocl_get_num_groups"])
 
     def resolve_get_work_dim(self, mod):
-        return types.Function(Ocl_get_work_dim)
+        return types.Function(globals()["Ocl_get_work_dim"])
 
     def resolve_get_group_id(self, mod):
-        return types.Function(Ocl_get_group_id)
+        return types.Function(globals()["Ocl_get_group_id"])
 
     def resolve_barrier(self, mod):
-        return types.Function(Ocl_barrier)
+        return types.Function(globals()["Ocl_barrier"])
 
     def resolve_mem_fence(self, mod):
-        return types.Function(Ocl_mem_fence)
+        return types.Function(globals()["Ocl_mem_fence"])
 
     def resolve_sub_group_barrier(self, mod):
-        return types.Function(Ocl_sub_group_barrier)
+        return types.Function(globals()["Ocl_sub_group_barrier"])
 
     def resolve_atomic(self, mod):
         return types.Module(dpex.atomic)

--- a/numba_dpex/tests/ocl/__init__.py
+++ b/numba_dpex/tests/ocl/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2021 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/numba_dpex/tests/ocl/__init__.py
+++ b/numba_dpex/tests/ocl/__init__.py
@@ -1,13 +1,3 @@
-# Copyright 2021 Intel Corporation
+# Copyright 2021 - 2022 Intel Corporation
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0

--- a/numba_dpex/tests/ocl/test_ocldecl.py
+++ b/numba_dpex/tests/ocl/test_ocldecl.py
@@ -1,0 +1,43 @@
+# Copyright 2021 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from numba import types
+
+import numba_dpex as dpex
+from numba_dpex.ocl import ocldecl
+from numba_dpex.ocl.ocldecl import registry
+
+
+@pytest.mark.parametrize(
+    "fname",
+    [
+        "get_global_id",
+        "get_local_id",
+        "get_group_id",
+        "get_num_groups",
+        "get_work_dim",
+        "get_global_size",
+        "get_local_size",
+        "barrier",
+        "mem_fence",
+        "sub_group_barrier",
+    ],
+)
+def test_registry(fname):
+    function = getattr(dpex, fname)
+    template = getattr(ocldecl, f"Ocl_{fname}")
+
+    assert template in registry.functions
+    assert (function, types.Function(template)) in registry.globals

--- a/numba_dpex/tests/ocl/test_ocldecl.py
+++ b/numba_dpex/tests/ocl/test_ocldecl.py
@@ -1,16 +1,6 @@
-# Copyright 2021 Intel Corporation
+# Copyright 2021 - 2022 Intel Corporation
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 
 import pytest
 from numba import types


### PR DESCRIPTION
Closes #693.

The dpex kernel API intrinsic functions such as `dpex.get_global_id` always need to be called with the fully qualified name including the module. As described in issue #693, these functions cannot be directly called inside a kernel function.

The PR adds the intrinsic functions in dpex to the `globals` dictionary to allow the usage without a module name specifier.