### PR TITLE
Fix issue with math.ceil() and math.floor() output

### DIFF
--- a/numba_dpex/ocl/mathdecl.py
+++ b/numba_dpex/ocl/mathdecl.py
@@ -230,10 +230,24 @@ class Math_atanh(Math_unary):
 
 class Math_floor(Math_unary):
     key = math.floor
+    cases = [
+        signature(types.intp, types.intp),
+        signature(types.int64, types.int64),
+        signature(types.uint64, types.uint64),
+        signature(types.int64, types.float32),
+        signature(types.int64, types.float64),
+    ]
 
 
 class Math_ceil(Math_unary):
     key = math.ceil
+    cases = [
+        signature(types.intp, types.intp),
+        signature(types.int64, types.int64),
+        signature(types.uint64, types.uint64),
+        signature(types.int64, types.float32),
+        signature(types.int64, types.float64),
+    ]
 
 
 class Math_trunc(Math_unary):

--- a/numba_dpex/tests/kernel_tests/test_math_functions.py
+++ b/numba_dpex/tests/kernel_tests/test_math_functions.py
@@ -5,13 +5,24 @@
 import math
 
 import dpctl
+import dpnp
 import numpy as np
 import pytest
 
 import numba_dpex as dpex
 from numba_dpex.tests._helper import filter_strings
 
-list_of_unary_ops = ["fabs", "exp", "log", "sqrt", "sin", "cos", "tan"]
+list_of_unary_ops = [
+    "fabs",
+    "exp",
+    "log",
+    "sqrt",
+    "sin",
+    "cos",
+    "tan",
+    "ceil",
+    "floor",
+]
 
 
 @pytest.fixture(params=list_of_unary_ops)
@@ -24,31 +35,44 @@ list_of_dtypes = [
     np.float64,
 ]
 
+N = 2048
+
 
 @pytest.fixture(params=list_of_dtypes)
 def input_arrays(request):
     # The size of input and out arrays to be used
-    N = 2048
     a = np.array(np.random.random(N), request.param)
     b = np.array(np.random.random(N), request.param)
-    return a, b
+    c = np.zeros(N, dtype=np.int64)
+    return a, b, c
 
 
 @pytest.mark.parametrize("filter_str", filter_strings)
 def test_binary_ops(filter_str, unary_op, input_arrays):
-    a, actual = input_arrays
+    a, actual, actual_value_types = input_arrays
+
+    if unary_op == "ceil" or unary_op == "floor":
+        a = a * 10.0
+
     uop = getattr(math, unary_op)
     np_uop = getattr(np, unary_op)
 
     @dpex.kernel
-    def f(a, b):
+    def f(a, b, c):
         i = dpex.get_global_id(0)
-        b[i] = uop(a[i])
+        k = uop(a[i])
+        if type(k) is int or type(k) is np.int32 or type(k) is np.int64:
+            c[i] = 3
+        b[i] = k
 
     device = dpctl.SyclDevice(filter_str)
     with dpctl.device_context(device):
-        f[a.size, dpex.DEFAULT_LOCAL_SIZE](a, actual)
+        f[a.size, dpex.DEFAULT_LOCAL_SIZE](a, actual, actual_value_types)
 
     expected = np_uop(a)
 
     np.testing.assert_allclose(actual, expected, rtol=1e-5, atol=0)
+
+    if unary_op == "ceil" or unary_op == "floor":
+        expected_value_types = (np.ones(N) * 3).astype(np.int64)
+        np.testing.assert_equal(actual_value_types, expected_value_types)


### PR DESCRIPTION
Addressing issue #759 

`math.ceil()`  and `math.floor()` are supposed to return `int` inside `numba_dpex.kernel`, but they are returning `float64`. This PR should fix that issue.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] If this PR is a work in progress, are you filing the PR as a draft?
