### PR TITLE
I lose you win IPLDT check...

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -55,5 +55,4 @@ about:
 
 extra:
     recipe-maintainers:
-        - diptorupd
-        - oleksandr-pavlyk
+        - Intel Python


### PR DESCRIPTION
Remove the github IDs from the conda recipe meta.yaml file. The presence of the ids trigger an Intel SDL IPLDT check failure.