### PR TITLE
Output LLVM IR if NUMBA_DPEX_DEBUG environment variable is set

### DIFF
--- a/numba_dpex/config.py
+++ b/numba_dpex/config.py
@@ -89,6 +89,9 @@ DEBUGINFO_DEFAULT = _readenv(
     "NUMBA_DPEX_DEBUGINFO", int, config.DEBUGINFO_DEFAULT
 )
 
+# Emit LLVM assembly language format(.ll)
+DUMP_KERNEL_LLVM = _readenv("NUMBA_DPEX_DUMP_KERNEL_LLVM", int, config.DUMP_OPTIMIZED)
+
 # configs for caching
 # To see the debug messages for the caching.
 # Execute like:

--- a/numba_dpex/config.py
+++ b/numba_dpex/config.py
@@ -90,7 +90,9 @@ DEBUGINFO_DEFAULT = _readenv(
 )
 
 # Emit LLVM assembly language format(.ll)
-DUMP_KERNEL_LLVM = _readenv("NUMBA_DPEX_DUMP_KERNEL_LLVM", int, config.DUMP_OPTIMIZED)
+DUMP_KERNEL_LLVM = _readenv(
+    "NUMBA_DPEX_DUMP_KERNEL_LLVM", int, config.DUMP_OPTIMIZED
+)
 
 # configs for caching
 # To see the debug messages for the caching.

--- a/numba_dpex/core/kernel_interface/spirv_kernel.py
+++ b/numba_dpex/core/kernel_interface/spirv_kernel.py
@@ -7,7 +7,7 @@ from types import FunctionType
 
 from numba.core import ir
 
-from numba_dpex import spirv_generator
+from numba_dpex import config, spirv_generator
 from numba_dpex.core.compiler import compile_with_dpex
 from numba_dpex.core.exceptions import UncompiledKernelError, UnreachableError
 
@@ -138,6 +138,20 @@ class SpirvKernel(KernelInterface):
         )
         self._llvm_module = kernel.module.__str__()
         self._module_name = kernel.name
+
+        # Dump LLVM IR if DEBUG flag is set.
+        if config.DEBUG:
+            import hashlib
+
+            # Embed hash of module name in the output file name
+            # so that different kernels are written to separate files
+            with open(
+                "llvm_kernel_"
+                + hashlib.sha256(self._module_name.encode()).hexdigest()
+                + ".ll",
+                "w",
+            ) as f:
+                f.write(self._llvm_module)
 
         # FIXME: There is no need to serialize the bitcode. It can be passed to
         # llvm-spirv directly via stdin.

--- a/numba_dpex/core/kernel_interface/spirv_kernel.py
+++ b/numba_dpex/core/kernel_interface/spirv_kernel.py
@@ -140,7 +140,7 @@ class SpirvKernel(KernelInterface):
         self._module_name = kernel.name
 
         # Dump LLVM IR if DEBUG flag is set.
-        if config.DEBUG:
+        if config.DUMP_KERNEL_LLVM:
             import hashlib
 
             # Embed hash of module name in the output file name

--- a/numba_dpex/tests/test_dump_kernel_llvm.py
+++ b/numba_dpex/tests/test_dump_kernel_llvm.py
@@ -1,0 +1,84 @@
+#! /usr/bin/env python
+
+# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import hashlib
+import os
+
+import numba_dpex as dpex
+from numba_dpex import config, float32, usm_ndarray
+from numba_dpex.core.descriptor import dpex_kernel_target
+
+f32arrty = usm_ndarray(ndim=1, dtype=float32, layout="C")
+
+
+def _get_kernel_llvm(fn, sig, debug=False):
+    kernel = dpex.core.kernel_interface.spirv_kernel.SpirvKernel(
+        fn, fn.__name__
+    )
+    kernel.compile(
+        args=sig,
+        target_ctx=dpex_kernel_target.target_context,
+        typing_ctx=dpex_kernel_target.typing_context,
+        debug=debug,
+        compile_flags=None,
+    )
+    return kernel.module_name, kernel.llvm_module
+
+
+def test_dump_file_on_dump_kernel_llvm_flag_on():
+    """
+    Test functionality of DUMP_KERNEL_LLVM config variable.
+    Check llvm source is dumped in .ll file in current directory
+    and compare with llvm source stored in SprivKernel.
+    """
+
+    def data_parallel_sum(var_a, var_b, var_c):
+        i = dpex.get_global_id(0)
+        var_c[i] = var_a[i] + var_b[i]
+
+    sig = (f32arrty, f32arrty, f32arrty)
+
+    config.DUMP_KERNEL_LLVM = True
+
+    llvm_module_name, llvm_module_str = _get_kernel_llvm(data_parallel_sum, sig)
+
+    dump_file_name = (
+        "llvm_kernel_"
+        + hashlib.sha256(llvm_module_name.encode()).hexdigest()
+        + ".ll"
+    )
+
+    with open(dump_file_name, "r") as f:
+        llvm_dump = f.read()
+
+    assert llvm_module_str == llvm_dump
+
+    os.remove(dump_file_name)
+
+
+def test_no_dump_file_on_dump_kernel_llvm_flag_off():
+    """
+    Test functionality of DUMP_KERNEL_LLVM config variable.
+    Check llvm source is not dumped in .ll file in current directory.
+    """
+
+    def data_parallel_sum(var_a, var_b, var_c):
+        i = dpex.get_global_id(0)
+        var_c[i] = var_a[i] + var_b[i]
+
+    sig = (f32arrty, f32arrty, f32arrty)
+
+    config.DUMP_KERNEL_LLVM = False
+
+    llvm_module_name, llvm_module_str = _get_kernel_llvm(data_parallel_sum, sig)
+
+    dump_file_name = (
+        "llvm_kernel_"
+        + hashlib.sha256(llvm_module_name.encode()).hexdigest()
+        + ".ll"
+    )
+
+    assert not os.path.isfile(dump_file_name)


### PR DESCRIPTION
- [x] Have you provided a meaningful PR description?

Adding functionality to output LLVM IR to a file. The output file name contains a hash generated from the LLVM module name. This allows us to write different kernels to separate files since the hash is expected to be unique.

- [x] Have you added a test, reproducer or referred to an issue with a reproducer?

Tested with Blackscholes in dpbench. File name generated is `llvm_kernel_ce84b7ebc25a6c5f71403d77de797be75067dce745a14ae28ca34dc5e3365998.ll`

- [x] Have you tested your changes locally for CPU and GPU devices?
Tested on GPU

- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] If this PR is a work in progress, are you filing the PR as a draft?
