### PR TITLE
Using cached queue instead of creating new one on type inference

### DIFF
--- a/numba_dpex/core/typeconv/array_conversion.py
+++ b/numba_dpex/core/typeconv/array_conversion.py
@@ -37,7 +37,6 @@ def to_usm_ndarray(suai_attrs, addrspace=address_space.GLOBAL):
         ndim=suai_attrs.dimensions,
         layout=layout,
         usm_type=suai_attrs.usm_type,
-        device=suai_attrs.device,
         queue=suai_attrs.queue,
         readonly=not suai_attrs.is_writable,
         name=None,

--- a/numba_dpex/core/types/usm_ndarray_type.py
+++ b/numba_dpex/core/types/usm_ndarray_type.py
@@ -59,8 +59,10 @@ class USMNdArray(Array):
                     "The device keyword arg should be a str object specifying "
                     "a SYCL filter selector"
                 )
-            self.queue = dpctl.SyclQueue(device)
-            self.device = self.queue.sycl_device.filter_string
+            self.queue = dpctl.tensor._device.normalize_queue_device(
+                device=device
+            )
+            self.device = device
         elif queue is not None and device == "unknown":
             if not isinstance(queue, dpctl.SyclQueue):
                 raise TypeError(
@@ -69,7 +71,7 @@ class USMNdArray(Array):
             self.device = self.queue.sycl_device.filter_string
             self.queue = queue
         else:
-            self.queue = dpctl.SyclQueue()
+            self.queue = dpctl.tensor._device.normalize_queue_device()
             self.device = self.queue.sycl_device.filter_string
 
         if not dtype:

--- a/numba_dpex/core/typing/typeof.py
+++ b/numba_dpex/core/typing/typeof.py
@@ -42,10 +42,7 @@ def _typeof_helper(val, array_class_type):
             "The usm_type for the usm_ndarray could not be inferred"
         )
 
-    try:
-        device = val.sycl_device
-    except AttributeError:
-        raise ValueError("The device for the usm_ndarray could not be inferred")
+    assert val.sycl_queue is not None
 
     return array_class_type(
         dtype=dtype,
@@ -53,7 +50,6 @@ def _typeof_helper(val, array_class_type):
         layout=layout,
         readonly=readonly,
         usm_type=usm_type,
-        device=device,
         queue=val.sycl_queue,
         addrspace=address_space.GLOBAL,
     )

--- a/numba_dpex/core/typing/typeof.py
+++ b/numba_dpex/core/typing/typeof.py
@@ -43,7 +43,7 @@ def _typeof_helper(val, array_class_type):
         )
 
     try:
-        device = val.sycl_device.filter_string
+        device = val.sycl_device
     except AttributeError:
         raise ValueError("The device for the usm_ndarray could not be inferred")
 


### PR DESCRIPTION
Using queue cached by `dpctl` for `USMNdArray` type.

Potentially fixes #945 