### PR TITLE
Fix a crash when calling take() for input array with non-integer values

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -99,7 +99,7 @@ jobs:
         python: ["3.8", "3.9"]
         numba: ["0.55"]
         dpctl: ["0.12"]
-        dpnp: ["0.10"]
+        dpnp: ["0.10.1"]
 
     steps:
       - name: Download artifact

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -98,7 +98,7 @@ jobs:
       matrix:
         python: ["3.8", "3.9"]
         numba: ["0.55"]
-        dpctl: ["0.12"]
+        dpctl: ["0.13"]
         dpnp: ["0.10.1"]
 
     steps:
@@ -148,7 +148,7 @@ jobs:
     strategy:
       matrix:
         python: ["3.8", "3.9"]
-        dpctl: ["0.12"]
+        dpctl: ["0.13"]
         integration_channels: [""]
         experimental: [true]  # packages are not available on -c intel yet
         artifact_name: [""]

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
         - cython
         - numba 0.54*|0.55*
         - dpctl >=0.12.0dev3
-        - dpnp >=0.10.0dev0
+        - dpnp >=0.10.1
         - wheel
     run:
         - python
@@ -28,7 +28,7 @@ requirements:
         - dpctl 0.11*|0.12*
         - spirv-tools
         - llvm-spirv 11.*
-        - dpnp 0.10*
+        - dpnp >=0.10.1
         - packaging
 
 test:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -19,13 +19,13 @@ requirements:
         - setuptools
         - cython
         - numba 0.54*|0.55*
-        - dpctl >=0.12.0dev3
+        - dpctl >=0.13.0
         - dpnp >=0.10.1
         - wheel
     run:
         - python
         - numba 0.54*|0.55*
-        - dpctl 0.11*|0.12*
+        - dpctl >=0.13.0
         - spirv-tools
         - llvm-spirv 11.*
         - dpnp >=0.10.1

--- a/docs/user_guides/getting_started.rst
+++ b/docs/user_guides/getting_started.rst
@@ -7,8 +7,8 @@ Installation
 Numba-dpex depends on following components:
 
 * numba 0.54.* or 0.55.* (`Numba`_)
-* dpctl 0.9.* (`Intel Python dpctl`_)
-* dpnp 0.10.* (`Intel Python DPNP`_)
+* dpctl 0.12.* (`Intel Python dpctl`_)
+* dpnp 0.10.1 (`Intel Python DPNP`_)
 * `llvm-spirv`_ (SPIRV generation from LLVM IR)
 * `llvmdev`_ (LLVM IR generation)
 * `spirv-tools`_

--- a/docs/user_guides/getting_started.rst
+++ b/docs/user_guides/getting_started.rst
@@ -7,7 +7,7 @@ Installation
 Numba-dpex depends on following components:
 
 * numba 0.54.* or 0.55.* (`Numba`_)
-* dpctl 0.12.* (`Intel Python dpctl`_)
+* dpctl 0.13.* (`Intel Python dpctl`_)
 * dpnp 0.10.1 (`Intel Python DPNP`_)
 * `llvm-spirv`_ (SPIRV generation from LLVM IR)
 * `llvmdev`_ (LLVM IR generation)

--- a/environment.yml
+++ b/environment.yml
@@ -12,9 +12,9 @@ dependencies:
   - dpcpp_linux-64
   - cython
   - numba 0.55*
-  - dpctl 0.12*
-  - dpnp 0.9.0dev0=*_58  # 0.9.0rc1 requires changes
-  - mkl 2021.3.0  # for dpnp
+  - dpctl >=0.13.0
+  - dpnp >=0.10.1
+  - mkl >=2021.3.0  # for dpnp
   - spirv-tools
   # - llvm-spirv 11.*
   - packaging

--- a/environment/coverage.yml
+++ b/environment/coverage.yml
@@ -13,7 +13,7 @@ dependencies:
   - cython
   - numba 0.55*
   - dpctl 0.12*
-  - dpnp 0.10*
+  - dpnp >=0.10.1
   - spirv-tools
   # - llvm-spirv 11.*
   - packaging

--- a/environment/docs.yml
+++ b/environment/docs.yml
@@ -13,7 +13,7 @@ dependencies:
   - cython
   - numba 0.55*
   - dpctl 0.12*
-  - dpnp 0.10*
+  - dpnp >=0.10.1
   - spirv-tools
   # - llvm-spirv 11.*
   - packaging

--- a/numba_dpex/dpnp_iface/dpnp_array_ops_impl.py
+++ b/numba_dpex/dpnp_iface/dpnp_array_ops_impl.py
@@ -299,7 +299,7 @@ def dpnp_take_impl(a, ind):
         types.voidptr,
         types.intp,
     )
-    dpnp_func = dpnp_ext.dpnp_func("dpnp_" + name, [a.dtype.name, "NONE"], sig)
+    dpnp_func = dpnp_ext.dpnp_func("dpnp_" + name, [a.dtype.name, ind.dtype.name], sig)
 
     res_dtype = a.dtype
     PRINT_DEBUG = dpnp_lowering.DEBUG

--- a/numba_dpex/dpnp_iface/dpnp_array_ops_impl.py
+++ b/numba_dpex/dpnp_iface/dpnp_array_ops_impl.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Intel Corporation
+# Copyright 2021-2022 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/numba_dpex/dpnp_iface/dpnp_array_ops_impl.py
+++ b/numba_dpex/dpnp_iface/dpnp_array_ops_impl.py
@@ -287,7 +287,7 @@ def dpnp_take_impl(a, ind):
     ret_type = types.void
     """
     dpnp source:
-    https://github.com/IntelPython/dpnp/blob/ca6eb1b8fc561957402b6f258529f862c4a8f945/dpnp/backend/kernels/dpnp_krnl_indexing.cpp#L479
+    https://github.com/IntelPython/dpnp/blob/9b14f0ca76a9e0c309bb97b4d5caa0870eecd6bb/dpnp/backend/kernels/dpnp_krnl_indexing.cpp#L925
     Function declaration:
     void dpnp_take_c(void* array1_in, const size_t array1_size, void* indices1, void* result1, size_t size)
     """
@@ -299,7 +299,9 @@ def dpnp_take_impl(a, ind):
         types.voidptr,
         types.intp,
     )
-    dpnp_func = dpnp_ext.dpnp_func("dpnp_" + name, [a.dtype.name, ind.dtype.name], sig)
+    dpnp_func = dpnp_ext.dpnp_func(
+        "dpnp_" + name, [a.dtype.name, ind.dtype.name], sig
+    )
 
     res_dtype = a.dtype
     PRINT_DEBUG = dpnp_lowering.DEBUG

--- a/numba_dpex/dpnp_iface/dpnp_fptr_interface.pyx
+++ b/numba_dpex/dpnp_iface/dpnp_fptr_interface.pyx
@@ -131,7 +131,7 @@ cdef extern from "dpnp_iface_fptr.hpp":
         DPNPFuncType return_type
         void * ptr
 
-    DPNPFuncData get_dpnp_function_ptr(DPNPFuncName name, DPNPFuncType first_type, DPNPFuncType second_type)
+    DPNPFuncData get_dpnp_function_ptr(DPNPFuncName name, DPNPFuncType first_type, DPNPFuncType second_type) except +
 
 
 

--- a/numba_dpex/tests/njit_tests/dpnp/test_numpy_array_ops.py
+++ b/numba_dpex/tests/njit_tests/dpnp/test_numpy_array_ops.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 Intel Corporation
+# Copyright 2020-2022 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/numba_dpex/tests/njit_tests/dpnp/test_numpy_array_ops.py
+++ b/numba_dpex/tests/njit_tests/dpnp/test_numpy_array_ops.py
@@ -119,8 +119,8 @@ def test_unary_ops(filter_str, unary_op, input_arrays, get_shape, capfd):
 
 
 list_of_indices = [
-    np.array([0, 2, 5]),
-    np.array([0, 5]),
+    np.array([0, 2, 5], dtype=np.int64),
+    np.array([0, 5], dtype=np.int32),
 ]
 
 


### PR DESCRIPTION
DPNP map of kernel functions for take() was updated in scope of [#1172](https://github.com/IntelPython/dpnp/pull/1172): an input array of indices has to be of an integer type. For other types of indices data, DPNP backend function get_dpnp_function_ptr() will raise a runtime exception pointing on the types mismatching.
Numba-DPEX had missing "except +" notation while declaring get_dpnp_function_ptr() in cython file. Thus the exception from DPNP backend led to a core dump in Numba-DPEX instead of printing the error.

Numba-DPEX shall explicitly pass a type of input array for indices while calling DPNP backend, rather than passing "None". It will help to select a proper kernel function, since DPNP has to know how incoming array is placed in the memory to avoid any potential memory corruption issue while accessing it.

- [X] Have you provided a meaningful PR description?
- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
