### PR TITLE
Use intershphinx extension to generate inventory data for cross-linking

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,6 +38,7 @@ extensions = [
     "sphinx_rtd_theme",
     "sphinx.ext.autodoc",
     "sphinx.ext.todo",
+    "sphinx.ext.intersphinx",
     "sphinxcontrib.apidoc",
 ]
 


### PR DESCRIPTION
Use `"sphinx.ext.intersphinx"` extension to generate site objects inventory used for cross-linking.

- [X] Have you provided a meaningful PR description?

Rendered site should contain `objects.inv` file with the required data.