### PR TITLE
Pass dpnp arrays directly to kernel instead of using dpctl.asarray.

### DIFF
--- a/numba_dpex/tests/integration/test_dpnp_interop.py
+++ b/numba_dpex/tests/integration/test_dpnp_interop.py
@@ -2,12 +2,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import dpctl
 import numpy as np
 import pytest
 
 import numba_dpex as dpex
-from numba_dpex.tests._helper import filter_strings
 
 dpnp = pytest.importorskip("dpnp", reason="DPNP is not installed")
 
@@ -25,38 +23,7 @@ def dtype(request):
     return request.param
 
 
-list_of_usm_type = [
-    "shared",
-    "device",
-    "host",
-]
-
-
-@pytest.fixture(params=list_of_usm_type)
-def usm_type(request):
-    return request.param
-
-
-@pytest.mark.parametrize("filter_str", filter_strings)
-def test_dpnp_create_array_in_context(filter_str, dtype):
-    if (
-        "opencl" not in dpctl.get_current_queue().sycl_device.filter_string
-        and "opencl" in filter_str
-    ):
-        pytest.skip("Bug in DPNP. See: IntelPython/dpnp#723")
-
-    with dpctl.device_context(filter_str):
-        a = dpnp.arange(1024, dtype=dtype)  # noqa
-
-
-@pytest.mark.parametrize("filter_str", filter_strings)
-def test_consuming_array_from_dpnp(filter_str, dtype):
-    if (
-        "opencl" not in dpctl.get_current_queue().sycl_device.filter_string
-        and "opencl" in filter_str
-    ):
-        pytest.skip("Bug in DPNP. See: IntelPython/dpnp#723")
-
+def test_consuming_array_from_dpnp(dtype):
     @dpex.kernel
     def data_parallel_sum(a, b, c):
         """
@@ -67,9 +34,8 @@ def test_consuming_array_from_dpnp(filter_str, dtype):
 
     global_size = 1021
 
-    with dpctl.device_context(filter_str):
-        a = dpex.asarray(dpnp.arange(global_size, dtype=dtype))
-        b = dpex.asarray(dpnp.arange(global_size, dtype=dtype))
-        c = dpex.asarray(dpnp.ones_like(a))
+    a = dpnp.arange(global_size, dtype=dtype)
+    b = dpnp.arange(global_size, dtype=dtype)
+    c = dpnp.ones_like(a)
 
-        data_parallel_sum[global_size, dpex.DEFAULT_LOCAL_SIZE](a, b, c)
+    data_parallel_sum[global_size](a, b, c)


### PR DESCRIPTION
- [X] Have you provided a meaningful PR description?
The changes in #804 ensure that dpnp arrays can be directly passed to a kernel as arguments without needing `asarray` conversion. Other updates to the test case to bring it in line with changes post #804.

- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
