### PR TITLE
Changes to allow dpnp.ndarray objects as kernel arguments.

### DIFF
--- a/numba_dpex/core/datamodel/models.py
+++ b/numba_dpex/core/datamodel/models.py
@@ -62,10 +62,22 @@ def _init_data_model_manager():
 
 dpex_data_model_manager = _init_data_model_manager()
 
+# XXX A kernel function has the spir_kernel ABI and requires pointers to have an
+# address space attribute. For this reason, the UsmNdArray type uses dpex's
+# ArrayModel where the pointers are address space casted to have a SYCL-specific
+# address space value. The DpnpNdArray type can be used inside djit functions
+# as host function calls arguments, such as dpnp library calls. The DpnpNdArray
+# needs to use Numba's array model as its data model. Thus, from a Numba typing
+# perspective dpnp.ndarrays cannot be directly passed to a kernel. To get
+# around the limitation, the DpexKernelTypingContext does not resolve the type
+# of dpnp.array args to a kernel as DpnpNdArray type objects, but uses the
+# ``to_usm_ndarray`` utility function to convert them into a UsmNdArray type
+# object.
+
 # Register the USMNdArray type with the dpex ArrayModel
 register_model(USMNdArray)(ArrayModel)
 dpex_data_model_manager.register(USMNdArray, ArrayModel)
 
-# Register the DpnpNdArray type with the dpex ArrayModel
+# Register the DpnpNdArray type with the Numba ArrayModel
 register_model(DpnpNdArray)(DpnpNdArrayModel)
 dpex_data_model_manager.register(DpnpNdArray, DpnpNdArrayModel)

--- a/numba_dpex/core/kernel_interface/dispatcher.py
+++ b/numba_dpex/core/kernel_interface/dispatcher.py
@@ -486,7 +486,8 @@ class JitKernel:
                 warn(
                     "Ambiguous kernel launch paramters. If your data have "
                     + "dimensions > 1, include a default/empty local_range:\n"
-                    + "    <function>[(X,Y), numba_dpex.DEFAULT_LOCAL_RANGE](<params>)\n"
+                    + "    <function>[(X,Y), numba_dpex.DEFAULT_LOCAL_RANGE]"
+                    "(<params>)\n"
                     + "otherwise your code might produce erroneous results.",
                     DeprecationWarning,
                     stacklevel=2,
@@ -500,7 +501,7 @@ class JitKernel:
                 + "parameters is deprecated. Users should set the kernel "
                 + "parameters through Range/NdRange classes.\n"
                 + "Example:\n"
-                + "    from numba_dpex.core.kernel_interface.utils import Range,NdRange\n\n"
+                + "    from numba_dpex import Range,NdRange\n\n"
                 + "    # for global range only\n"
                 + "    <function>[Range(X,Y)](<parameters>)\n"
                 + "    # or,\n"
@@ -531,10 +532,11 @@ class JitKernel:
                     )
                 else:
                     warn(
-                        "Empty local_range calls are deprecated. Please use Range/NdRange "
-                        + "to specify the kernel launch parameters:\n"
+                        "Empty local_range calls are deprecated. Please use "
+                        "Range/NdRange to specify the kernel launch parameters:"
+                        "\n"
                         + "Example:\n"
-                        + "    from numba_dpex.core.kernel_interface.utils import Range,NdRange\n\n"
+                        + "    from numba_dpex import Range,NdRange\n\n"
                         + "    # for global range only\n"
                         + "    <function>[Range(X,Y)](<parameters>)\n"
                         + "    # or,\n"

--- a/numba_dpex/core/targets/kernel_target.py
+++ b/numba_dpex/core/targets/kernel_target.py
@@ -19,6 +19,7 @@ from numba.core.utils import cached_property
 from numba_dpex.core.datamodel.models import _init_data_model_manager
 from numba_dpex.core.exceptions import UnsupportedKernelArgumentError
 from numba_dpex.core.typeconv import to_usm_ndarray
+from numba_dpex.core.types import DpnpNdArray
 from numba_dpex.core.utils import get_info_from_suai
 from numba_dpex.utils import (
     address_space,
@@ -67,6 +68,20 @@ class DpexKernelTypingContext(typing.BaseContext):
         """
         try:
             _type = type(typeof(val))
+
+            # XXX A kernel function has the spir_kernel ABI and requires
+            # pointers to have an address space attribute. For this reason, the
+            # UsmNdArray type uses a custom data model where the pointers are
+            # address space casted to have a SYCL-specific address space value.
+            # The DpnpNdArray type on the other hand is meant to be used inside
+            # host functions and has Numba's array model as its data model.
+            # If the value is a DpnpNdArray then use the ``to_usm_ndarray``
+            # function to convert it into a UsmNdArray type rather than passing
+            # it to the kernel as a DpnpNdArray. Thus, from a Numba typing
+            # perspective dpnp.ndarrays cannot be directly passed to a kernel.
+            if _type is DpnpNdArray:
+                suai_attrs = get_info_from_suai(val)
+                return to_usm_ndarray(suai_attrs)
         except ValueError:
             # When an array-like kernel argument is not recognized by
             # numba-dpex, this additional check sees if the array-like object

--- a/numba_dpex/tests/kernel_tests/test_dpnp_ndarray_args.py
+++ b/numba_dpex/tests/kernel_tests/test_dpnp_ndarray_args.py
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: 2020 - 2022 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import dpnp
+from numpy.testing import assert_almost_equal
+
+import numba_dpex as ndpx
+from numba_dpex import float32
+
+COEFFICIENTS = dpnp.asarray(
+    [
+        [
+            -0.008086340206185568,
+            0.242590206185567,
+            -0.6172680412371134,
+            0,
+        ],
+        [
+            0.015431701030927836,
+            -1.168492268041237,
+            27.60438144329897,
+            -188.1443298969072,
+        ],
+        [
+            -0.0036404639175257733,
+            0.5480025773195877,
+            -23.890463917525775,
+            326.8041237113402,
+        ],
+        [
+            -0.010869845360824743,
+            1.4155283505154639,
+            -58.59149484536083,
+            789.4845360824743,
+        ],
+        [
+            -0.0028801546391752576,
+            0.21707474226804124,
+            1.3311855670103092,
+            -209.22680412371133,
+        ],
+        [
+            0.042390463917525774,
+            -7.9316365979381445,
+            490.25386597938143,
+            -9987.680412371134,
+        ],
+        [
+            -0.061681701030927835,
+            13.923518041237113,
+            -1039.6069587628865,
+            25709.072164948455,
+        ],
+        [
+            0.029336340206185568,
+            -7.920811855670103,
+            707.9394329896908,
+            -20892.164948453606,
+        ],
+    ],
+    dtype=dpnp.float32,
+)
+
+
+@ndpx.kernel()
+def _kernel(coefficients):
+    c = ndpx.private.array(4, dtype=float32)
+    gr_id = ndpx.get_group_id(0)
+    c[0] = coefficients[gr_id][0]
+    c[1] = coefficients[gr_id][1]
+    c[2] = coefficients[gr_id][2]
+    c[3] = coefficients[gr_id][3]
+
+
+def test_setting_private_from_dpnp_ndarray():
+    N_SEGMENTS = 8
+    LOCAL_SIZE = 128
+    # Number of points in the batch. Each work item processes one batch
+    N_POINTS_PER_WORK_ITEM = 4
+    # Number of points processed by a work group
+    N_POINTS_PER_WORK_GROUP = N_POINTS_PER_WORK_ITEM * LOCAL_SIZE
+    # Total number of points
+    N_POINTS = N_POINTS_PER_WORK_GROUP * N_SEGMENTS
+    global_range = ndpx.Range(N_POINTS // N_POINTS_PER_WORK_ITEM)
+    local_range = ndpx.Range(LOCAL_SIZE)
+    try:
+        _kernel[ndpx.NdRange(global_range, local_range)](COEFFICIENTS)
+    except Exception as e:
+        assert (
+            False
+        ), f"'_kernel' raised an exception {e} when passing a dpnp.ndarray arg"


### PR DESCRIPTION
- [x] Have you provided a meaningful PR description?
    - Changes the `DpexKernelTypingContext` to always use the `to_usm_ndarray` utility function to convert `dpnp.ndarray`
      arguments to a `UsmNdArray` type.
    - The change allows passing `dpnp.ndarrays` correctly to kernels without impacting dpjit functions.
    - Fixes numba_dpex/examples/kernel/interpolation.py

- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
