### PR TITLE
Replace ImportError with logging.warning if dpctl version is not met

### DIFF
--- a/numba_dpex/config.py
+++ b/numba_dpex/config.py
@@ -15,7 +15,10 @@ def _ensure_dpctl():
     from numba_dpex.dpctl_support import dpctl_version
 
     if dpctl_version < (0, 14):
-        raise ImportError("numba_dpex needs dpctl 0.14 or greater")
+        logging.warning(
+            "numba_dpex needs dpctl 0.14 or greater, using "
+            f"dpctl={dpctl_version} may cause unexpected behavior"
+        )
 
 
 def _dpctl_has_non_host_device():

--- a/numba_dpex/dpctl_support.py
+++ b/numba_dpex/dpctl_support.py
@@ -4,4 +4,18 @@
 
 import dpctl
 
-dpctl_version = tuple(map(int, dpctl.__version__.split(".")[:2]))
+
+def _parse_version():
+    t = dpctl.__version__.split(".")
+    if len(t) > 1:
+        try:
+            return tuple(map(int, t))
+        except ValueError:
+            return (0, 0)
+    else:
+        return (0, 0)
+
+
+dpctl_version = _parse_version()
+
+del _parse_version


### PR DESCRIPTION
If dpctl was built from source without `.git` folder present, `dpctl.__version__` is `0+unknown` and `dpctl_version` computation in `numba_dpex/dpctl_support.py` broke down. 

Introduced function to safely infer `dpctl_version`, and modified `config.py` to issue soft `logging.warning` about unmet dpctl version instead of raising hard `ImportError`.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
