### PR TITLE
Use kernel compiler for parfors as well.

### DIFF
--- a/numba_dpex/core/compiler.py
+++ b/numba_dpex/core/compiler.py
@@ -85,7 +85,7 @@ def compile_with_dpex(
             return_type=return_type,
             flags=flags,
             locals={},
-            pipeline_class=OffloadCompiler,
+            pipeline_class=KernelCompiler,
         )
     else:
         raise UnreachableError()


### PR DESCRIPTION
- [X] Have you provided a meaningful PR description?
The `OffloadCompiler` is deprecated and set to be removed in 0.21. Instead, we now have two separate pipelines `DpjitCompiler` and `KernelCompiler` to compile `dpjit` and `kernel` decorated functions respectively.

The PR changes the `compiler.py` implementation to use the `KernelCompiler` when compiling kernels generated as numba function IR from parfor nodes. 
- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
Existing test cases for parfor and dpjit should not break after the change.
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
