### PR TITLE
Fix flake8 pre-commit hook.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
     -   id: isort
         name: isort (cython)
         types: [cython]
--   repo: https://gitlab.com/pycqa/flake8
+-   repo: https://github.com/pycqa/flake8
     rev: 3.9.2
     hooks:
     -   id: flake8


### PR DESCRIPTION
Fixes the broken flake8 workflow by updating the git repo for the pre-commit hook from gitlab to hithub.