### PR TITLE
Fix license in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -183,7 +183,7 @@ metadata = dict(
         "Environment :: GPU",
         "Environment :: Plugins",
         "Intended Audience :: Developers",
-        "License :: OSI Approved :: BSD License",
+        "License :: OSI Approved :: Apache 2.0",
         "Operating System :: OS Independent",
         "Programming Language :: Cython",
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
The license in our setup.py was never updated once me moved from BSD 2 to Apache 2.0. The PR corrects the setup.py to have the right license attribute for the product.
