### PR TITLE
Updates the black requirement to black 23.1

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -27,3 +27,4 @@ jobs:
       - uses: psf/black@stable
         with:
           args: ". --check"
+          version: "23.1.0"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
 -   repo: https://github.com/psf/black
-    rev: 22.10.0
+    rev: 23.1.0
     hooks:
     -   id: black
         exclude: "versioneer.py|numba_dpex/_version.py"
@@ -23,7 +23,7 @@ repos:
     -   id: blacken-docs
         additional_dependencies: [black==22.10]
 -   repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
     -   id: isort
         name: isort (python)

--- a/numba_dpex/core/passes/dufunc_inliner.py
+++ b/numba_dpex/core/passes/dufunc_inliner.py
@@ -129,7 +129,6 @@ def dufunc_inliner(func_ir, calltypes, typemap, typingctx, targetctx):
     while work_list:
         label, block = work_list.pop()
         for i, instr in enumerate(block.body):
-
             if isinstance(instr, ir.Assign):
                 expr = instr.value
                 if isinstance(expr, ir.Expr):

--- a/numba_dpex/core/passes/lowerer.py
+++ b/numba_dpex/core/passes/lowerer.py
@@ -640,7 +640,7 @@ def _create_gufunc_for_parfor_body(
                 prev_block.append(ir.Jump(body_first_label, loc))
                 # Add all the parfor loop body blocks to the gufunc function's
                 # IR.
-                for (l, b) in loop_body.items():
+                for l, b in loop_body.items():
                     gufunc_ir.blocks[l] = b
                 body_last_label = max(loop_body.keys())
                 gufunc_ir.blocks[new_label] = block
@@ -1036,7 +1036,6 @@ def generate_kernel_launch_ops(
         all_val_types,
         range(len(expr_args)),
     ):
-
         if config.DEBUG_ARRAY_OPT:
             print(
                 "var:",
@@ -1447,7 +1446,6 @@ def lower_parfor_rollback(lowerer, parfor):
     try:
         _lower_parfor_gufunc(lowerer, parfor)
         if config.DEBUG:
-
             device_filter_str = (
                 dpctl.get_current_queue().get_sycl_device().filter_string
             )

--- a/numba_dpex/core/passes/passes.py
+++ b/numba_dpex/core/passes/passes.py
@@ -36,7 +36,6 @@ from .lowerer import DPEXLowerer
 
 @register_pass(mutates_CFG=True, analysis_only=False)
 class ConstantSizeStaticLocalMemoryPass(FunctionPass):
-
     _name = "dpex_constant_size_static_local_memory_pass"
 
     def __init__(self):
@@ -86,7 +85,6 @@ class ConstantSizeStaticLocalMemoryPass(FunctionPass):
                                         and attr_node.op == "getattr"
                                         and attr_node.attr == "local"
                                     ):
-
                                         arg = None
                                         # at first look in keyword arguments to
                                         # get the shape, which has to be
@@ -147,7 +145,6 @@ class ConstantSizeStaticLocalMemoryPass(FunctionPass):
 
 @register_pass(mutates_CFG=True, analysis_only=False)
 class PreParforPass(FunctionPass):
-
     _name = "dpex_pre_parfor_pass"
 
     def __init__(self):
@@ -193,7 +190,6 @@ class PreParforPass(FunctionPass):
 
 @register_pass(mutates_CFG=True, analysis_only=False)
 class ParforPass(FunctionPass):
-
     _name = "dpex_parfor_pass"
 
     def __init__(self):
@@ -260,7 +256,6 @@ def fallback_context(state, msg):
 
 @register_pass(mutates_CFG=True, analysis_only=False)
 class DpexLowering(LoweringPass):
-
     _name = "dpex_lowering"
 
     def __init__(self):
@@ -340,7 +335,6 @@ class DpexLowering(LoweringPass):
 
 @register_pass(mutates_CFG=True, analysis_only=False)
 class NoPythonBackend(FunctionPass):
-
     _name = "dpex_nopython_backend"
 
     def __init__(self):
@@ -380,7 +374,6 @@ class NoPythonBackend(FunctionPass):
 
 @register_pass(mutates_CFG=False, analysis_only=True)
 class DumpParforDiagnostics(AnalysisPass):
-
     _name = "dpex_dump_parfor_diagnostics"
 
     def __init__(self):

--- a/numba_dpex/core/passes/rename_numpy_functions_pass.py
+++ b/numba_dpex/core/passes/rename_numpy_functions_pass.py
@@ -237,7 +237,7 @@ class RewriteOverloadedNumPyFunctionsPass(FunctionPass):
 def get_dpnp_func_typ(func):
     from numba.core.typing.templates import builtin_registry
 
-    for (k, v) in builtin_registry.globals:
+    for k, v in builtin_registry.globals:
         if k == func:
             return v
     raise RuntimeError("type for func ", func, " not found")

--- a/numba_dpex/dpnp_iface/dpnp_linalgimpl.py
+++ b/numba_dpex/dpnp_iface/dpnp_linalgimpl.py
@@ -431,7 +431,6 @@ def dpnp_dot_impl(a, b):
         dpnp_func = dpnp_ext.dpnp_func("dpnp_dot", [a.dtype.name, "NONE"], sig)
 
         def dot_2_vv(a, b):
-
             (m,) = a.shape
             (n,) = b.shape
 

--- a/numba_dpex/examples/kernel/kernel_specialization.py
+++ b/numba_dpex/examples/kernel/kernel_specialization.py
@@ -51,6 +51,7 @@ assert np.array_equal(npc, npc_expected)
 # Multiple signatures can be specified as a list to eager compile multiple
 # versions of the kernel.
 
+
 # specialize a kernel for the i64arrty
 @dpex.kernel([(i64arrty, i64arrty, i64arrty), (f32arrty, f32arrty, f32arrty)])
 def data_parallel_sum2(a, b, c):

--- a/numba_dpex/examples/kernel/vector_sum.py
+++ b/numba_dpex/examples/kernel/vector_sum.py
@@ -18,7 +18,6 @@ def kernel_vector_sum(a, b, c):
 
 # Utility function for printing and testing
 def driver(a, b, c, global_size):
-
     kernel_vector_sum[Range(global_size)](a, b, c)
 
     a_np = dpnp.asnumpy(a)  # Copy dpnp array a to NumPy array a_np

--- a/numba_dpex/numpy_usm_shared.py
+++ b/numba_dpex/numpy_usm_shared.py
@@ -72,7 +72,6 @@ for (
     py_name,
     c_address,
 ) in numba_dpex._usm_allocators_ext.c_helpers.items():
-
     llb.add_symbol(py_name, c_address)
 
 
@@ -154,6 +153,7 @@ register_model(UsmSharedArrayType)(numba.core.datamodel.models.ArrayModel)
 dpex_data_model_manager.register(
     UsmSharedArrayType, numba.core.datamodel.models.ArrayModel
 )
+
 
 # This tells Numba how to convert from its native representation
 # of a UsmArray in a njit function back to a Python UsmArray.

--- a/numba_dpex/ocl/ocldecl.py
+++ b/numba_dpex/ocl/ocldecl.py
@@ -140,7 +140,6 @@ class OCL_local_array(CallableTemplate):
 
     def generic(self):
         def typer(shape, dtype):
-
             # Only integer literals and tuples of integer literals are valid
             # shapes
             if isinstance(shape, types.Integer):
@@ -184,7 +183,6 @@ class OCL_private_array(CallableTemplate):
 
     def generic(self):
         def typer(shape, dtype):
-
             # Only integer literals and tuples of integer literals are valid
             # shapes
             if isinstance(shape, types.Integer):

--- a/numba_dpex/tests/kernel_tests/test_kernel_launch_params.py
+++ b/numba_dpex/tests/kernel_tests/test_kernel_launch_params.py
@@ -12,6 +12,7 @@ from numba_dpex.core.exceptions import (
     InvalidKernelLaunchArgsError,
     UnknownGlobalRangeError,
 )
+from numba_dpex.core.kernel_interface.utils import Range
 
 
 @dpex.kernel
@@ -27,9 +28,7 @@ def test_1D_global_range_as_int():
 
 
 def test_1D_global_range_as_one_tuple():
-    k = vecadd[
-        10,
-    ]
+    k = vecadd[Range(10)]
     assert k._global_range == [10]
     assert k._local_range is None
 

--- a/numba_dpex/tests/kernel_tests/test_kernel_specialization.py
+++ b/numba_dpex/tests/kernel_tests/test_kernel_specialization.py
@@ -11,6 +11,7 @@ from numba_dpex.core.exceptions import (
     InvalidKernelSpecializationError,
     MissingSpecializationError,
 )
+from numba_dpex.core.kernel_interface.utils import Range
 
 i64arrty = usm_ndarray(int64, 1, "C")
 f32arrty = usm_ndarray(float32, 1, "C")
@@ -59,9 +60,7 @@ def test_missing_specialization_error():
     c = dpt.zeros(1024, dtype=dpt.int32)
 
     with pytest.raises(MissingSpecializationError):
-        specialized_kernel1(data_parallel_sum)[
-            1024,
-        ](a, b, c)
+        specialized_kernel1(data_parallel_sum)[Range(1024)](a, b, c)
 
 
 def test_execution_of_specialized_kernel():
@@ -70,9 +69,7 @@ def test_execution_of_specialized_kernel():
     b = dpt.ones(1024, dtype=dpt.int64)
     c = dpt.zeros(1024, dtype=dpt.int64)
 
-    specialized_kernel1(data_parallel_sum)[
-        1024,
-    ](a, b, c)
+    specialized_kernel1(data_parallel_sum)[Range(1024)](a, b, c)
 
     npc = dpt.asnumpy(c)
     import numpy as np


### PR DESCRIPTION
Numba-dpex now uses black 23.1 and the PR updates the pre-commit config and reformat the files impacted by the change.