### PR TITLE
Dispatcher/caching rewrite to address performance regression

### DIFF
--- a/numba_dpex/core/caching.py
+++ b/numba_dpex/core/caching.py
@@ -10,10 +10,6 @@ from numba.core.caching import CacheImpl, IndexDataCacheFile
 from numba_dpex import config
 
 
-def build_key(*args):
-    return tuple(args)
-
-
 class _CacheImpl(CacheImpl):
     """Implementation of `CacheImpl` to be used by subclasses of `_Cache`.
 
@@ -414,7 +410,13 @@ class LRUCache(AbstractCache):
                         self._name, len(self._lookup), str(key)
                     )
                 )
-            self._lookup[key].value = value
+            node = self._lookup[key]
+            node.value = value
+
+            if node is not self._tail:
+                self._unlink_node(node)
+                self._append_tail(node)
+
             return
 
         if key in self._evicted:

--- a/numba_dpex/core/kernel_interface/func.py
+++ b/numba_dpex/core/kernel_interface/func.py
@@ -5,17 +5,18 @@
 """_summary_
 """
 
-import hashlib
-
 from numba.core import sigutils, types
-from numba.core.serialize import dumps
 from numba.core.typing.templates import AbstractTemplate, ConcreteTemplate
 
 from numba_dpex import config
-from numba_dpex.core.caching import LRUCache, NullCache, build_key
+from numba_dpex.core.caching import LRUCache, NullCache
 from numba_dpex.core.compiler import compile_with_dpex
 from numba_dpex.core.descriptor import dpex_kernel_target
-from numba_dpex.core.types import USMNdArray
+from numba_dpex.core.utils import (
+    build_key,
+    create_func_hash,
+    strip_usm_metadata,
+)
 from numba_dpex.utils import npytypes_array_to_dpex_array
 
 
@@ -94,7 +95,7 @@ class DpexFunctionTemplate(object):
         self._debug = debug
         self._enable_cache = enable_cache
 
-        self._func_hash = self._create_func_hash()
+        self._func_hash = create_func_hash(pyfunc)
 
         if not config.ENABLE_CACHE:
             self._cache = NullCache()
@@ -108,28 +109,6 @@ class DpexFunctionTemplate(object):
             self._cache = NullCache()
         self._cache_hits = 0
 
-    def _create_func_hash(self):
-        """Creates a tuple of sha256 hashes out of code and variable bytes extracted from the compiled funtion."""
-
-        codebytes = self._pyfunc.__code__.co_code
-        if self._pyfunc.__closure__ is not None:
-            try:
-                cvars = tuple(
-                    [x.cell_contents for x in self._pyfunc.__closure__]
-                )
-                # Note: cloudpickle serializes a function differently depending
-                #       on how the process is launched; e.g. multiprocessing.Process
-                cvarbytes = dumps(cvars)
-            except:
-                cvarbytes = b""  # a temporary solution for function template
-        else:
-            cvarbytes = b""
-
-        return (
-            hashlib.sha256(codebytes).hexdigest(),
-            hashlib.sha256(cvarbytes).hexdigest(),
-        )
-
     @property
     def cache(self):
         """Cache accessor"""
@@ -139,20 +118,6 @@ class DpexFunctionTemplate(object):
     def cache_hits(self):
         """Cache hit count accessor"""
         return self._cache_hits
-
-    def _strip_usm_metadata(self, argtypes):
-        stripped_argtypes = []
-        for argty in argtypes:
-            if isinstance(argty, USMNdArray):
-                # Convert the USMNdArray to an abridged type that disregards the
-                # usm_type, device, queue, address space attributes.
-                stripped_argtypes.append(
-                    (argty.ndim, argty.dtype, argty.layout)
-                )
-            else:
-                stripped_argtypes.append(argty)
-
-        return tuple(stripped_argtypes)
 
     def compile(self, args):
         """Compile a `numba_dpex.func` decorated function
@@ -175,7 +140,7 @@ class DpexFunctionTemplate(object):
         ]
 
         # Generate key used for cache lookup
-        stripped_argtypes = self._strip_usm_metadata(argtypes)
+        stripped_argtypes = strip_usm_metadata(argtypes)
         codegen_magic_tuple = (
             dpex_kernel_target.target_context.codegen().magic_tuple()
         )

--- a/numba_dpex/core/utils/__init__.py
+++ b/numba_dpex/core/utils/__init__.py
@@ -2,9 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from .caching_utils import build_key, create_func_hash, strip_usm_metadata
 from .suai_helper import SyclUSMArrayInterface, get_info_from_suai
 
 __all__ = [
     "get_info_from_suai",
     "SyclUSMArrayInterface",
+    "create_func_hash",
+    "strip_usm_metadata",
+    "build_key",
 ]

--- a/numba_dpex/core/utils/caching_utils.py
+++ b/numba_dpex/core/utils/caching_utils.py
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: 2020 - 2022 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import hashlib
+
+from numba.core.serialize import dumps
+
+from numba_dpex.core.types import USMNdArray
+
+
+def build_key(*args):
+    """Constructs key from variable list of args
+
+    Args:
+       *args: List of components to construct key
+    Return:
+       Tuple of args
+    """
+    return tuple(args)
+
+
+def create_func_hash(pyfunc):
+    """Creates a tuple of sha256 hashes out of code and
+    variable bytes extracted from the compiled funtion.
+
+    Args:
+       pyfunc: Python function object
+    Return:
+       Tuple of hashes of code and variable bytes
+    """
+    codebytes = pyfunc.__code__.co_code
+    if pyfunc.__closure__ is not None:
+        try:
+            cvars = tuple([x.cell_contents for x in pyfunc.__closure__])
+            # Note: cloudpickle serializes a function differently depending
+            #       on how the process is launched; e.g. multiprocessing.Process
+            cvarbytes = dumps(cvars)
+        except:
+            cvarbytes = b""  # a temporary solution for function template
+    else:
+        cvarbytes = b""
+
+    return (
+        hashlib.sha256(codebytes).hexdigest(),
+        hashlib.sha256(cvarbytes).hexdigest(),
+    )
+
+
+def strip_usm_metadata(argtypes):
+    """Convert the USMNdArray to an abridged type that disregards the
+    usm_type, device, queue, address space attributes.
+
+    Args:
+       argtypes: List of types
+
+    Return:
+       Tuple of types after removing USM metadata from USMNdArray type
+    """
+
+    stripped_argtypes = []
+    for argty in argtypes:
+        if isinstance(argty, USMNdArray):
+            stripped_argtypes.append((argty.ndim, argty.dtype, argty.layout))
+        else:
+            stripped_argtypes.append(argty)
+
+    return tuple(stripped_argtypes)


### PR DESCRIPTION
This PR partially addresses the performance regressions described in #886. It contains the following 4 key changes.

(1) ~~The put() function implementation in LRUCache contains a call to get(), which was unnecessary. This PR removes the call to get().~~ Replaced call to get() in LRUCache.put() method with explicit logic to update the linked list keeping track of LRU ordering.

(2) Sha256 hash computation was being performed on every call to build cache key, which in turn was being called on for each dynamic call to a kernel. Instead of computing hash on every dynamic call to a kernel, it can be done once. This PR performs the hash computation for every static instance of a kernel rather than every dynamic instance.

(3) The types of kernel arguments are used as a part of the key when caching. The arguments types were being pre-processed to strip out USM metadata. This functionality was being performed twice for each call, once for building key for kernel module cache and again for kernel bundle cache. This PR changes the logic to perform the pre-processing once per-call.

(4) The function that build the cache key takes variable number of arguments and returns a tuple. The rest of the logic from build key has been moved to dispatcher and func. The key intuition of using variable args is to support the different caches, so far, kernel module cache and kernel bundle cache. Both these caches use different number of keys. (Side note: The build_key function is ideally suited to exist as a static method inside AbstractCache class).

**Effects of optimizations:**
Evaluated the effect of these changes using kmeans implementation from [here](https://github.com/soda-inria/sklearn-numba-dpex).
On Intel ATS GPUs the execution time before the changes is 1.7 seconds. After these changes the execution time reduces to 1.4 seconds. See log below. With numba-dpex 0.19.0 the execution time is 1.1 seconds. These changes partially address the regression introduced after 0.19.0.

Run Log with numba-dpex 0.19.0:
-------------------------------------
python benchmark/kmeans.py
Running Kmeans numba_dpex lloyd GPU ... done in 1.1 s


Run Log with numba-dpex main:
-------------------------------------
python benchmark/kmeans.py
Running Kmeans numba_dpex lloyd GPU ... done in 1.7 s

Run Log with this PR:
------------------------
python benchmark/kmeans.py
Running Kmeans numba_dpex lloyd GPU ... done in 1.4 s

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] If this PR is a work in progress, are you filing the PR as a draft?
