### PR TITLE
Move target.py and descriptor.py into the core module.

### DIFF
--- a/numba_dpex/compiler.py
+++ b/numba_dpex/compiler.py
@@ -121,7 +121,7 @@ def compile_with_depx(pyfunc, return_type, args, is_kernel, debug=None):
 
     """
     # First compilation will trigger the initialization of the backend.
-    from .descriptor import dpex_target
+    from .core.descriptor import dpex_target
 
     typingctx = dpex_target.typing_context
     targetctx = dpex_target.target_context
@@ -282,7 +282,7 @@ def compile_func(pyfunc, return_type, args, debug=None):
 
 def compile_func_template(pyfunc, debug=None):
     """Compile a DpexFunctionTemplate"""
-    from .descriptor import dpex_target
+    from .core.descriptor import dpex_target
 
     dft = DpexFunctionTemplate(pyfunc, debug=debug)
 
@@ -719,7 +719,7 @@ class JitKernel(KernelBase):
         self.debug = debug
         self.access_types = access_types
 
-        from .descriptor import dpex_target
+        from .core.descriptor import dpex_target
 
         self.typingctx = dpex_target.typing_context
 

--- a/numba_dpex/core/descriptor.py
+++ b/numba_dpex/core/descriptor.py
@@ -14,12 +14,12 @@ class DpexTarget(TargetDescriptor):
 
     @utils.cached_property
     def _toplevel_target_context(self):
-        # Lazily-initialized top-level target context, for all threads
+        """Lazily-initialized top-level target context, for all threads."""
         return DpexTargetContext(self.typing_context, self._target_name)
 
     @utils.cached_property
     def _toplevel_typing_context(self):
-        # Lazily-initialized top-level typing context, for all threads
+        """Lazily-initialized top-level typing context, for all threads."""
         return DpexTypingContext()
 
     @property

--- a/numba_dpex/core/passes/lowerer.py
+++ b/numba_dpex/core/passes/lowerer.py
@@ -44,9 +44,9 @@ from numba.parfors.parfor_lowering import _lower_parfor_parallel
 
 import numba_dpex as dpex
 from numba_dpex import config
+from numba_dpex.core.target import DpexTargetContext
 from numba_dpex.core.types import Array
 from numba_dpex.dpctl_iface import KernelLaunchOps
-from numba_dpex.target import DpexTargetContext
 from numba_dpex.utils import address_space, npytypes_array_to_dpex_array
 
 from .dufunc_inliner import dufunc_inliner

--- a/numba_dpex/core/target.py
+++ b/numba_dpex/core/target.py
@@ -25,7 +25,7 @@ from numba_dpex.utils import (
     suai_to_dpex_array,
 )
 
-from . import codegen
+from .. import codegen
 
 CC_SPIR_KERNEL = "spir_kernel"
 CC_SPIR_FUNC = "spir_func"
@@ -87,7 +87,7 @@ class DpexTypingContext(typing.BaseContext):
         """Register the OpenCL API and math and other functions."""
         from numba.core.typing import cmathdecl, npydecl
 
-        from .ocl import mathdecl, ocldecl
+        from ..ocl import mathdecl, ocldecl
 
         self.install_registry(ocldecl.registry)
         self.install_registry(mathdecl.registry)
@@ -354,8 +354,8 @@ class DpexTargetContext(BaseContext):
         """
         from numba.np import npyimpl
 
-        from . import printimpl
-        from .ocl import mathimpl, oclimpl
+        from .. import printimpl
+        from ..ocl import mathimpl, oclimpl
 
         self.insert_func_defn(oclimpl.registry.functions)
         self.insert_func_defn(mathimpl.registry.functions)

--- a/numba_dpex/device_init.py
+++ b/numba_dpex/device_init.py
@@ -31,7 +31,8 @@ DEFAULT_LOCAL_SIZE = []
 
 import dpctl
 
-from . import initialize, target
+from . import initialize
+from .core import target
 from .decorators import autojit, func, kernel
 
 

--- a/numba_dpex/dpctl_iface/usm_ndarray_type.py
+++ b/numba_dpex/dpctl_iface/usm_ndarray_type.py
@@ -6,7 +6,7 @@ from dpctl.tensor import usm_ndarray
 from numba.extending import register_model, typeof_impl
 from numba.np import numpy_support
 
-import numba_dpex.target as dpex_target
+import numba_dpex.core.target as dpex_target
 from numba_dpex.core.types import Array, ArrayModel
 from numba_dpex.utils import address_space
 

--- a/numba_dpex/dpnp_ndarray/models.py
+++ b/numba_dpex/dpnp_ndarray/models.py
@@ -5,7 +5,7 @@
 from numba.core.datamodel.models import ArrayModel as dpnp_ndarray_Model
 from numba.extending import register_model
 
-from numba_dpex.target import spirv_data_model_manager
+from numba_dpex.core.target import spirv_data_model_manager
 
 from .types import dpnp_ndarray_Type
 

--- a/numba_dpex/numpy_usm_shared.py
+++ b/numba_dpex/numpy_usm_shared.py
@@ -50,7 +50,7 @@ from numba.np.arrayobj import _array_copy
 
 from numba_dpex.core.types import Array, ArrayModel
 
-from . import target as dpex_target
+from .core import target as dpex_target
 
 debug = config.DEBUG
 

--- a/numba_dpex/offload_dispatcher.py
+++ b/numba_dpex/offload_dispatcher.py
@@ -7,7 +7,7 @@ from numba.core.registry import cpu_target
 from numba.core.target_extension import dispatcher_registry, target_registry
 
 import numba_dpex.config as dpex_config
-from numba_dpex.target import DPEX_TARGET_NAME
+from numba_dpex.core.target import DPEX_TARGET_NAME
 
 
 class OffloadDispatcher(dispatcher.Dispatcher):

--- a/numba_dpex/retarget.py
+++ b/numba_dpex/retarget.py
@@ -15,7 +15,7 @@ except ImportError:
 
 from numba.core.retarget import BasicRetarget
 
-from numba_dpex.target import DPEX_TARGET_NAME
+from numba_dpex.core.target import DPEX_TARGET_NAME
 
 
 class DpexRetarget(BasicRetarget):

--- a/numba_dpex/spirv_generator.py
+++ b/numba_dpex/spirv_generator.py
@@ -10,7 +10,7 @@ import tempfile
 from subprocess import CalledProcessError, check_call
 
 from numba_dpex import config
-from numba_dpex.target import LINK_ATOMIC, LLVM_SPIRV_ARGS
+from numba_dpex.core.target import LINK_ATOMIC, LLVM_SPIRV_ARGS
 
 
 def _raise_bad_env_path(msg, path, extra=None):


### PR DESCRIPTION
Moves the `numba_dpex.target` and `numba_dpex.descriptor` modules into `numba_dpex.core` sub-module and update all impacted imports.

The eventual goal of these incremental changes is to move all the compiler machinery into `core`.
