### PR TITLE
Solving perferomance regression issue by caching the kernel_bundle

### DIFF
--- a/numba_dpex/core/caching.py
+++ b/numba_dpex/core/caching.py
@@ -16,8 +16,8 @@ from numba_dpex.core.types import USMNdArray
 def build_key(
     argtypes, pyfunc, codegen, backend=None, device_type=None, exec_queue=None
 ):
-    """Constructs a key from python function, context, backend and the device
-    type.
+    """Constructs a key from python function, context, backend, the device
+    type and execution queue.
 
     Compute index key for the given argument types and codegen. It includes a
     description of the OS, target architecture and hashes of the bytecode for
@@ -34,6 +34,7 @@ def build_key(
             Defaults to None.
         device_type (enum, optional): A 'device_type' enum.
             Defaults to None.
+        exec_queue (dpctl._sycl_queue.SyclQueue', optional): A SYCL queue object.
 
     Returns:
         tuple: A tuple of return type, argtpes, magic_tuple of codegen

--- a/numba_dpex/core/caching.py
+++ b/numba_dpex/core/caching.py
@@ -13,7 +13,9 @@ from numba_dpex import config
 from numba_dpex.core.types import USMNdArray
 
 
-def build_key(argtypes, pyfunc, codegen, backend=None, device_type=None):
+def build_key(
+    argtypes, pyfunc, codegen, backend=None, device_type=None, exec_queue=None
+):
     """Constructs a key from python function, context, backend and the device
     type.
 
@@ -64,6 +66,7 @@ def build_key(argtypes, pyfunc, codegen, backend=None, device_type=None):
         codegen.magic_tuple(),
         backend,
         device_type,
+        exec_queue,
         (
             hashlib.sha256(codebytes).hexdigest(),
             hashlib.sha256(cvarbytes).hexdigest(),

--- a/numba_dpex/tests/test_device_array_args.py
+++ b/numba_dpex/tests/test_device_array_args.py
@@ -26,7 +26,7 @@ d = a + b
 
 
 @skip_no_opencl_cpu
-class TestArrayArgsGPU:
+class TestArrayArgsCPU:
     def test_device_array_args_cpu(self):
         c = np.ones_like(a)
 
@@ -37,7 +37,7 @@ class TestArrayArgsGPU:
 
 
 @skip_no_opencl_gpu
-class TestArrayArgsCPU:
+class TestArrayArgsGPU:
     def test_device_array_args_gpu(self):
         c = np.ones_like(a)
 


### PR DESCRIPTION
This PR might solve issue #886. 

In version 0.19.0, the `create_program_from_spirv()` was done only once. See [line 483](https://github.com/IntelPython/numba-dpex/blob/0.19.0/numba_dpex/compiler.py#L483) in `compiler.py`.

In the current main it's been done everytime when `__call__()` function was invoked from `JitKernel` (See [here](https://github.com/IntelPython/numba-dpex/blob/main/numba_dpex/core/kernel_interface/dispatcher.py#L630)). Therefore we are now caching the `kernel_bundle` to avoid the repeated call of `create_program_from_spirv()`. 

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] If this PR is a work in progress, are you filing the PR as a draft?
