### PR TITLE
Fix typo in the keyword argumnet when constructing a tensor.

### DIFF
--- a/numba_dpex/core/types/usm_ndarray_type.py
+++ b/numba_dpex/core/types/usm_ndarray_type.py
@@ -74,7 +74,7 @@ class USMNdArray(Array):
 
         if not dtype:
             dummy_tensor = dpctl.tensor.empty(
-                sh=1, order=layout, usm_type=usm_type, sycl_queue=self.queue
+                shape=1, order=layout, usm_type=usm_type, sycl_queue=self.queue
             )
             # convert dpnp type to numba/numpy type
             _dtype = dummy_tensor.dtype

--- a/numba_dpex/tests/dpjit_tests/dpnp/test_dpnp_empty.py
+++ b/numba_dpex/tests/dpjit_tests/dpnp/test_dpnp_empty.py
@@ -47,3 +47,29 @@ def test_dpnp_empty(shape, dtype, usm_type, device):
         )
     else:
         c.sycl_device.filter_string == dpctl.SyclDevice().filter_string
+
+
+@pytest.mark.parametrize("shape", shapes)
+def test_dpnp_empty_default_dtype(shape):
+    @dpjit
+    def func1(shape):
+        c = dpnp.empty(shape=shape)
+        return c
+
+    try:
+        c = func1(shape)
+    except Exception:
+        pytest.fail("Calling dpnp.empty inside dpjit failed")
+
+    if len(c.shape) == 1:
+        assert c.shape[0] == shape
+    else:
+        assert c.shape == shape
+
+    dummy_tensor = dpctl.tensor.empty(shape=1)
+
+    assert c.dtype == dummy_tensor.dtype
+
+    dummy_tensor = dpctl.tensor.empty(shape)
+
+    assert c.dtype == dummy_tensor.dtype


### PR DESCRIPTION
- [X] Have you provided a meaningful PR description?
   - numba-dpex's usm_ndarray type relies on dpctl.tensor to determine the default dtype for an array. In the constructor for the usm_ndarray type, there was a typo that was causing an exception in dpjit when dpnp.empty or other constructor was called without a dtype.
   - Adds a unit test case.
- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
