### PR TITLE
Update dependencies for 2022.2

### DIFF
--- a/conda-recipe/bld.bat
+++ b/conda-recipe/bld.bat
@@ -9,6 +9,6 @@ rem Build wheel package
 if NOT "%WHEELS_OUTPUT_FOLDER%"=="" (
     %PYTHON% setup.py bdist_wheel
     if errorlevel 1 exit 1
-    copy dist\numba_dppy*.whl %WHEELS_OUTPUT_FOLDER%
+    copy dist\numba_dpex*.whl %WHEELS_OUTPUT_FOLDER%
     if errorlevel 1 exit 1
 )

--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -16,5 +16,5 @@ else
 fi
 if [[ -v WHEELS_OUTPUT_FOLDER ]]; then
     $PYTHON setup.py bdist_wheel "${WHEELS_BUILD_ARGS[@]}"
-    cp dist/numba_dppy*.whl "${WHEELS_OUTPUT_FOLDER[@]}"
+    cp dist/numba_dpex*.whl "${WHEELS_OUTPUT_FOLDER[@]}"
 fi

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -19,16 +19,16 @@ requirements:
         - setuptools
         - cython
         - numba 0.54*|0.55*
-        - dpctl >=0.12.0dev3
-        - dpnp >=0.10.0dev0
+        - dpctl >=0.13.0
+        - dpnp >=0.10.1
         - wheel
     run:
         - python
         - numba 0.54*|0.55*
-        - dpctl 0.11*|0.12*
+        - dpctl >=0.13.0
         - spirv-tools
         - llvm-spirv 11.*
-        - dpnp 0.10*
+        - dpnp >=0.10.1
         - packaging
 
 test:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
         - cython
         - numba 0.54*|0.55*
         - dpctl >=0.13.0
-        - dpnp >=0.10.1
+        - dpnp >=0.10.*
         - wheel
     run:
         - python
@@ -28,7 +28,7 @@ requirements:
         - dpctl >=0.13.0
         - spirv-tools
         - llvm-spirv 11.*
-        - dpnp >=0.10.1
+        - dpnp >=0.10.*
         - packaging
 
 test:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,5 +1,5 @@
 package:
-    name: numba-dppy
+    name: numba-dpex
     version: {{ GIT_DESCRIBE_TAG }}
 
 source:
@@ -39,7 +39,7 @@ test:
     - pexpect
 
 about:
-    home: https://github.com/IntelPython/numba-dppy
+    home: https://github.com/IntelPython/numba-dpex
     summary: "Numba extension for Intel CPU and GPU backend"
     license: Apache-2.0
     license_file: LICENSE


### PR DESCRIPTION
Updated run-time dependencies of `numba-dpex` to require `dpctl >=0.13` given binary incompatibility of `dpctl` v0.12 and `dpctl` v0.13 