### PR TITLE
Set the max spirv version to 1.1

### DIFF
--- a/numba_dpex/spirv_generator.py
+++ b/numba_dpex/spirv_generator.py
@@ -75,6 +75,8 @@ class CmdLine:
         if config.DEBUG:
             llvm_spirv_flags.append("--spirv-debug-info-version=ocl-100")
 
+        if not config.NATIVE_FP_ATOMICS:
+            llvm_spirv_args = ["--spirv-max-version", "1.1"] + llvm_spirv_args
         llvm_spirv_tool = self._llvm_spirv()
 
         if config.DEBUG:
@@ -94,7 +96,7 @@ class CmdLine:
             # use llvm-spirv from dpcpp package.
             # assume dpcpp from .../bin folder.
             # assume llvm-spirv from .../bin-llvm folder.
-            dpcpp_path = shutil.which("dpcpp")
+            dpcpp_path = shutil.which("icx")
             if dpcpp_path is not None:
                 bin_llvm = os.path.dirname(dpcpp_path) + "/../bin-llvm/"
                 bin_llvm = os.path.normpath(bin_llvm)

--- a/setup.py
+++ b/setup.py
@@ -116,9 +116,11 @@ def spirv_compile():
     ]
     spirv_args = [
         _llvm_spirv(),
+        "--spirv-max-version",
+        "1.1",
+        "numba_dpex/ocl/atomics/atomic_ops.bc",
         "-o",
         "numba_dpex/ocl/atomics/atomic_ops.spir",
-        "numba_dpex/ocl/atomics/atomic_ops.bc",
     ]
     subprocess.check_call(
         clang_args,
@@ -140,15 +142,14 @@ def _llvm_spirv():
 
     result = None
 
-    if result is None:
-        # use llvm-spirv from dpcpp package.
-        # assume dpcpp from .../bin folder.
-        # assume llvm-spirv from .../bin-llvm folder.
-        dpcpp_path = shutil.which("dpcpp")
-        if dpcpp_path is not None:
-            bin_llvm = os.path.dirname(dpcpp_path) + "/../bin-llvm/"
-            bin_llvm = os.path.normpath(bin_llvm)
-            result = shutil.which("llvm-spirv", path=bin_llvm)
+    # use llvm-spirv from dpcpp package.
+    # assume dpcpp from .../bin folder.
+    # assume llvm-spirv from .../bin-llvm folder.
+    dpcpp_path = shutil.which("icx")
+    if dpcpp_path is not None:
+        bin_llvm = os.path.dirname(dpcpp_path) + "/../bin-llvm/"
+        bin_llvm = os.path.normpath(bin_llvm)
+        result = shutil.which("llvm-spirv", path=bin_llvm)
 
     if result is None:
         result = "llvm-spirv"


### PR DESCRIPTION
numba-dpex does not pin the max-spirv-version that `llvm-spirv` generates and lets `llvm-spriv` decide what SPIR-V code to generate based on the LLVM-IR generated by the Numba front-end.

The behaviour is causing an issue with oneAPI dpcpp 2023.0 (Refer #868). The issue arises when a pre-compiled SPIR-V binary produced by compiling an OpenCL program implementing software atomic add for floating point values is linked to the SPIR-V module generated by JIT compilation inside numba-dpex.

The PR implements a workaround by setting the `spirv-max-version` flags to 1.1 when generating SPIR-V both for the pre-compiled OpenCL program and inside numba-dpex. SPIR-V version 1.1 is used as it seems to be the default used by dpcpp.

