### PR TITLE
A new LRU cache mechanism for numba_dpex with kernel pickling capability

### DIFF
--- a/docs/developer_guides/caching.rst
+++ b/docs/developer_guides/caching.rst
@@ -1,0 +1,24 @@
+.. _caching:
+
+Caching Mechanism in Numba-dpex
+================================
+
+Caching is done by saving the compiled kernel code, the ELF object of the executable code. By using the kernel code, cached kernels have minimal overhead because no compilation is needed.
+
+Unlike Numba, we do not perform file-based caching, instead we use an Least Recently Used (LRU) caching mechanism. However when a kernel needs to be evicted, we utilize numba's file-based caching mechanism described `here <https://numba.pydata.org/numba-doc/latest/developer/caching.html>`_.
+
+Algorithm
+==========
+
+The caching mechanism for Numba-dpex works as follows: The cache is an LRU cache backed by an ordered dictionary mapped onto a doubly linked list. The tail of the list contains the most recently used (MRU) kernel and the head of the list contains the least recently used (LRU) kernel. The list  has a fixed size. If a new kernel arrives to be cached and if the size is already on the maximum limit, the algorithm evicts the LRU kernel to make room for the MRU kernel. The evicted item will be serialized and pickled into a file using Numba's caching mechanism.
+
+Everytime whenever a kernel needs to be retrieved from the cache, the mechanism will look for the kernel in the cache and will be loaded if it's already present. However, if the program is seeking for a kernel that has been evicted, the algorithm will load it from the file and enqueue in the cache.
+
+Settings
+========
+
+Therefore, we employ similar environment variables as used in Numba, i.e. ``NUMBA_CACHE_DIR`` etc. However we add three more environment variables to control the caching mechanism.
+
+- In order to specify cache capacity, one can use ``NUMBA_DPEX_CACHE_SIZE``. By default, it's set to 10.
+- ``NUMBA_DPEX_ENABLE_CACHE`` can be used to enable/disable the caching mechanism. By default it's enabled, i.e. set to 1.
+- In order to enable the debugging messages related to caching, one can set ``NUMBA_DPEX_DEBUG_CACHE`` to 1. All environment variables are defined in :file:`numba_dpex/config.py`.

--- a/numba_dpex/codegen.py
+++ b/numba_dpex/codegen.py
@@ -66,6 +66,9 @@ class JITSPIRVCodegen(CPUCodegen):
         assert list(llvm_module.global_variables) == [], "Module isn't empty"
         self._data_layout = SPIR_DATA_LAYOUT[utils.MACHINE_BITS]
         self._target_data = ll.create_target_data(self._data_layout)
+        self._tm_features = (
+            ""  # We need this for chaching, not sure about this value for now
+        )
 
     def _create_empty_module(self, name):
         ir_module = lc.Module(name)

--- a/numba_dpex/config.py
+++ b/numba_dpex/config.py
@@ -92,6 +92,21 @@ DEBUGINFO_DEFAULT = _readenv(
     "NUMBA_DPEX_DEBUGINFO", int, config.DEBUGINFO_DEFAULT
 )
 
+# configs for caching
+# To see the debug messages for the caching.
+# Execute like:
+#   NUMBA_DPEX_DEBUG_CACHE=1 python <code>
+DEBUG_CACHE = _readenv("NUMBA_DPEX_DEBUG_CACHE", int, 0)
+# This is a global flag to turn the caching on/off,
+# regardless of whatever has been specified in Dispatcher.
+# Useful for debugging. Execute like:
+#   NUMBA_DPEX_ENABLE_CACHE=0 python <code>
+# to turn off the caching globally.
+ENABLE_CACHE = _readenv("NUMBA_DPEX_ENABLE_CACHE", int, 1)
+# Capacity of the cache, execute it like:
+#   NUMBA_DPEX_CACHE_SIZE=20 python <code>
+CACHE_SIZE = _readenv("NUMBA_DPEX_CACHE_SIZE", int, 10)
+
 TESTING_SKIP_NO_DPNP = _readenv("NUMBA_DPEX_TESTING_SKIP_NO_DPNP", int, 0)
 TESTING_SKIP_NO_DEBUGGING = _readenv(
     "NUMBA_DPEX_TESTING_SKIP_NO_DEBUGGING", int, 1

--- a/numba_dpex/core/caching.py
+++ b/numba_dpex/core/caching.py
@@ -1,0 +1,503 @@
+# SPDX-FileCopyrightText: 2020 - 2022 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import hashlib
+import sys
+from abc import ABCMeta, abstractmethod
+
+from numba.core.caching import CacheImpl, IndexDataCacheFile
+from numba.core.serialize import dumps
+
+from numba_dpex import config
+
+
+def build_key(sig, argtypes, pyfunc, codegen, backend=None, device_type=None):
+    """Constructs a key from python function, context, backend
+        and the device type.
+
+    Compute index key for the given signature and codegen.
+    It includes a description of the OS, target architecture
+    and hashes of the bytecode for the function and, if the
+    function has a __closure__, a hash of the cell_contents.
+
+    Args:
+        sig (inspect.Signature): The signature object of
+            a python function.
+        codegen (numba.core.codegen.Codegen):
+            The codegen object found from the target context.
+        backend (enum, optional): A 'backend_type' enum.
+            Defaults to None.
+        device_type (enum, optional): A 'device_type' enum.
+            Defaults to None.
+
+    Returns:
+        tuple: A tuple of signature, magic_tuple of codegen
+            and another tuple of hashcodes from bytecode and
+            cell_contents.
+    """
+
+    codebytes = pyfunc.__code__.co_code
+    if pyfunc.__closure__ is not None:
+        try:
+            cvars = tuple([x.cell_contents for x in pyfunc.__closure__])
+            # Note: cloudpickle serializes a function differently depending
+            #       on how the process is launched; e.g. multiprocessing.Process
+            cvarbytes = dumps(cvars)
+        except:
+            cvarbytes = b""  # a temporary solution for function template
+    else:
+        cvarbytes = b""
+
+    return (
+        sig,
+        argtypes,
+        codegen.magic_tuple(),
+        backend,
+        device_type,
+        (
+            hashlib.sha256(codebytes).hexdigest(),
+            hashlib.sha256(cvarbytes).hexdigest(),
+        ),
+    )
+
+
+class _CacheImpl(CacheImpl):
+    """Implementation of `CacheImpl` to be used by subclasses of `_Cache`.
+
+    This class is an implementation of `CacheImpl` to be used by subclasses
+    of `_Cache`. To be assigned in `_impl_class`. Implements the more common
+    and core mechanism for the caching.
+
+    """
+
+    def reduce(self, data):
+        """Serialize an object before caching.
+        Args:
+            data (object): The object to be serialized before pickling.
+        """
+        # TODO: Implement, but looks like we might not need it at all.
+        # Look at numba.core.caching for how to implement.
+        pass
+
+    def rebuild(self, target_context, reduced_data):
+        """Deserialize after unpickling from the cache.
+        Args:
+            target_context (numba_dpex.core.target.DpexTargetContext):
+                The target context for the kernel.
+            reduced_data (object): The data to be deserialzed after unpickling.
+        """
+        # TODO: Implement, but looks like we might not need it at all.
+        # Look at numba.core.caching for how to implement.
+        pass
+
+    def check_cachable(self, cres):
+        """Check if a certain object is cacheable.
+
+        Args:
+            cres (object): The object to be cached. For example, if the object is
+            `CompileResult`, then you might want to follow the similar checks as
+            has been done in `numba.core.caching.CompileResultCacheImpl`.
+
+        Returns:
+            bool: Return `True` if cacheable, otherwise `False`.
+        """
+        # TODO: Although, for the time being, assuming all Kernels in numba_dpex
+        # are always cachable. However, we might need to add some bells and
+        # whistles in the future. Look at numba.core.caching for how to implement.
+        return True
+
+
+class AbstractCache(metaclass=ABCMeta):
+    """Abstract cache class to specify basic caching operations.
+
+    This class will be used to create an non-functional dummy cache
+    (i.e. NullCache) and other functional cache. The dummy cache
+    will be used as a placeholder when caching is disabled.
+
+    Args:
+        metaclass (type, optional): Metaclass for the abstract class.
+            Defaults to ABCMeta.
+    """
+
+    @abstractmethod
+    def get(self):
+        """An abstract method to retrieve item from the cache."""
+
+    @abstractmethod
+    def put(self, key, value):
+        """An abstract method to save item into the cache.
+
+        Args:
+            key (object): The key for the data
+                (i.e. compiled kernel/function etc.).
+            value (object): The data (i.e. compiled kernel/function)
+                to be saved.
+        """
+
+
+class NullCache(AbstractCache):
+    """A dummy cache used if user decides to disable caching.
+
+    If the caching is disabled this class will be used to
+    perform all caching operations, all of which will be basically
+    NOP. This idea is copied from numba.
+
+    Args:
+        AbstractCache (class): The abstract cache from which all
+        other caching classes will be derived.
+    """
+
+    def get(self, key):
+        """Function to get an item (i.e. compiled kernel/function)
+        from the cache
+
+        Args:
+            key (object): The key to retrieve the
+                data (i.e. compiled kernel/function)
+
+        Returns:
+            None: Returns None.
+        """
+        return None
+
+    def put(self, key, value):
+        """Function to save a compiled kernel/function
+        into the cache.
+
+        Args:
+            key (object): The key to the data (i.e. compiled kernel/function).
+            value (object): The data to be cached (i.e. compiled kernel/function).
+        """
+        pass
+
+
+class Node:
+    """A 'Node' class for LRUCache."""
+
+    def __init__(self, key, value):
+        """Constructor for the Node.
+
+        Args:
+            key (object): The key to the value.
+            value (object): The data to be saved.
+        """
+        self.key = key
+        self.value = value
+        self.next = None
+        self.previous = None
+
+    def __str__(self):
+        """__str__ for Node.
+
+        Returns:
+            str: A human readable representation of a Node.
+        """
+        return "(" + str(self.key) + ": " + str(self.value) + ")"
+
+    def __repr__(self):
+        """__repr__ for Node
+
+        Returns:
+            str: A human readable representation of a Node.
+        """
+        return self.__str__()
+
+
+class LRUCache(AbstractCache):
+    """LRUCache implementation for caching kernels,
+    functions and modules.
+
+    The cache is basically a doubly-linked-list backed
+    with a dictionary as a lookup table.
+    """
+
+    def __init__(self, capacity=10, pyfunc=None):
+        """Constructor for LRUCache.
+
+        Args:
+            capacity (int, optional): The max capacity of the cache.
+                Defaults to 10.
+            pyfunc (NoneType, optional): A python function to be cached.
+                Defaults to None.
+        """
+        self._capacity = capacity
+        self._lookup = {}
+        self._evicted = {}
+        self._dummy = Node(0, 0)
+        self._head = self._dummy.next
+        self._tail = self._dummy.next
+        self._pyfunc = pyfunc
+        self._cache_file = None
+        # if pyfunc is specified, we will use files for evicted items
+        if self._pyfunc is not None:
+            # _CacheImpl object to be used
+            self._impl_class = _CacheImpl
+            self._impl = self._impl_class(self._pyfunc)
+            self._cache_path = self._impl.locator.get_cache_path()
+            # This may be a bit strict but avoids us maintaining a magic number
+            source_stamp = self._impl.locator.get_source_stamp()
+            filename_base = self._impl.filename_base
+            self._cache_file = IndexDataCacheFile(
+                cache_path=self._cache_path,
+                filename_base=filename_base,
+                source_stamp=source_stamp,
+            )
+
+    @property
+    def head(self):
+        """Get the head of the cache.
+
+        This is used for testing/debugging purposes.
+
+        Returns:
+            Node: The head of the cache.
+        """
+        return self._head
+
+    @property
+    def tail(self):
+        """Get the tail of the cache.
+
+        This is used for testing/debugging purposes.
+
+        Returns:
+            Node: The tail of the cache.
+        """
+        return self._tail
+
+    @property
+    def evicted(self):
+        """Get the list of evicted items from the cache.
+
+        This is used for testing/debugging purposes.
+
+        Returns:
+            dict: A table of evicted items from the cache.
+        """
+        return self._evicted
+
+    def _get_memsize(self, obj, seen=None):
+        """Recursively finds size of *almost any* object.
+
+        This function might be useful in the future when
+        size based (not count based) cache limit will be
+        implemented.
+
+        Args:
+            obj (object): Any object.
+            seen (set, optional): Set of seen object id().
+                Defaults to None.
+
+        Returns:
+            int: Size of the object in bytes.
+        """
+        size = sys.getsizeof(obj)
+        if seen is None:
+            seen = set()
+        obj_id = id(obj)
+        if obj_id in seen:
+            return 0
+        # Important mark as seen *before* entering recursion to gracefully handle
+        # self-referential objects
+        seen.add(obj_id)
+        if isinstance(obj, dict):
+            size += sum([self._get_memsize(v, seen) for v in obj.values()])
+            size += sum([self._get_memsize(k, seen) for k in obj.keys()])
+        elif hasattr(obj, "__dict__"):
+            size += self._get_memsize(obj.__dict__, seen)
+        elif hasattr(obj, "__iter__") and not isinstance(
+            obj, (str, bytes, bytearray)
+        ):
+            size += sum([self._get_memsize(i, seen) for i in obj])
+        return size
+
+    def size(self):
+        """Get the current size of the cache.
+
+        Returns:
+            int: The current number of items in the cache.
+        """
+        return len(self._lookup)
+
+    def memsize(self):
+        """Get the total memory size of the cache.
+
+        This function might be useful in the future when
+        size based (not count based) cache limit will be
+        implemented.
+
+        Returns:
+            int: Get the total memory size of the cache in bytes.
+        """
+        size = 0
+        current = self._head
+        while current:
+            size = size + self._get_memsize(current.value)
+            current = current.next
+        return size
+
+    def __str__(self):
+        """__str__ function for the cache
+
+        Returns:
+            str: A human readable representation of the cache.
+        """
+        items = []
+        current = self._head
+        while current:
+            items.append(str(current))
+            current = current.next
+        return "{" + ", ".join(items) + "}"
+
+    def __repr__(self):
+        """__repr__ function for the cache
+
+        Returns:
+            str: A human readable representation of the cache.
+        """
+        return self.__str__()
+
+    def clean(self):
+        """Clean the cache"""
+        self._lookup = {}
+        self._evicted = {}
+        self._dummy = Node(0, 0)
+        self._head = self._dummy.next
+        self._tail = self._dummy.next
+
+    def _remove_head(self):
+        """Remove the head of the cache"""
+        if not self._head:
+            return
+        prev = self._head
+        self._head = self._head.next
+        if self._head:
+            self._head.previous = None
+        del prev
+
+    def _append_tail(self, new_node):
+        """Add the new node to the tail end"""
+        if not self._tail:
+            self._head = self._tail = new_node
+        else:
+            self._tail.next = new_node
+            new_node.previous = self._tail
+            self._tail = self._tail.next
+
+    def _unlink_node(self, node):
+        """Unlink current linked node"""
+        if node is None:
+            return
+
+        if self._head is node:
+            self._head = node.next
+            if node.next:
+                node.next.previous = None
+            node.previous, node.next = None, None
+            return
+
+        # removing the node from somewhere in the middle; update pointers
+        prev, nex = node.previous, node.next
+        prev.next = nex
+        nex.previous = prev
+        node.previous, node.next = None, None
+
+    def get(self, key):
+        """Get the value associated with the key.
+
+        Args:
+            key (object): A key for the lookup table.
+
+        Returns:
+            object: The value associated with the key.
+        """
+
+        if key not in self._lookup:
+            if key not in self._evicted:
+                return None
+            elif self._cache_file:
+                value = self._cache_file.load(key)
+                if config.DEBUG_CACHE:
+                    print(
+                        "[cache]: unpickled an evicted artifact, key: {0:s}.".format(
+                            str(key)
+                        )
+                    )
+            else:
+                value = self._evicted[key]
+            self.put(key, value)
+            return value
+        else:
+            if config.DEBUG_CACHE:
+                print(
+                    "[cache] size: {0:d}, loading artifact, key: {1:s}".format(
+                        len(self._lookup), str(key)
+                    )
+                )
+            node = self._lookup[key]
+
+        if node is not self._tail:
+            self._unlink_node(node)
+            self._append_tail(node)
+
+        return node.value
+
+    def put(self, key, value):
+        """Store the key-value pair into the cache.
+
+        Args:
+            key (object): The key for the data.
+            value (object): The data to be saved.
+        """
+        if key in self._lookup:
+            if config.DEBUG_CACHE:
+                print(
+                    "[cache] size: {0:d}, storing artifact, key: {1:s}".format(
+                        len(self._lookup), str(key)
+                    )
+                )
+            self._lookup[key].value = value
+            self.get(key)
+            return
+
+        if key in self._evicted:
+            self._evicted.pop(key)
+
+        if len(self._lookup) >= self._capacity:
+            # remove head node and correspond key
+            if self._cache_file:
+                if config.DEBUG_CACHE:
+                    print(
+                        "[cache] size: {0:d}, pickling the LRU item, key: {1:s}, indexed at {2:s}.".format(
+                            len(self._lookup),
+                            str(self._head.key),
+                            self._cache_file._index_path,
+                        )
+                    )
+                self._cache_file.save(self._head.key, self._head.value)
+                self._evicted[
+                    self._head.key
+                ] = None  # as we are using cache files, we save memory
+            else:
+                self._evicted[self._head.key] = self._head.value
+            self._lookup.pop(self._head.key)
+            if config.DEBUG_CACHE:
+                print(
+                    "[cache] size: {0:d}, capacity exceeded, evicted".format(
+                        len(self._lookup)
+                    ),
+                    self._head.key,
+                )
+            self._remove_head()
+
+        # add new node and hash key
+        new_node = Node(key, value)
+        self._lookup[key] = new_node
+        self._append_tail(new_node)
+        if config.DEBUG_CACHE:
+            print(
+                "[cache] size: {0:d}, saved artifact, key: {1:s}".format(
+                    len(self._lookup), str(key)
+                )
+            )

--- a/numba_dpex/core/kernel_interface/dispatcher.py
+++ b/numba_dpex/core/kernel_interface/dispatcher.py
@@ -2,15 +2,18 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+
 import copy
 from inspect import signature
 from warnings import warn
 
 import dpctl
 import dpctl.program as dpctl_prog
+from numba.core import utils
 from numba.core.types import Array as ArrayType
 
 from numba_dpex import config
+from numba_dpex.core.caching import LRUCache, NullCache, build_key
 from numba_dpex.core.descriptor import dpex_target
 from numba_dpex.core.exceptions import (
     ComputeFollowsDataInferenceError,
@@ -57,6 +60,7 @@ class Dispatcher(object):
         debug_flags=None,
         compile_flags=None,
         array_access_specifiers=None,
+        enable_cache=True,
     ):
         self.typingctx = dpex_target.typing_context
         self.pyfunc = pyfunc
@@ -66,6 +70,16 @@ class Dispatcher(object):
         # TODO: To be removed once the__getitem__ is removed
         self._global_range = None
         self._local_range = None
+        # caching related attributes
+        if not config.ENABLE_CACHE:
+            self._cache = NullCache()
+        elif enable_cache:
+            self._cache = LRUCache(
+                capacity=config.CACHE_SIZE, pyfunc=self.pyfunc
+            )
+        else:
+            self._cache = NullCache()
+        self._cache_hits = 0
 
         if array_access_specifiers:
             warn(
@@ -84,6 +98,22 @@ class Dispatcher(object):
             self._create_sycl_kernel_bundle_flags = ["-g", "-cl-opt-disable"]
         else:
             self._create_sycl_kernel_bundle_flags = []
+
+    @property
+    def cache(self):
+        return self._cache
+
+    @property
+    def cache_hits(self):
+        return self._cache_hits
+
+    def enable_caching(self):
+        if not config.ENABLE_CACHE:
+            self._cache = NullCache()
+        else:
+            self._cache = LRUCache(
+                capacity=config.CACHE_SIZE, pyfunc=self.pyfunc
+            )
 
     def _check_range(self, range, device):
 
@@ -406,6 +436,7 @@ class Dispatcher(object):
 
         exec_queue = self._determine_kernel_launch_queue(args, argtypes)
         backend = exec_queue.backend
+        device_type = exec_queue.sycl_device.device_type
 
         if exec_queue.backend not in [
             dpctl.backend_type.opencl,
@@ -420,24 +451,53 @@ class Dispatcher(object):
             global_range, local_range, exec_queue.sycl_device
         )
 
-        # TODO: Enable caching of kernels, but do it using Numba's caching
-        # machinery
+        # TODO: Enable caching of kernels, but do it using LRU
+        # caching and numba's pickle framework.
 
-        kernel = SpirvKernel(self.pyfunc, self.kernel_name)
-        kernel.compile(
-            arg_types=argtypes,
-            debug=self.debug_flags,
-            extra_compile_flags=self.compile_flags,
+        # load the kernel from cache
+        sig = utils.pysignature(self.pyfunc)
+        key = build_key(
+            sig,
+            tuple(argtypes),
+            self.pyfunc,
+            dpex_target.target_context.codegen(),
+            backend=backend,
+            device_type=device_type,
         )
+        artifact = self._cache.get(key)
+        # if it's not cached, i.e. first time
+        if artifact is not None:
+            device_driver_ir_module, kernel_module_name = artifact
+            self._cache_hits += 1
+        else:
+            kernel = SpirvKernel(self.pyfunc, self.kernel_name)
+            kernel.compile(
+                arg_types=argtypes,
+                debug=self.debug_flags,
+                extra_compile_flags=self.compile_flags,
+            )
+
+            device_driver_ir_module = kernel.device_driver_ir_module
+            kernel_module_name = kernel.module_name
+
+            key = build_key(
+                sig,
+                tuple(argtypes),
+                self.pyfunc,
+                kernel.target_context.codegen(),
+                backend=backend,
+                device_type=device_type,
+            )
+            self._cache.put(key, (device_driver_ir_module, kernel_module_name))
 
         # create a sycl::KernelBundle
         kernel_bundle = dpctl_prog.create_program_from_spirv(
             exec_queue,
-            kernel.device_driver_ir_module,
+            device_driver_ir_module,
             " ".join(self._create_sycl_kernel_bundle_flags),
         )
         #  get the sycl::kernel
-        kernel = kernel_bundle.get_sycl_kernel(kernel.module_name)
+        kernel = kernel_bundle.get_sycl_kernel(kernel_module_name)
 
         packer = Packer(
             kernel_name=self.kernel_name,

--- a/numba_dpex/core/kernel_interface/spirv_kernel.py
+++ b/numba_dpex/core/kernel_interface/spirv_kernel.py
@@ -38,6 +38,7 @@ class SpirvKernel(KernelInterface):
             self._func_ty = ir.FunctionIR
         else:
             raise UnreachableError()
+        self._target_context = None
 
     @property
     def llvm_module(self):
@@ -65,6 +66,13 @@ class SpirvKernel(KernelInterface):
         """The name of the compiled LLVM module for the kernel."""
         if self._module_name:
             return self._module_name
+        else:
+            raise UncompiledKernelError(self._pyfunc_name)
+
+    @property
+    def target_context(self):
+        if self._target_context:
+            return self._target_context
         else:
             raise UncompiledKernelError(self._pyfunc_name)
 

--- a/numba_dpex/tests/kernel_tests/test_caching.py
+++ b/numba_dpex/tests/kernel_tests/test_caching.py
@@ -3,11 +3,56 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import dpctl
+import dpctl.tensor as dpt
 import numpy as np
 import pytest
 
 import numba_dpex as dpex
+from numba_dpex.core.kernel_interface.dispatcher import (
+    Dispatcher,
+    get_ordered_arg_access_types,
+)
 from numba_dpex.tests._helper import filter_strings
+
+
+# @pytest.mark.xfail
+@pytest.mark.parametrize("filter_str", filter_strings)
+def test_caching_hit_counts(filter_str):
+    """Tests the correct number of cache hits.
+    If a Dispatcher is invoked 10 times and if the caching is enabled,
+    then the total number of cache hits will be 9. Given the fact that
+    the first time the kernel will be compiled and it will be loaded
+    off the cache for the next time on.
+    Args:
+        filter_str (str): The device name coming from filter_strings in ._helper.py
+    """
+
+    def data_parallel_sum(x, y, z):
+        """
+        Vector addition using the ``kernel`` decorator.
+        """
+        i = dpex.get_global_id(0)
+        z[i] = x[i] + y[i]
+
+    a = dpt.arange(0, 100, device=filter_str)
+    b = dpt.arange(0, 100, device=filter_str)
+    c = dpt.zeros_like(a, device=filter_str)
+
+    expected = dpt.asnumpy(a) + dpt.asnumpy(b)
+
+    d = Dispatcher(
+        data_parallel_sum,
+        array_access_specifiers=get_ordered_arg_access_types(
+            data_parallel_sum, None
+        ),
+    )
+
+    N = 10
+    for i in range(N):
+        d(a, b, c, global_range=[100])
+    actual = dpt.asnumpy(c)
+
+    assert np.array_equal(expected, actual) and (d.cache_hits == N - 1)
 
 
 @pytest.mark.xfail


### PR DESCRIPTION
- [x] Have you provided a meaningful PR description?
    - This PR addresses issue #814 
    - This PR implements an LRU cache mechanism for numba_dpex.
    - The LRU cache can pickle kernels if they are evicted.
    - This PR is rebased on top of https://github.com/IntelPython/numba-dpex/commit/26c4334b1ef0b08ade41c5ca301c528ca2e9aa79
    - This PR supercedes #815 and #833
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] If this PR is a work in progress, are you filing the PR as a draft?

TODO:
- [x] Add cache capacity in config.
- [x] Remove OS-info from the key.
- [x] Split `driver.py` into separate commits.
- [x] Documentation about the caching mechanism. Add a new rst file in https://github.com/IntelPython/numba-dpex/tree/refactor/kernel_interfaces/docs/developer_guides
- [ ] Currently caching is initialized on kernel/function basis (i.e. local), we need to make it global (i.e. entire program basis).
- [x] Need to do similar caching for functions and function templates.