### PR TITLE
Handle the case when arraystruct->meminfo is null to close gh-965

### DIFF
--- a/numba_dpex/core/runtime/_dpexrt_python.c
+++ b/numba_dpex/core/runtime/_dpexrt_python.c
@@ -959,6 +959,13 @@ DPEXRT_sycl_usm_ndarray_to_python_acqref(arystruct_t *arystruct,
         }
         Py_DECREF(args);
     }
+    else {
+        PyErr_Format(PyExc_ValueError,
+                     "In 'DPEXRT_sycl_usm_ndarray_to_python_acqref', "
+                     "failed to create a new MemInfoObject object since "
+                     "meminfo field was null");
+        return MOD_ERROR_VAL;
+    }
 
     shape = arystruct->shape_and_strides;
 


### PR DESCRIPTION
Closes gh-965 by raising Python exception when `arraystruct->meminfo` field is null, and unhandled exception would have caused dereferencing of the null pointer and subsequent crash.


- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
