### PR TITLE
Bump dpctl version requirement to 0.14 and fix issue caused by API change

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -19,13 +19,13 @@ requirements:
         - setuptools
         - cython
         - numba 0.56*
-        - dpctl >=0.13.0
+        - dpctl >=0.14*
         - dpnp >=0.11*
         - wheel
     run:
         - python
         - numba >=0.56*
-        - dpctl >=0.13.0
+        - dpctl >=0.14*
         - spirv-tools
         - llvm-spirv 11.*
         - dpnp >=0.11*

--- a/numba_dpex/config.py
+++ b/numba_dpex/config.py
@@ -2,9 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import imp
+import logging
 import os
-import warnings
 
 from numba.core import config
 
@@ -15,25 +14,23 @@ def _ensure_dpctl():
     """
     from numba_dpex.dpctl_support import dpctl_version
 
-    if dpctl_version < (0, 8):
-        raise ImportError("numba_dpex needs dpctl 0.8 or greater")
+    if dpctl_version < (0, 14):
+        raise ImportError("numba_dpex needs dpctl 0.14 or greater")
 
 
 def _dpctl_has_non_host_device():
     """
-    Make sure dpctl has non-host SYCL devices on the system.
+    Ensure dpctl can create a default sycl device
     """
     import dpctl
 
-    # For the numba_dpex extension to work, we should have at least one
-    # non-host SYCL device installed.
-    # FIXME: In future, we should support just the host device.
-    if not dpctl.select_default_device().is_host:
+    try:
+        dpctl.select_default_device()
         return True
-    else:
+    except Exception:
         msg = "dpctl could not find any non-host SYCL device on the system. "
         msg += "A non-host SYCL device is required to use numba_dpex."
-        warnings.warn(msg, UserWarning)
+        logging.exception(msg)
         return False
 
 
@@ -57,11 +54,8 @@ def _readenv(name, ctor, default):
     try:
         return ctor(value)
     except Exception:
-        import warnings
-
-        warnings.warn(
-            "environ %s defined but failed to parse '%s'" % (name, value),
-            RuntimeWarning,
+        logging.exception(
+            "environ %s defined but failed to parse '%s'" % (name, value)
         )
         return default
 

--- a/numba_dpex/device_init.py
+++ b/numba_dpex/device_init.py
@@ -35,21 +35,4 @@ from . import initialize
 from .core import target
 from .decorators import autojit, func, kernel
 
-
-def is_available():
-    """Returns a boolean indicating if dpctl could find a default device.
-
-    A ValueError is thrown by dpctl if no default device is found and it
-    implies that numba_dpex cannot create a SYCL queue to compile kernels.
-
-    Returns:
-        bool: True if a default SYCL device is found, otherwise False.
-    """
-    try:
-        d = dpctl.select_default_device()
-        return not d.is_host
-    except ValueError:
-        return False
-
-
 initialize.load_dpctl_sycl_interface()


### PR DESCRIPTION
- [x] Have you provided a meaningful PR description?

There are API changes in dpctl 0.14.1dev1 to accommodate changes in dpcpp 2023.0. Specifically, `dpctl.SyclDevice` no longer has the `is_host` property. The change impacts the check inside `numba_dpex.config._dpctl_has_non_host_device` that was throwing an uncaught `AttributeError`.

The PR fixes the issue by using only `dpctl.select_default_device()`. Also the minimum dpctl version required was bumped to 0.14.

- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
