### PR TITLE
Fix tests for intefration sycl usm array interface

### DIFF
--- a/numba_dpex/examples/sum_reduction_recursive_ocl.py
+++ b/numba_dpex/examples/sum_reduction_recursive_ocl.py
@@ -99,13 +99,13 @@ def sum_reduce(A):
     print("Using device ...")
     device.print_device_info()
 
-    with dpctl.device_context(device):
-        inp_buf = dpctl_mem.MemoryUSMShared(A.size * A.dtype.itemsize)
+    with dpctl.device_context(device) as q:
+        inp_buf = dpctl_mem.MemoryUSMShared(A.size * A.dtype.itemsize, queue=q)
         inp_ndarray = np.ndarray(A.shape, buffer=inp_buf, dtype=A.dtype)
         np.copyto(inp_ndarray, A)
 
         partial_sums_buf = dpctl_mem.MemoryUSMShared(
-            partial_sums.size * partial_sums.dtype.itemsize
+            partial_sums.size * partial_sums.dtype.itemsize, queue=q
         )
         partial_sums_ndarray = np.ndarray(
             partial_sums.shape,

--- a/numba_dpex/tests/integration/DuckUSMArray.py
+++ b/numba_dpex/tests/integration/DuckUSMArray.py
@@ -1,4 +1,5 @@
 import dpctl.memory as dpmem
+import dpctl.tensor as dpt
 import numpy as np
 
 
@@ -6,9 +7,8 @@ class DuckUSMArray:
     """A Python class that defines a __sycl_usm_array_interface__ attribute."""
 
     def __init__(self, shape, dtype="d", host_buffer=None):
-        nelems = np.prod(shape)
-        bytes = nelems * np.dtype(dtype).itemsize
-        shmem = dpmem.MemoryUSMShared(bytes)
+        _tensor = dpt.empty(shape, dtype=dtype, usm_type="shared")
+        shmem = _tensor.usm_data
         if isinstance(host_buffer, np.ndarray):
             shmem.copy_from_host(host_buffer.view(dtype="|u1"))
         self.arr = np.ndarray(shape, dtype=dtype, buffer=shmem)

--- a/numba_dpex/tests/integration/test_sycl_usm_array_iface_interop.py
+++ b/numba_dpex/tests/integration/test_sycl_usm_array_iface_interop.py
@@ -47,8 +47,7 @@ def test_kernel_valid_usm_obj(dtype):
     C = DuckUSMArray(shape=buffC.shape, dtype=dtype, host_buffer=buffC)
 
     try:
-        with dpctl.device_context(dpctl.select_default_device()):
-            vecadd[N, dpex.DEFAULT_LOCAL_SIZE](A, B, C)
+        vecadd[N, dpex.DEFAULT_LOCAL_SIZE](A, B, C)
     except Exception:
         pytest.fail(
             "Could not pass Python object with sycl_usm_array_interface"

--- a/numba_dpex/tests/test_array_utils.py
+++ b/numba_dpex/tests/test_array_utils.py
@@ -33,14 +33,14 @@ from . import _helper
 def test_has_usm_memory(filter_str):
     a = np.ones(1023, dtype=np.float32)
 
-    with dpctl.device_context(filter_str):
+    with dpctl.device_context(filter_str) as q:
         # test usm_ndarray
         da = dpt.usm_ndarray(a.shape, dtype=a.dtype, buffer="shared")
         usm_mem = has_usm_memory(da)
         assert da.usm_data._pointer == usm_mem._pointer
 
         # test usm allocated numpy.ndarray
-        buf = dpctl_mem.MemoryUSMShared(a.size * a.dtype.itemsize)
+        buf = dpctl_mem.MemoryUSMShared(a.size * a.dtype.itemsize, queue=q)
         ary_buf = np.ndarray(a.shape, buffer=buf, dtype=a.dtype)
         usm_mem = has_usm_memory(ary_buf)
         assert buf._pointer == usm_mem._pointer


### PR DESCRIPTION
This PR adjusts `numba_dpex` tests to create `DuckUSMArray` using the same queue.

This solves tests failures:

```
FAILED test_sycl_usm_array_iface_interop.py::test_kernel_valid_usm_obj[i4] - Failed: Could not pass Python object with sycl_usm_array_interface to a kernel.
FAILED test_sycl_usm_array_iface_interop.py::test_kernel_valid_usm_obj[i8] - Failed: Could not pass Python object with sycl_usm_array_interface to a kernel.
FAILED test_sycl_usm_array_iface_interop.py::test_kernel_valid_usm_obj[f4] - Failed: Could not pass Python object with sycl_usm_array_interface to a kernel.
FAILED test_sycl_usm_array_iface_interop.py::test_kernel_valid_usm_obj[f8] - Failed: Could not pass Python object with sycl_usm_array_interface to a kernel.
```

Kernels could not launch due to strengthened check in execution queue deduction in `dpctl` with transition to `dpctl` 0.13

- [X] Have you provided a meaningful PR description?
