### PR TITLE
Fixed a blunder in _parse_version

### DIFF
--- a/numba_dpex/dpctl_support.py
+++ b/numba_dpex/dpctl_support.py
@@ -9,7 +9,7 @@ def _parse_version():
     t = dpctl.__version__.split(".")
     if len(t) > 1:
         try:
-            return tuple(map(int, t))
+            return tuple(map(int, t[:2]))
         except ValueError:
             return (0, 0)
     else:

--- a/numba_dpex/tests/test_dpctl_api.py
+++ b/numba_dpex/tests/test_dpctl_api.py
@@ -5,6 +5,7 @@
 import dpctl
 import pytest
 
+from numba_dpex.dpctl_support import dpctl_version
 from numba_dpex.tests._helper import filter_strings
 
 
@@ -16,3 +17,11 @@ def test_dpctl_api(filter_str):
         dpctl.get_current_queue()
         dpctl.get_num_activated_queues()
         dpctl.is_in_device_context()
+
+
+def test_dpctl_version():
+    dpctl_v = dpctl.__version__
+    computed_v = ".".join(str(n) for n in dpctl_version)
+    n = len(computed_v)
+    assert n <= len(dpctl_v)
+    assert computed_v == dpctl_v[:n]


### PR DESCRIPTION
Added hastily remove slicing of dpctl version tuple to the first two elements which are expected to be integral.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
