### PR TITLE
Fix/dpnp overloads

### DIFF
--- a/numba_dpex/dpctl_iface/__init__.py
+++ b/numba_dpex/dpctl_iface/__init__.py
@@ -23,10 +23,11 @@ __all__ = [
     USMNdArrayType,
 ]
 
+create_event_vector = dpctl_fn_ty.dpctl_event_vector_create()
+event_wait = dpctl_fn_ty.dpctl_event_wait()
+event_delete = dpctl_fn_ty.dpctl_event_delete()
+free_with_queue = dpctl_fn_ty.dpctl_free_with_queue()
 get_current_queue = dpctl_fn_ty.dpctl_get_current_queue()
 malloc_shared = dpctl_fn_ty.dpctl_malloc_shared()
 queue_memcpy = dpctl_fn_ty.dpctl_queue_memcpy()
-free_with_queue = dpctl_fn_ty.dpctl_free_with_queue()
-event_wait = dpctl_fn_ty.dpctl_event_wait()
-event_delete = dpctl_fn_ty.dpctl_event_delete()
 queue_wait = dpctl_fn_ty.dpctl_queue_wait()

--- a/numba_dpex/dpctl_iface/dpctl_function_types.py
+++ b/numba_dpex/dpctl_iface/dpctl_function_types.py
@@ -26,7 +26,7 @@ def dpctl_queue_memcpy():
 
 
 def dpctl_event_wait():
-    ret_type = types.voidptr
+    ret_type = types.void
     sig = signature(ret_type, types.voidptr)
     return types.ExternalFunction("DPCTLEvent_Wait", sig)
 
@@ -47,3 +47,9 @@ def dpctl_queue_wait():
     ret_type = types.void
     sig = signature(ret_type, types.voidptr)
     return types.ExternalFunction("DPCTLQueue_Wait", sig)
+
+
+def dpctl_event_vector_create():
+    ret_type = types.voidptr
+    sig = signature(ret_type)
+    return types.ExternalFunction("DPCTLEventVector_Create", sig)


### PR DESCRIPTION
- [X] Have you provided a meaningful PR description?

Recent changes to dpnp has changed the signatures for the dpnp back end functions. The change is causing dpex calls to dpnp backend to break. The PR addresses the issue by updating the signatures for the dpnp overloads to match current signature of dpnp backend functions.

- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [X] If this PR is a work in progress, are you filing the PR as a draft?
