### PR TITLE
Updates to the dpjit decorator and dpjit target context

### DIFF
--- a/numba_dpex/core/targets/dpjit_target.py
+++ b/numba_dpex/core/targets/dpjit_target.py
@@ -5,7 +5,7 @@
 """Defines the target and typing contexts for numba_dpex's dpjit decorator.
 """
 
-from numba.core.base import BaseContext
+from numba.core.cpu import CPUContext
 from numba.core.target_extension import CPU, target_registry
 
 
@@ -20,6 +20,6 @@ DPEX_TARGET_NAME = "dpex"
 target_registry[DPEX_TARGET_NAME] = Dpex
 
 
-class DpexTargetContext(BaseContext):
+class DpexTargetContext(CPUContext):
     def __init__(self, typingctx, target=DPEX_TARGET_NAME):
         super().__init__(typingctx, target)


### PR DESCRIPTION
- [X] Have you provided a meaningful PR description?
Updates the dpjit decorator to be a shim over Numba's jit decorator and only change the Pipeline. The pipeline is presently the OffloadPipeline that may change in the future.

Also update the `DpexTargetContext` to inherit from `CPUContext` instead of `BaseContext`.

- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
No, as no real functionality has been added and the work is mostly stubs.
- [X] Have you tested your changes locally for CPU and GPU devices?
Yes
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
