### PR TITLE
Removes the usage of llvmlite.llvmpy

### DIFF
--- a/numba_dpex/core/codegen.py
+++ b/numba_dpex/core/codegen.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from llvmlite import binding as ll
-from llvmlite.llvmpy import core as lc
+from llvmlite import ir as llvmir
 from numba.core import utils
 from numba.core.codegen import CPUCodegen, CPUCodeLibrary
 
@@ -71,7 +71,7 @@ class JITSPIRVCodegen(CPUCodegen):
         )
 
     def _create_empty_module(self, name):
-        ir_module = lc.Module(name)
+        ir_module = llvmir.Module(name)
         ir_module.triple = SPIR_TRIPLE[utils.MACHINE_BITS]
         if self._data_layout:
             ir_module.data_layout = self._data_layout

--- a/numba_dpex/dpctl_iface/dpctl_capi_fn_builder.py
+++ b/numba_dpex/dpctl_iface/dpctl_capi_fn_builder.py
@@ -7,7 +7,7 @@ This module provides a set of wrapper functions to insert dpctl C API function
 declarations into an LLVM module.
 """
 
-import llvmlite.llvmpy.core as lc
+from llvmlite import ir as llvmir
 from numba.core import cgutils, types
 
 import numba_dpex.utils as utils
@@ -36,7 +36,7 @@ class DpctlCAPIFnBuilder:
         Return: A Python object wrapping an LLVM Function.
 
         """
-        func_ty = lc.Type.function(return_ty, arg_list)
+        func_ty = llvmir.FunctionType(return_ty, arg_list)
         fn = cgutils.get_or_insert_function(builder.module, func_ty, func_name)
         return fn
 

--- a/numba_dpex/ocl/oclimpl.py
+++ b/numba_dpex/ocl/oclimpl.py
@@ -6,10 +6,8 @@ import operator
 from functools import reduce
 
 import dpctl
-import llvmlite.binding as ll
-import llvmlite.llvmpy.core as lc
-from llvmlite import ir
-from llvmlite.llvmpy.core import Type
+from llvmlite import binding as ll
+from llvmlite import ir as llvmir
 from numba.core import cgutils, types
 from numba.core.imputils import Registry
 from numba.core.typing.npydecl import parse_dtype
@@ -26,7 +24,8 @@ from . import stubs
 registry = Registry()
 lower = registry.lower
 
-_void_value = lc.Constant.null(lc.Type.pointer(lc.Type.int(8)))
+_void_value = llvmir.Constant(llvmir.IntType(8).as_pointer(), None)
+
 
 # -----------------------------------------------------------------------------
 
@@ -56,11 +55,11 @@ def _declare_function(context, builder, name, sig, cargs, mangler=mangle_c):
     """
     mod = builder.module
     if sig.return_type == types.void:
-        llretty = lc.Type.void()
+        llretty = llvmir.VoidType()
     else:
         llretty = context.get_value_type(sig.return_type)
     llargs = [context.get_value_type(t) for t in sig.args]
-    fnty = Type.function(llretty, llargs)
+    fnty = llvmir.FunctionType(llretty, llargs)
     mangled = mangler(name, cargs)
     fn = cgutils.get_or_insert_function(mod, fnty, mangled)
     fn.calling_convention = kernel_target.CC_SPIR_FUNC
@@ -186,7 +185,7 @@ def insert_and_call_atomic_fn(
     ll_p = None
     name = ""
     if dtype.name == "float32":
-        ll_val = ir.FloatType()
+        ll_val = llvmir.FloatType()
         ll_p = ll_val.as_pointer()
         if fn_type == "add":
             name = "numba_dpex_atomic_add_f32"
@@ -196,7 +195,7 @@ def insert_and_call_atomic_fn(
             raise TypeError("Operation type is not supported %s" % (fn_type))
     elif dtype.name == "float64":
         if True:
-            ll_val = ir.DoubleType()
+            ll_val = llvmir.DoubleType()
             ll_p = ll_val.as_pointer()
             if fn_type == "add":
                 name = "numba_dpex_atomic_add_f64"
@@ -222,12 +221,12 @@ def insert_and_call_atomic_fn(
 
     mod = builder.module
     if sig.return_type == types.void:
-        llretty = lc.Type.void()
+        llretty = llvmir.VoidType()
     else:
         llretty = context.get_value_type(sig.return_type)
 
     llargs = [ll_p, context.get_value_type(sig.args[2])]
-    fnty = ir.FunctionType(llretty, llargs)
+    fnty = llvmir.FunctionType(llretty, llargs)
 
     fn = cgutils.get_or_insert_function(mod, fnty, name)
     fn.calling_convention = kernel_target.CC_SPIR_FUNC
@@ -281,8 +280,8 @@ def native_atomic_add(context, builder, sig, args):
     retty = context.get_value_type(sig.return_type)
     spirv_fn_arg_types = [
         ptr_type,
-        ir.IntType(32),
-        ir.IntType(32),
+        llvmir.IntType(32),
+        llvmir.IntType(32),
         context.get_value_type(sig.args[2]),
     ]
 
@@ -299,7 +298,7 @@ def native_atomic_add(context, builder, sig, args):
         ],
     )
 
-    fnty = ir.FunctionType(retty, spirv_fn_arg_types)
+    fnty = llvmir.FunctionType(retty, spirv_fn_arg_types)
     fn = cgutils.get_or_insert_function(builder.module, fnty, mangled_fn_name)
     fn.calling_convention = kernel_target.CC_SPIR_FUNC
 
@@ -516,18 +515,20 @@ def _generic_array(context, builder, shape, dtype, symbol_name, addrspace):
     """
     elemcount = reduce(operator.mul, shape)
     lldtype = context.get_data_type(dtype)
-    laryty = Type.array(lldtype, elemcount)
+    laryty = llvmir.ArrayType(lldtype, elemcount)
 
     if addrspace == address_space.LOCAL:
         lmod = builder.module
 
         # Create global variable in the requested address-space
-        gvmem = lmod.add_global_variable(laryty, symbol_name, addrspace)
+        gvmem = cgutils.add_global_variable(
+            lmod, laryty, symbol_name, addrspace
+        )
 
         if elemcount <= 0:
             raise ValueError("array length <= 0")
         else:
-            gvmem.linkage = lc.LINKAGE_INTERNAL
+            gvmem.linkage = "internal"
 
         if dtype not in types.number_domain:
             raise TypeError("unsupported type: %s" % dtype)

--- a/numba_dpex/printimpl.py
+++ b/numba_dpex/printimpl.py
@@ -4,8 +4,8 @@
 
 from functools import singledispatch
 
-import llvmlite.llvmpy.core as lc
-from numba.core import cgutils, types, typing
+import llvmlite.ir as llvmir
+from numba.core import cgutils, types
 from numba.core.imputils import Registry
 
 from numba_dpex.utils import address_space
@@ -15,8 +15,12 @@ lower = registry.lower
 
 
 def declare_print(lmod):
-    voidptrty = lc.Type.pointer(lc.Type.int(8), addrspace=address_space.GENERIC)
-    printfty = lc.Type.function(lc.Type.int(), [voidptrty], var_arg=True)
+    voidptrty = llvmir.PointerType(
+        llvmir.IntType(8), addrspace=address_space.GENERIC
+    )
+    printfty = llvmir.FunctionType(
+        llvmir.IntType(32), [voidptrty], var_arg=True
+    )
     printf = cgutils.get_or_insert_function(lmod, printfty, "printf")
     return printf
 

--- a/numba_dpex/utils/llvm_codegen_helpers.py
+++ b/numba_dpex/utils/llvm_codegen_helpers.py
@@ -2,8 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import llvmlite.ir as lir
-import llvmlite.llvmpy.core as lc
+from llvmlite import ir as llvmir
 from numba.core import cgutils, types
 
 
@@ -12,14 +11,14 @@ class LLVMTypes:
     A helper class to get LLVM Values for integer C types.
     """
 
-    byte_t = lc.Type.int(8)
-    byte_ptr_t = lc.Type.pointer(byte_t)
-    byte_ptr_ptr_t = lc.Type.pointer(byte_ptr_t)
-    int32_t = lc.Type.int(32)
-    int32_ptr_t = lc.Type.pointer(int32_t)
-    int64_t = lc.Type.int(64)
-    int64_ptr_t = lc.Type.pointer(int64_t)
-    void_t = lir.VoidType()
+    byte_t = llvmir.IntType(8)
+    byte_ptr_t = byte_t.as_pointer()
+    byte_ptr_ptr_t = byte_ptr_t.as_pointer()
+    int32_t = llvmir.IntType(32)
+    int32_ptr_t = int32_t.as_pointer()
+    int64_t = llvmir.IntType(64)
+    int64_ptr_t = int64_t.as_pointer()
+    void_t = llvmir.VoidType()
 
 
 def get_llvm_type(context, type):
@@ -46,7 +45,7 @@ def get_llvm_ptr_type(type):
     Returns: An LLVM pointer type object corresponding to the input LLVM type.
 
     """
-    return lc.Type.pointer(type)
+    return type.as_pointer()
 
 
 def create_null_ptr(builder, context):


### PR DESCRIPTION
- [X] Have you provided a meaningful PR description?
The llvmlite.llvmpy module has been deprecated and is slotted for removal with the next llvmlite release. The PR updates our source code to remove all usage of llvmlit.llvmpy and replace it with corresponding functionality from llvmlite.ir.
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
No, but all existing tests have been verified.
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
