### PR TITLE
Implementation for dpnp.full_like()

### DIFF
--- a/numba_dpex/tests/dpjit_tests/dpnp/test_dpnp_full_like.py
+++ b/numba_dpex/tests/dpjit_tests/dpnp/test_dpnp_full_like.py
@@ -1,0 +1,105 @@
+# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for dpnp ndarray constructors."""
+
+import math
+
+import dpctl
+import dpctl.tensor as dpt
+import dpnp
+import numpy
+import pytest
+from numba import errors
+
+from numba_dpex import dpjit
+
+shapes = [11, (3, 7)]
+dtypes = [dpnp.int32, dpnp.int64, dpnp.float32, dpnp.float64]
+usm_types = ["device", "shared", "host"]
+devices = ["cpu", "unknown"]
+fill_values = [
+    7,
+    -7,
+    7.1,
+    -7.1,
+    math.pi,
+    math.e,
+    4294967295,
+    4294967295.0,
+    3.4028237e38,
+]
+
+
+@pytest.mark.parametrize("shape", shapes)
+@pytest.mark.parametrize("fill_value", fill_values)
+@pytest.mark.parametrize("dtype", dtypes)
+@pytest.mark.parametrize("usm_type", usm_types)
+@pytest.mark.parametrize("device", devices)
+def test_dpnp_full_like(shape, fill_value, dtype, usm_type, device):
+    @dpjit
+    def func(a, v):
+        c = dpnp.full_like(a, v, dtype=dtype, usm_type=usm_type, device=device)
+        return c
+
+    if isinstance(shape, int):
+        NZ = numpy.random.rand(shape)
+    else:
+        NZ = numpy.random.rand(*shape)
+
+    try:
+        c = func(NZ, fill_value)
+    except Exception:
+        pytest.fail("Calling dpnp.full_like inside dpjit failed")
+
+    C = numpy.full_like(NZ, fill_value, dtype=dtype)
+
+    if len(c.shape) == 1:
+        assert c.shape[0] == NZ.shape[0]
+    else:
+        assert c.shape == NZ.shape
+
+    assert c.dtype == dtype
+    assert c.usm_type == usm_type
+    if device != "unknown":
+        assert (
+            c.sycl_device.filter_string
+            == dpctl.SyclDevice(device).filter_string
+        )
+    else:
+        c.sycl_device.filter_string == dpctl.SyclDevice().filter_string
+
+    assert numpy.array_equal(dpt.asnumpy(c._array_obj), C)
+
+
+def test_dpnp_full_like_exceptions():
+    @dpjit
+    def func1(a):
+        c = dpnp.full_like(a, shape=(3, 3))
+        return c
+
+    try:
+        func1(numpy.random.rand(5, 5))
+    except Exception as e:
+        assert isinstance(e, errors.TypingError)
+        assert (
+            "No implementation of function Function(<function full_like"
+            in str(e)
+        )
+
+    queue = dpctl.SyclQueue()
+
+    @dpjit
+    def func2(a):
+        c = dpnp.full_like(a, sycl_queue=queue)
+        return c
+
+    try:
+        func2(numpy.random.rand(5, 5))
+    except Exception as e:
+        assert isinstance(e, errors.TypingError)
+        assert (
+            "No implementation of function Function(<function full_like"
+            in str(e)
+        )


### PR DESCRIPTION
Implementation for `dpnp.full_like()`.

This will enable calling `dpnp.full_like()` inside `@dpjit` functions.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?