### PR TITLE
Added examples to github workflow.

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -146,7 +146,7 @@ jobs:
       - name: Run examples
         run: |
           ls
-	  pwd
+          pwd
           cd ./numba-dpex/numba_dpex/examples/
           source $CONDA/etc/profile.d/conda.sh
           conda activate numba_dpex_env

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -152,7 +152,7 @@ jobs:
           conda activate numba_dpex_env
           # echo "libintelocl.so" | tee /etc/OpenCL/vendors/intel-cpu.icd
           export OCL_ICD_FILENAMES=libintelocl.so
-          for script in $(find . \( -not -name "_*" -and -name "*.py" \))
+          for script in $(find . \( -not -name "_*" -not -name "vectorize.py" -not -name "usm_ndarray.py" -and -name "*.py" \))
           do
             echo "Executing ${script}"
             python ${script} || exit 1

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -143,6 +143,17 @@ jobs:
           # echo "libintelocl.so" | tee /etc/OpenCL/vendors/intel-cpu.icd
           export OCL_ICD_FILENAMES=libintelocl.so
           python -m pytest -q -ra --disable-warnings --pyargs $MODULE_NAME -vv
+      - name: Run examples
+          cd numba_dpex/examples/
+          source $CONDA/etc/profile.d/conda.sh
+          conda activate numba_dpex_env
+          # echo "libintelocl.so" | tee /etc/OpenCL/vendors/intel-cpu.icd
+          export OCL_ICD_FILENAMES=libintelocl.so
+          for script in $(find . \( -not -name "_*" -and -name "*.py" \))
+          do
+            echo "Executing ${script}"
+            python ${script} || exit 1
+          done
 
   test_windows:
     needs: build_windows

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -152,7 +152,7 @@ jobs:
           conda activate numba_dpex_env
           # echo "libintelocl.so" | tee /etc/OpenCL/vendors/intel-cpu.icd
           export OCL_ICD_FILENAMES=libintelocl.so
-          for script in $(find . \( -not -name "_*" -not -name "vectorize.py" -not -name "usm_ndarray.py" -and -name "*.py" \))
+          for script in $(find . \( -not -name "_*" -not -name "vectorize.py" -and -name "*.py" \))
           do
             echo "Executing ${script}"
             python ${script} || exit 1

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -145,7 +145,9 @@ jobs:
           python -m pytest -q -ra --disable-warnings --pyargs $MODULE_NAME -vv
       - name: Run examples
         run: |
-          cd numba_dpex/examples/
+          ls
+	  pwd
+          cd ./numba-dpex/numba_dpex/examples/
           source $CONDA/etc/profile.d/conda.sh
           conda activate numba_dpex_env
           # echo "libintelocl.so" | tee /etc/OpenCL/vendors/intel-cpu.icd

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -144,6 +144,7 @@ jobs:
           export OCL_ICD_FILENAMES=libintelocl.so
           python -m pytest -q -ra --disable-warnings --pyargs $MODULE_NAME -vv
       - name: Run examples
+        run: |
           cd numba_dpex/examples/
           source $CONDA/etc/profile.d/conda.sh
           conda activate numba_dpex_env

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -147,7 +147,6 @@ jobs:
         run: |
           ls
           pwd
-          sycl-ls
           cd ./numba-dpex/numba_dpex/examples/
           source $CONDA/etc/profile.d/conda.sh
           conda activate numba_dpex_env

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -147,6 +147,7 @@ jobs:
         run: |
           ls
           pwd
+          sycl-ls
           cd ./numba-dpex/numba_dpex/examples/
           source $CONDA/etc/profile.d/conda.sh
           conda activate numba_dpex_env

--- a/numba_dpex/examples/debug/simple_dpex_func.py
+++ b/numba_dpex/examples/debug/simple_dpex_func.py
@@ -25,7 +25,6 @@ a = np.arange(global_size, dtype=np.float32)
 b = np.arange(global_size, dtype=np.float32)
 c = np.empty_like(a)
 
-# device = dpctl.SyclDevice("opencl:gpu")
 device = dpctl.select_default_device()
 with dpctl.device_context(device):
     kernel_sum[global_size, dpex.DEFAULT_LOCAL_SIZE](a, b, c)

--- a/numba_dpex/examples/debug/simple_dpex_func.py
+++ b/numba_dpex/examples/debug/simple_dpex_func.py
@@ -25,7 +25,8 @@ a = np.arange(global_size, dtype=np.float32)
 b = np.arange(global_size, dtype=np.float32)
 c = np.empty_like(a)
 
-device = dpctl.SyclDevice("opencl:gpu")
+# device = dpctl.SyclDevice("opencl:gpu")
+device = dpctl.select_default_device()
 with dpctl.device_context(device):
     kernel_sum[global_size, dpex.DEFAULT_LOCAL_SIZE](a, b, c)
 

--- a/numba_dpex/examples/debug/simple_sum.py
+++ b/numba_dpex/examples/debug/simple_sum.py
@@ -21,7 +21,8 @@ a = np.array(np.random.random(N), dtype=np.float32)
 b = np.array(np.random.random(N), dtype=np.float32)
 c = np.ones_like(a)
 
-device = dpctl.SyclDevice("opencl:gpu")
+# device = dpctl.SyclDevice("opencl:gpu")
+device = dpctl.select_default_device()
 with dpctl.device_context(device):
     data_parallel_sum[global_size, dpex.DEFAULT_LOCAL_SIZE](a, b, c)
 

--- a/numba_dpex/examples/debug/simple_sum.py
+++ b/numba_dpex/examples/debug/simple_sum.py
@@ -21,7 +21,6 @@ a = np.array(np.random.random(N), dtype=np.float32)
 b = np.array(np.random.random(N), dtype=np.float32)
 c = np.ones_like(a)
 
-# device = dpctl.SyclDevice("opencl:gpu")
 device = dpctl.select_default_device()
 with dpctl.device_context(device):
     data_parallel_sum[global_size, dpex.DEFAULT_LOCAL_SIZE](a, b, c)

--- a/numba_dpex/examples/debug/sum_local_vars.py
+++ b/numba_dpex/examples/debug/sum_local_vars.py
@@ -23,7 +23,8 @@ a = np.array(np.random.random(N), dtype=np.float32)
 b = np.array(np.random.random(N), dtype=np.float32)
 c = np.ones_like(a)
 
-device = dpctl.SyclDevice("opencl:gpu")
+# device = dpctl.SyclDevice("opencl:gpu")
+device = dpctl.select_default_device()
 with dpctl.device_context(device):
     data_parallel_sum[global_size, dpex.DEFAULT_LOCAL_SIZE](a, b, c)
 

--- a/numba_dpex/examples/debug/sum_local_vars.py
+++ b/numba_dpex/examples/debug/sum_local_vars.py
@@ -23,7 +23,6 @@ a = np.array(np.random.random(N), dtype=np.float32)
 b = np.array(np.random.random(N), dtype=np.float32)
 c = np.ones_like(a)
 
-# device = dpctl.SyclDevice("opencl:gpu")
 device = dpctl.select_default_device()
 with dpctl.device_context(device):
     data_parallel_sum[global_size, dpex.DEFAULT_LOCAL_SIZE](a, b, c)

--- a/numba_dpex/examples/debug/sum_local_vars_revive.py
+++ b/numba_dpex/examples/debug/sum_local_vars_revive.py
@@ -29,7 +29,6 @@ a = np.array(np.random.random(N), dtype=np.float32)
 b = np.array(np.random.random(N), dtype=np.float32)
 c = np.ones_like(a)
 
-# device = dpctl.SyclDevice("opencl:gpu")
 device = dpctl.select_default_device()
 with dpctl.device_context(device):
     data_parallel_sum[global_size, dpex.DEFAULT_LOCAL_SIZE](a, b, c)

--- a/numba_dpex/examples/debug/sum_local_vars_revive.py
+++ b/numba_dpex/examples/debug/sum_local_vars_revive.py
@@ -29,7 +29,8 @@ a = np.array(np.random.random(N), dtype=np.float32)
 b = np.array(np.random.random(N), dtype=np.float32)
 c = np.ones_like(a)
 
-device = dpctl.SyclDevice("opencl:gpu")
+# device = dpctl.SyclDevice("opencl:gpu")
+device = dpctl.select_default_device()
 with dpctl.device_context(device):
     data_parallel_sum[global_size, dpex.DEFAULT_LOCAL_SIZE](a, b, c)
 

--- a/numba_dpex/examples/select_device_for_kernel.py
+++ b/numba_dpex/examples/select_device_for_kernel.py
@@ -83,7 +83,9 @@ def select_device_ndarray(N):
     got = np.ones_like(a)
 
     # This context manager is specifying to use the Opencl GPU.
-    with numba_dpex.offload_to_sycl_device("opencl:gpu"):
+    default_device = dpctl.select_default_device()
+
+    with numba_dpex.offload_to_sycl_device(default_device.filter_string):
         sum_kernel[N, 1](a, b, got)
 
     expected = a + b
@@ -99,7 +101,8 @@ def select_device_SUAI(N):
     b = np.array(np.random.random(N), np.float32)
     got = np.ones_like(a)
 
-    device = dpctl.SyclDevice("opencl:gpu")
+    #   device = dpctl.SyclDevice("opencl:gpu")
+    device = dpctl.select_default_device()
     queue = dpctl.SyclQueue(device)
 
     # We are allocating the data in Opencl GPU and this device

--- a/numba_dpex/examples/select_device_for_kernel.py
+++ b/numba_dpex/examples/select_device_for_kernel.py
@@ -101,7 +101,6 @@ def select_device_SUAI(N):
     b = np.array(np.random.random(N), np.float32)
     got = np.ones_like(a)
 
-    #   device = dpctl.SyclDevice("opencl:gpu")
     device = dpctl.select_default_device()
     queue = dpctl.SyclQueue(device)
 


### PR DESCRIPTION
- [x] Have you provided a meaningful PR description?

1. Added running numba dpex examples as part of workflow. 
2. Switched to select_default_device() to pass CI.
3. Disabled two examples: vectorize.py and usm_ndarray.py which are failing. Investigation will be made in separate PR (#807 & #838 ). 
