### PR TITLE
Enable dpnp parfor reduction

### DIFF
--- a/numba_dpex/config.py
+++ b/numba_dpex/config.py
@@ -89,3 +89,6 @@ TESTING_SKIP_NO_DEBUGGING = _readenv(
     "NUMBA_DPEX_TESTING_SKIP_NO_DEBUGGING", int, 1
 )
 TESTING_LOG_DEBUGGING = _readenv("NUMBA_DPEX_TESTING_LOG_DEBUGGING", int, DEBUG)
+# Flag to turn on the ConstantSizeStaticLocalMemoryPass in the kernel pipeline.
+# The pass is turned off by default.
+STATIC_LOCAL_MEM_PASS = _readenv("NUMBA_DPEX_STATIC_LOCAL_MEM_PASS", int, 0)

--- a/numba_dpex/core/pipelines/kernel_compiler.py
+++ b/numba_dpex/core/pipelines/kernel_compiler.py
@@ -29,6 +29,7 @@ from numba.core.untyped_passes import (
     WithLifting,
 )
 
+from numba_dpex import config
 from numba_dpex.core.exceptions import UnsupportedCompilationModeError
 from numba_dpex.core.passes.passes import (
     ConstantSizeStaticLocalMemoryPass,
@@ -65,10 +66,11 @@ class _KernelPassBuilder(object):
         # Add pass to ensure when users allocate static constant memory the
         # size of the allocation is a constant and not specified by a closure
         # variable.
-        pm.add_pass(
-            ConstantSizeStaticLocalMemoryPass,
-            "dpex constant size for static local memory",
-        )
+        if config.STATIC_LOCAL_MEM_PASS:
+            pm.add_pass(
+                ConstantSizeStaticLocalMemoryPass,
+                "dpex constant size for static local memory",
+            )
 
         # --- End of dpex passes added to the untyped pipeline               --#
 

--- a/numba_dpex/core/runtime/_dpexrt_python.c
+++ b/numba_dpex/core/runtime/_dpexrt_python.c
@@ -187,6 +187,47 @@ static void DpexrtQueue_SubmitRange(const void *KRef,
         __FILE__, __LINE__));
 }
 
+static void DpexrtQueue_SubmitNDRange(const void *KRef,
+                                      const void *QRef,
+                                      void **Args,
+                                      const DPCTLKernelArgType *ArgTypes,
+                                      size_t NArgs,
+                                      const size_t gRange[3],
+                                      const size_t lRange[3],
+                                      size_t Ndims,
+                                      const void *DepEvents,
+                                      size_t NDepEvents)
+{
+    DPCTLSyclEventRef eref = NULL;
+    DPCTLSyclQueueRef qref = NULL;
+
+    DPEXRT_DEBUG(drt_debug_print(
+        "DPEXRT-DEBUG: Inside DpexrtQueue_SubmitNDRange %s, line %d\n",
+        __FILE__, __LINE__));
+
+    qref = (DPCTLSyclQueueRef)QRef;
+
+    eref = DPCTLQueue_SubmitNDRange((DPCTLSyclKernelRef)KRef, qref, Args,
+                                    (DPCTLKernelArgType *)ArgTypes, NArgs,
+                                    gRange, lRange, Ndims,
+                                    (DPCTLSyclEventRef *)DepEvents, NDepEvents);
+    if (eref == NULL) {
+        DPEXRT_DEBUG(
+            drt_debug_print("DPEXRT-ERROR: Kernel submission using "
+                            "DpexrtQueue_SubmitNDRange failed! %s, line %d\n",
+                            __FILE__, __LINE__));
+    }
+    else {
+        DPCTLQueue_Wait(qref);
+        DPCTLEvent_Wait(eref);
+        DPCTLEvent_Delete(eref);
+    }
+
+    DPEXRT_DEBUG(drt_debug_print(
+        "DPEXRT-DEBUG: Done with DpexrtQueue_SubmitNDRange %s, line %d\n",
+        __FILE__, __LINE__));
+}
+
 /*----------------------------------------------------------------------------*/
 /*---------------------- Functions for NRT_MemInfo allocation ----------------*/
 /*----------------------------------------------------------------------------*/
@@ -1246,6 +1287,7 @@ static PyObject *build_c_helpers_dict(void)
     _declpointer("DPEXRTQueue_CreateFromFilterString",
                  &DPEXRTQueue_CreateFromFilterString);
     _declpointer("DpexrtQueue_SubmitRange", &DpexrtQueue_SubmitRange);
+    _declpointer("DpexrtQueue_SubmitNDRange", &DpexrtQueue_SubmitNDRange);
     _declpointer("DPEXRT_MemInfo_alloc", &DPEXRT_MemInfo_alloc);
     _declpointer("DPEXRT_MemInfo_fill", &DPEXRT_MemInfo_fill);
     _declpointer("NRT_ExternalAllocator_new_for_usm",
@@ -1309,6 +1351,8 @@ MOD_INIT(_dpexrt_python)
                        PyLong_FromVoidPtr(&DPEXRTQueue_CreateFromFilterString));
     PyModule_AddObject(m, "DpexrtQueue_SubmitRange",
                        PyLong_FromVoidPtr(&DpexrtQueue_SubmitRange));
+    PyModule_AddObject(m, "DpexrtQueue_SubmitNDRange",
+                       PyLong_FromVoidPtr(&DpexrtQueue_SubmitNDRange));
     PyModule_AddObject(m, "DPEXRT_MemInfo_alloc",
                        PyLong_FromVoidPtr(&DPEXRT_MemInfo_alloc));
     PyModule_AddObject(m, "DPEXRT_MemInfo_fill",

--- a/numba_dpex/core/runtime/context.py
+++ b/numba_dpex/core/runtime/context.py
@@ -258,11 +258,7 @@ class DpexRTContext(object):
         """Calls DPEXRTQueue_CreateFromFilterString to create a new sycl::queue
         from a given filter string.
 
-        Args:
-            device (llvmlite.ir.values.FormattedConstant): An LLVM ArrayType
-                storing a const string for a DPC++ filter selector string.
-
-        Returns: A DPCTLSyclQueueRef pointer.
+        Returns: A LLVM IR call inst.
         """
         mod = builder.module
         fnty = llvmir.FunctionType(
@@ -293,6 +289,64 @@ class DpexRTContext(object):
                 nargs,
                 range,
                 nrange,
+                depevents,
+                ndepevents,
+            ],
+        )
+
+        return ret
+
+    def submit_ndrange(
+        self,
+        builder,
+        kref,
+        qref,
+        args,
+        argtys,
+        nargs,
+        grange,
+        lrange,
+        ndims,
+        depevents,
+        ndepevents,
+    ):
+        """Calls DPEXRTQueue_CreateFromFilterString to create a new sycl::queue
+        from a given filter string.
+
+        Returns: A LLVM IR call inst.
+        """
+
+        mod = builder.module
+        fnty = llvmir.FunctionType(
+            llvmir.types.VoidType(),
+            [
+                cgutils.voidptr_t,
+                cgutils.voidptr_t,
+                cgutils.voidptr_t.as_pointer(),
+                cgutils.int32_t.as_pointer(),
+                llvmir.IntType(64),
+                llvmir.IntType(64).as_pointer(),
+                llvmir.IntType(64).as_pointer(),
+                llvmir.IntType(64),
+                cgutils.voidptr_t,
+                llvmir.IntType(64),
+            ],
+        )
+        fn = cgutils.get_or_insert_function(
+            mod, fnty, "DpexrtQueue_SubmitNDRange"
+        )
+
+        ret = builder.call(
+            fn,
+            [
+                kref,
+                qref,
+                args,
+                argtys,
+                nargs,
+                grange,
+                lrange,
+                ndims,
                 depevents,
                 ndepevents,
             ],

--- a/numba_dpex/core/utils/kernel_launcher.py
+++ b/numba_dpex/core/utils/kernel_launcher.py
@@ -311,7 +311,6 @@ class KernelLaunchIRBuilder:
 
         Args:
             idx_range (_type_): _description_
-            kernel_name_tag (_type_): _description_
         """
         intp_t = utils.get_llvm_type(context=self.context, type=types.intp)
         intp_ptr_t = utils.get_llvm_ptr_type(intp_t)
@@ -341,27 +340,20 @@ class KernelLaunchIRBuilder:
 
         return self.builder.bitcast(global_range, intp_ptr_t)
 
-    def submit_sync_ranged_kernel(
+    def submit_sync_kernel(
         self,
-        idx_range,
         sycl_queue_val,
         total_kernel_args,
         arg_list,
         arg_ty_list,
+        global_range,
+        local_range=None,
     ):
         """
-        submit_sync_ranged_kernel(dim_bounds, sycl_queue_val)
-        Submits the kernel to the specified queue, waits and then copies
-        back any results to the host.
-
-        Args:
-            idx_range: Tuple specifying the range over which the kernel is
-            to be submitted.
-            sycl_queue_val : The SYCL queue on which the kernel is
-                             submitted.
+        Submits the kernel to the specified queue, waits.
         """
-        gr = self._create_sycl_range(idx_range)
-        args = [
+        gr = self._create_sycl_range(global_range)
+        args1 = [
             self.builder.inttoptr(
                 self.context.get_constant(types.uintp, self.kernel_addr),
                 utils.get_llvm_type(context=self.context, type=types.voidptr),
@@ -371,7 +363,9 @@ class KernelLaunchIRBuilder:
             arg_ty_list,
             self.context.get_constant(types.uintp, total_kernel_args),
             gr,
-            self.context.get_constant(types.uintp, len(idx_range)),
+        ]
+        args2 = [
+            self.context.get_constant(types.uintp, len(global_range)),
             self.builder.bitcast(
                 utils.create_null_ptr(
                     builder=self.builder, context=self.context
@@ -380,5 +374,11 @@ class KernelLaunchIRBuilder:
             ),
             self.context.get_constant(types.uintp, 0),
         ]
-
-        self.rtctx.submit_range(self.builder, *args)
+        args = []
+        if len(local_range) == 0:
+            args = args1 + args2
+            self.rtctx.submit_range(self.builder, *args)
+        else:
+            lr = self._create_sycl_range(local_range)
+            args = args1 + [lr] + args2
+            self.rtctx.submit_ndrange(self.builder, *args)

--- a/numba_dpex/core/utils/kernel_templates/kernel_template_iface.py
+++ b/numba_dpex/core/utils/kernel_templates/kernel_template_iface.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import abc
+
+
+class KernelTemplateInterface(metaclass=abc.ABCMeta):
+    @classmethod
+    def __subclasshook__(cls, subclass):
+        return hasattr(
+            callable(subclass._generate_kernel_stub_as_string)
+            and callable(subclass._generate_kernel_ir)
+            and callable(subclass.dump_kernel_string)
+            and callable(subclass.dump_kernel_ir)
+            and hasattr(subclass, "kernel_ir")
+            and hasattr(subclass, "kernel_string")
+        )
+
+    @abc.abstractmethod
+    def _generate_kernel_stub_as_string(self):
+        """Generates as a string a stub for a numba_dpex kernel function"""
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def _generate_kernel_ir(self):
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def dump_kernel_string(self):
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def dump_kernel_ir(self):
+        raise NotImplementedError
+
+    @property
+    @abc.abstractmethod
+    def kernel_ir(self):
+        raise NotImplementedError
+
+    @property
+    @abc.abstractmethod
+    def kernel_string(self):
+        raise NotImplementedError

--- a/numba_dpex/core/utils/kernel_templates/reduction_template.py
+++ b/numba_dpex/core/utils/kernel_templates/reduction_template.py
@@ -1,0 +1,363 @@
+# SPDX-FileCopyrightText: 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import operator
+import sys
+
+import dpnp
+from numba.core import compiler
+
+import numba_dpex as dpex
+
+from .kernel_template_iface import KernelTemplateInterface
+
+
+class TreeReduceIntermediateKernelTemplate(KernelTemplateInterface):
+    """The class to build reduction main kernel_txt template and
+    compiled Numba functionIR."""
+
+    def __init__(
+        self,
+        kernel_name,
+        kernel_params,
+        ivar_names,
+        sentinel_name,
+        loop_ranges,
+        param_dict,
+        parfor_dim,
+        redvars,
+        parfor_args,
+        parfor_reddict,
+        redvars_dict,
+        typemap,
+        work_group_size,
+    ) -> None:
+        self._kernel_name = kernel_name
+        self._kernel_params = kernel_params
+        self._ivar_names = ivar_names
+        self._sentinel_name = sentinel_name
+        self._loop_ranges = loop_ranges
+        self._param_dict = param_dict
+        self._parfor_dim = parfor_dim
+        self._redvars = redvars
+        self._parfor_args = parfor_args
+        self._parfor_reddict = parfor_reddict
+        self._redvars_dict = redvars_dict
+        self._typemap = typemap
+        self._work_group_size = work_group_size
+
+        self._kernel_txt = self._generate_kernel_stub_as_string()
+        self._kernel_ir = self._generate_kernel_ir()
+
+    def _generate_kernel_stub_as_string(self):
+        """Generate reduction main kernel template"""
+
+        gufunc_txt = ""
+        gufunc_txt += "def " + self._kernel_name
+        gufunc_txt += "(" + (", ".join(self._kernel_params)) + "):\n"
+        global_id_dim = 0
+        for_loop_dim = self._parfor_dim
+
+        if self._parfor_dim > 3:
+            raise NotImplementedError
+        else:
+            global_id_dim = self._parfor_dim
+
+        for dim in range(global_id_dim):
+            dstr = str(dim)
+            gufunc_txt += (
+                f"    {self._ivar_names[dim]} = dpex.get_global_id({dstr})\n"
+            )
+            gufunc_txt += f"    local_id{dim} = dpex.get_local_id({dstr})\n"
+            gufunc_txt += f"    local_size{dim} = dpex.get_local_size({dstr})\n"
+            gufunc_txt += f"    group_id{dim} = dpex.get_group_id({dstr})\n"
+
+        # Allocate local_sums arrays for each reduction variable.
+        for redvar in self._redvars:
+            rtyp = str(self._typemap[redvar])
+            redvar = self._redvars_dict[redvar]
+            gufunc_txt += f"    local_sums_{redvar} = \
+                dpex.local.array({self._work_group_size}, dpnp.{rtyp})\n"
+
+        for dim in range(global_id_dim, for_loop_dim):
+            for indent in range(1 + (dim - global_id_dim)):
+                gufunc_txt += "    "
+
+            start, stop, step = self._loop_ranges[dim]
+            st = str(self._param_dict.get(str(start), start))
+            en = str(self._param_dict.get(str(stop), stop))
+            gufunc_txt += (
+                f"for {self._ivar_names[dim]} in range({st}, {en} + 1):\n"
+            )
+
+        for dim in range(global_id_dim, for_loop_dim):
+            for indent in range(1 + (dim - global_id_dim)):
+                gufunc_txt += "    "
+        # Add the sentinel assignment so that we can find the loop body position
+        # in the IR.
+        for redvar in self._redvars:
+            legal_redvar = self._redvars_dict[redvar]
+            gufunc_txt += "    "
+            gufunc_txt += legal_redvar + " = 0\n"
+        gufunc_txt += "    "
+        gufunc_txt += self._sentinel_name + " = 0\n"
+
+        # Generate local_sum[local_id0] = redvar, for each reduction variable
+        for redvar in self._redvars:
+            legal_redvar = self._redvars_dict[redvar]
+            gufunc_txt += (
+                "    "
+                + f"local_sums_{legal_redvar}[local_id0] = {legal_redvar}\n"
+            )
+
+        gufunc_txt += (
+            "    stride0 = local_size0 // 2\n"
+            + "    while stride0 > 0:\n"
+            + "        dpex.barrier(dpex.LOCAL_MEM_FENCE)\n"
+            + "        if local_id0 < stride0:\n"
+        )
+
+        for redvar in self._redvars:
+            redop = self._parfor_reddict[redvar].redop
+            redvar_legal = self._redvars_dict[redvar]
+            if redop == operator.iadd:
+                gufunc_txt += (
+                    "            "
+                    f"local_sums_{redvar_legal}[local_id0] "
+                    f"+= local_sums_{redvar_legal}[local_id0 + stride0]\n"
+                )
+            elif redop == operator.imul:
+                gufunc_txt += (
+                    "            "
+                    f"local_sums_{redvar_legal}[local_id0] "
+                    f"*= local_sums_{redvar_legal}[local_id0 + stride0]\n"
+                )
+            else:
+                raise NotImplementedError
+
+        gufunc_txt += "        stride0 >>= 1\n"
+        gufunc_txt += "    if local_id0 == 0:\n"
+        for redvar in self._redvars:
+            for i, arg in enumerate(self._parfor_args):
+                if arg == redvar:
+                    partial_sum_var = self._kernel_params[i]
+                    redvar_legal = self._redvars_dict[redvar]
+                    gufunc_txt += (
+                        "        "
+                        f"{partial_sum_var}[group_id0] = "
+                        f"local_sums_{redvar_legal}[0]\n"
+                    )
+
+        gufunc_txt += "    return None\n"
+
+        return gufunc_txt
+
+    def _generate_kernel_ir(self):
+        """Exec the kernel_txt string into a Python function object and then
+        compile it using Numba's compiler front end.
+
+        Returns: The Numba functionIR object for the compiled kernel_txt string.
+
+        """
+        globls = {"dpnp": dpnp, "dpex": dpex}
+        locls = {}
+        exec(self._kernel_txt, globls, locls)
+        kernel_fn = locls[self._kernel_name]
+
+        return compiler.run_frontend(kernel_fn)
+
+    @property
+    def kernel_ir(self):
+        """Returns the Numba IR generated for a
+            TreeReduceIntermediateKernelTemplate.
+
+        Returns: The Numba functionIR object for the compiled kernel_txt string.
+        """
+        return self._kernel_ir
+
+    @property
+    def kernel_string(self):
+        """Returns the function string generated for a
+            TreeReduceIntermediateKernelTemplate.
+
+        Returns:
+            str: A string representing a stub reduction kernel function
+            for the parfor.
+        """
+        return self._kernel_txt
+
+    def dump_kernel_string(self):
+        """Helper to print the kernel function string."""
+        print(self._kernel_txt)
+        sys.stdout.flush()
+
+    def dump_kernel_ir(self):
+        """Helper to dump the Numba IR for a
+        TreeReduceIntermediateKernelTemplate."""
+        self._kernel_ir.dump()
+
+
+class RemainderReduceIntermediateKernelTemplate(KernelTemplateInterface):
+    """The class to build reduction remainder kernel_txt template and
+    compiled Numba functionIR.
+    """
+
+    def __init__(
+        self,
+        kernel_name,
+        kernel_params,
+        sentinel_name,
+        redvars,
+        parfor_reddict,
+        redvars_dict,
+        typemap,
+        legal_loop_indices,
+        global_size_var_name,
+        global_size_mod_var_name,
+        partial_sum_size_var_name,
+        partial_sum_var_name,
+        final_sum_var_name,
+        reductionKernelVar,
+    ) -> None:
+        self._kernel_name = kernel_name
+        self._kernel_params = kernel_params
+        self._sentinel_name = sentinel_name
+        self._redvars = redvars
+        self._parfor_reddict = parfor_reddict
+        self._redvars_dict = redvars_dict
+        self._typemap = typemap
+        self._legal_loop_indices = legal_loop_indices
+        self._global_size_var_name = global_size_var_name
+        self._global_size_mod_var_name = global_size_mod_var_name
+        self._partial_sum_size_var_name = partial_sum_size_var_name
+        self._partial_sum_var_name = partial_sum_var_name
+        self._final_sum_var_name = final_sum_var_name
+        self._reductionKernelVar = reductionKernelVar
+
+        self._kernel_txt = self._generate_kernel_stub_as_string()
+        self._kernel_ir = self._generate_kernel_ir()
+
+    def _generate_kernel_stub_as_string(self):
+        """Generate reduction remainder kernel template"""
+
+        gufunc_txt = ""
+        gufunc_txt += "def " + self._kernel_name
+        gufunc_txt += "(" + (", ".join(self._kernel_params))
+
+        for i in range(len(self._redvars)):
+            gufunc_txt += (
+                ", "
+                + f"{self._global_size_var_name[i]}, "
+                + f"{self._global_size_mod_var_name[i]}, "
+            )
+            gufunc_txt += (
+                f"{self._partial_sum_size_var_name[i]}, "
+                + f"{self._final_sum_var_name[i]}"
+            )
+
+        gufunc_txt += "):\n"
+
+        gufunc_txt += "    "
+
+        gufunc_txt += (
+            "for j" + f" in range({self._partial_sum_size_var_name[0]}):\n"
+        )
+
+        for i, redvar in enumerate(self._redvars):
+            gufunc_txt += f"        {self._final_sum_var_name[i]}[0] += \
+                {self._partial_sum_var_name[i]}[j]\n"
+
+        gufunc_txt += (
+            f"    for j in range ({self._global_size_mod_var_name[0]}) :\n"
+        )
+
+        for redvar in self._redvars:
+            legal_redvar = self._redvars_dict[redvar]
+            gufunc_txt += "        "
+            gufunc_txt += legal_redvar + " = 0\n"
+
+        gufunc_txt += (
+            "        "
+            + self._legal_loop_indices[0]
+            + " = "
+            + f"{self._global_size_var_name[0]} + j\n"
+        )
+
+        for redvar in self._redvars:
+            rtyp = str(self._typemap[redvar])
+            redvar = self._redvars_dict[redvar]
+            gufunc_txt += (
+                "        "
+                + f"local_sums_{redvar} = "
+                + f"dpex.local.array(1, dpnp.{rtyp})\n"
+            )
+
+        gufunc_txt += "        " + self._sentinel_name + " = 0\n"
+
+        for i, redvar in enumerate(self._redvars):
+            legal_redvar = self._redvars_dict[redvar]
+            gufunc_txt += (
+                "        " + f"local_sums_{legal_redvar}[0] = {legal_redvar}\n"
+            )
+
+        for i, redvar in enumerate(self._redvars):
+            legal_redvar = self._redvars_dict[redvar]
+            redop = self._parfor_reddict[redvar].redop
+            if redop == operator.iadd:
+                gufunc_txt += f"        {self._final_sum_var_name[i]}[0] +=  \
+                    local_sums_{legal_redvar}[0]\n"
+            elif redop == operator.imul:
+                gufunc_txt += f"        {self._final_sum_var_name[i]}[0] *=  \
+                    local_sums_{legal_redvar}[0]\n"
+            else:
+                raise NotImplementedError
+
+        return gufunc_txt
+
+    def _generate_kernel_ir(self):
+        """Exec the kernel_txt string into a Python function object and then
+        compile it using Numba's compiler front end.
+
+        Returns: The Numba functionIR object for the compiled kernel_txt string.
+
+        """
+
+        globls = {"dpnp": dpnp, "dpex": dpex}
+        locls = {}
+        exec(self._kernel_txt, globls, locls)
+        kernel_fn = locls[self._kernel_name]
+
+        return compiler.run_frontend(kernel_fn)
+
+    @property
+    def kernel_ir(self):
+        """Returns the Numba IR generated for a
+            RemainderReduceIntermediateKernelTemplate.
+
+        Returns: The Numba functionIR object for the compiled kernel_txt string.
+        """
+        return self._kernel_ir
+
+    @property
+    def kernel_string(self):
+        """Returns the function string generated for a
+            RemainderReduceIntermediateKernelTemplate.
+
+        Returns:
+            str: A string representing a stub reduction kernel function
+            for the parfor.
+        """
+        return self._kernel_txt
+
+    def dump_kernel_string(self):
+        """Helper to print the kernel function string."""
+
+        print(self._kernel_txt)
+        sys.stdout.flush()
+
+    def dump_kernel_ir(self):
+        """Helper to dump the Numba IR for the
+        RemainderReduceIntermediateKernelTemplate."""
+
+        self._kernel_ir.dump()

--- a/numba_dpex/core/utils/reduction_helper.py
+++ b/numba_dpex/core/utils/reduction_helper.py
@@ -1,0 +1,457 @@
+# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+import copy
+import operator
+
+import dpnp
+import numba
+from numba.core import ir, types
+from numba.core.ir_utils import (
+    get_np_ufunc_typ,
+    legalize_names,
+    remove_dels,
+    replace_var_names,
+)
+from numba.parfors.parfor_lowering_utils import ParforLoweringBuilder
+
+from numba_dpex import utils
+from numba_dpex.core.utils.kernel_launcher import KernelLaunchIRBuilder
+from numba_dpex.dpctl_iface import DpctlCAPIFnBuilder
+
+from ..passes import parfor
+from ..types.dpnp_ndarray_type import DpnpNdArray
+
+
+class ReductionHelper:
+    """The class to define and allocate reduction intermediate variables."""
+
+    def _allocate_partial_reduction_arrays(
+        self,
+        parfor,
+        lowerer,
+        red_name,
+        inputArrayType,
+    ):
+        # reduction arrays outer dimension equal to thread count
+        scope = parfor.init_block.scope
+        loc = parfor.init_block.loc
+        pfbdr = ParforLoweringBuilder(lowerer=lowerer, scope=scope, loc=loc)
+
+        # Get the type of the reduction variable.
+        redvar_typ = lowerer.fndesc.typemap[red_name]
+
+        # redarrvar_typ is type(partial_sum)
+        redarrvar_typ = self._redtyp_to_redarraytype(redvar_typ, inputArrayType)
+        reddtype = redarrvar_typ.dtype
+        redarrdim = redarrvar_typ.ndim
+
+        # allocate partial sum
+        work_group_size = 8
+        # writing work_group_size inot IR
+        work_group_size_var = pfbdr.assign(
+            rhs=ir.Const(work_group_size, loc),
+            typ=types.literal(work_group_size),
+            name="work_group_size",
+        )
+
+        # get total_work from parfor loop range
+        # FIXME: right way is to use (stop - start) if start != 0
+        total_work_var = pfbdr.assign(
+            rhs=parfor.loop_nests[0].stop,
+            typ=types.intp,
+            name="tot_work",
+        )
+
+        # global_size_mod = tot_work%work_group_size
+        ir_expr = ir.Expr.binop(
+            operator.mod, total_work_var, work_group_size_var, loc
+        )
+        pfbdr._calltypes[ir_expr] = numba.core.typing.signature(
+            types.intp, types.intp, types.intp
+        )
+        self.global_size_mod_var = pfbdr.assign(
+            rhs=ir_expr, typ=types.intp, name="global_size_mod"
+        )
+
+        # Calculates global_size_var as total_work - global_size_mod
+        ir_expr = ir.Expr.binop(
+            operator.sub, total_work_var, self.global_size_mod_var, loc
+        )
+        pfbdr._calltypes[ir_expr] = numba.core.typing.signature(
+            types.intp, types.intp, types.intp
+        )
+        self.global_size_var = pfbdr.assign(
+            rhs=ir_expr, typ=types.intp, name="global_size"
+        )
+
+        # Calculates partial_sum_size_var as
+        # global_size_var_assign // work_group_size_var_assign
+        ir_expr = ir.Expr.binop(
+            operator.floordiv,
+            self.global_size_var,
+            work_group_size_var,
+            loc,
+        )
+        pfbdr._calltypes[ir_expr] = numba.core.typing.signature(
+            types.intp, types.intp, types.intp
+        )
+        self.partial_sum_size_var = pfbdr.assign(
+            rhs=ir_expr, typ=types.intp, name="partial_sum_size"
+        )
+        # Dpnp object
+        fillFunc = None
+        parfor_reddict = parfor.reddict
+        redop = parfor_reddict[red_name].redop
+
+        if redop == operator.iadd:
+            fillFunc = dpnp.zeros
+        elif redop == operator.imul:
+            fillFunc = dpnp.ones
+        else:
+            raise NotImplementedError
+
+        kws = {
+            "shape": types.UniTuple(types.intp, redarrdim),
+            "dtype": types.DType(reddtype),
+            "order": types.literal(inputArrayType.layout),
+            "device": types.literal(inputArrayType.device),
+            "usm_type": types.literal(inputArrayType.usm_type),
+        }
+        glbl_np_empty = pfbdr.bind_global_function(
+            fobj=fillFunc,
+            ftype=get_np_ufunc_typ(fillFunc),
+            args=[],
+            kws=kws,
+        )
+
+        sizeVar = pfbdr.make_tuple_variable(
+            [self.partial_sum_size_var], name="tuple_sizeVar"
+        )
+        cval = pfbdr._typingctx.resolve_value_type(reddtype)
+        dt = pfbdr.make_const_variable(cval=cval, typ=types.DType(reddtype))
+
+        orderTyVar = pfbdr.make_const_variable(
+            cval=inputArrayType.layout, typ=types.literal(inputArrayType.layout)
+        )
+
+        deviceVar = pfbdr.make_const_variable(
+            cval=inputArrayType.device,
+            typ=types.literal(inputArrayType.device),
+        )
+        usmTyVar = pfbdr.make_const_variable(
+            cval=inputArrayType.usm_type,
+            typ=types.literal(inputArrayType.usm_type),
+        )
+        empty_call = pfbdr.call(
+            glbl_np_empty, args=[sizeVar, dt, orderTyVar, deviceVar, usmTyVar]
+        )
+
+        self.partial_sum_var = pfbdr.assign(
+            rhs=empty_call,
+            typ=redarrvar_typ,
+            name="partial_sum",
+        )
+
+        # final sum with size of 1
+        final_sum_size = 1
+        # writing work_group_size into IR
+        final_sum_size_var = pfbdr.assign(
+            rhs=ir.Const(final_sum_size, loc),
+            typ=types.literal(final_sum_size),
+            name="final_sum_size",
+        )
+        sizeVar = pfbdr.make_tuple_variable(
+            [final_sum_size_var], name="tuple_sizeVar"
+        )
+
+        empty_call = pfbdr.call(
+            glbl_np_empty, args=[sizeVar, dt, orderTyVar, deviceVar, usmTyVar]
+        )
+        self.final_sum_var = pfbdr.assign(
+            rhs=empty_call,
+            typ=redarrvar_typ,
+            name="final_sum",
+        )
+        self.work_group_size = work_group_size
+        self.redvars_to_redarrs_dict = {}
+        self.redvars_to_redarrs_dict[red_name] = []
+        self.redvars_to_redarrs_dict[red_name].append(self.partial_sum_var.name)
+        self.redvars_to_redarrs_dict[red_name].append(self.final_sum_var.name)
+
+    def _redtyp_to_redarraytype(self, redtyp, inputArrayType):
+        """Go from a reduction variable type to a reduction array type
+        used to hold per-worker results.
+        """
+        redarrdim = 1
+        # If the reduction type is an array then allocate reduction array with
+        # ndim+1 dimensions.
+        if isinstance(redtyp, DpnpNdArray):
+            redarrdim += redtyp.ndim
+            # We don't create array of array but multi-dimensional reduction
+            # array with same dtype.
+            redtyp = redtyp.dtype
+            red_layout = redtyp.layout
+            red_usm_type = redtyp.usm_type
+            red_device = redtyp.device
+        else:
+            redtyp = inputArrayType.dtype
+            red_layout = inputArrayType.layout
+            red_usm_type = inputArrayType.usm_type
+            red_device = inputArrayType.device
+        # For scalar, figure out from RHS what the array type is going to be
+        # for partial sums
+        # return type is the type for partial sum
+
+        return DpnpNdArray(
+            ndim=redarrdim,
+            dtype=redtyp,
+            layout=red_layout,
+            usm_type=red_usm_type,
+            device=red_device,
+        )
+
+
+class ReductionKernelVariables:
+    """
+    The parfor body and the main function body share ir.Var nodes.
+    We have to do some replacements of Var names in the parfor body
+    to make them legal parameter names. If we don't copy then the
+    Vars in the main function also would incorrectly change their name.
+    """
+
+    def __init__(
+        self,
+        lowerer,
+        parfor_node,
+        typemap,
+        parfor_outputs,
+        reductionHelperList,
+    ):
+        races = parfor_node.races
+        loop_body = copy.copy(parfor_node.loop_body)
+        remove_dels(loop_body)
+
+        # parfor_dim = len(parfor_node.loop_nests)
+        loop_indices = [
+            loop_nest.index_variable.name
+            for loop_nest in parfor_node.loop_nests
+        ]
+
+        # Get all the parfor params.
+        parfor_params = parfor_node.params
+
+        # Get all parfor reduction vars, and operators.
+        typemap = lowerer.fndesc.typemap
+
+        parfor_redvars, parfor_reddict = parfor.get_parfor_reductions(
+            lowerer.func_ir,
+            parfor_node,
+            parfor_params,
+            lowerer.fndesc.calltypes,
+        )
+        # Compute just the parfor inputs as a set difference.
+        parfor_inputs = sorted(list(set(parfor_params) - set(parfor_outputs)))
+        from .kernel_builder import _replace_var_with_array
+
+        _replace_var_with_array(
+            races, loop_body, typemap, lowerer.fndesc.calltypes
+        )
+
+        # Reorder all the params so that inputs go first then outputs.
+        parfor_params = parfor_inputs + parfor_outputs
+
+        # Some Var and loop_indices may not have legal parameter names so create
+        # a dict of potentially illegal param name to guaranteed legal name.
+        param_dict = {}
+        ind_dict = {}
+
+        from .kernel_builder import _legalize_names_with_typemap
+
+        param_dict = _legalize_names_with_typemap(parfor_params, typemap)
+        ind_dict = _legalize_names_with_typemap(loop_indices, typemap)
+        self._parfor_reddict = parfor_reddict
+        self._parfor_redvars = parfor_redvars
+        self._redvars_legal_dict = legalize_names(parfor_redvars)
+        # Compute a new list of legal loop index names.
+        legal_loop_indices = [ind_dict[v] for v in loop_indices]
+
+        tmp1 = []
+        self._final_sum_names = []
+        self._parfor_redvars_to_redarrs = {}
+        for ele1 in reductionHelperList:
+            for key in ele1.redvars_to_redarrs_dict.keys():
+                self._parfor_redvars_to_redarrs[
+                    key
+                ] = ele1.redvars_to_redarrs_dict[key]
+                tmp1.append(ele1.redvars_to_redarrs_dict[key][0])
+                tmp1.append(ele1.redvars_to_redarrs_dict[key][1])
+            self._final_sum_names.append(ele1.final_sum_var.name)
+
+        self._parfor_redarrs_legal_dict = {}
+        self._parfor_redarrs_legal_dict = legalize_names(tmp1)
+
+        # Get the types of each parameter.
+        from .kernel_builder import _to_scalar_from_0d
+
+        param_types = [_to_scalar_from_0d(typemap[v]) for v in parfor_params]
+
+        # Calculate types of args passed to gufunc.
+        func_arg_types = [typemap[v] for v in (parfor_inputs + parfor_outputs)]
+
+        # Replace illegal parameter names in the loop body with legal ones.
+        replace_var_names(loop_body, param_dict)
+
+        # remember the name before legalizing as the actual arguments
+        self.parfor_params = parfor_params
+        # Change parfor_params to be legal names.
+        parfor_params = [param_dict[v] for v in parfor_params]
+
+        parfor_params_orig = parfor_params
+
+        parfor_params = []
+        ascontig = False
+        for pindex in range(len(parfor_params_orig)):
+            if (
+                ascontig
+                and pindex < len(parfor_inputs)
+                and isinstance(param_types[pindex], types.npytypes.Array)
+            ):
+                parfor_params.append(parfor_params_orig[pindex] + "param")
+            else:
+                parfor_params.append(parfor_params_orig[pindex])
+
+        # Change parfor body to replace illegal loop index vars with legal ones.
+        replace_var_names(loop_body, ind_dict)
+        self._legal_loop_indices = legal_loop_indices
+        self._loop_body = loop_body
+        self._func_arg_types = func_arg_types
+        self._ind_dict = ind_dict
+        self._param_dict = param_dict
+        self._parfor_legalized_params = parfor_params
+        self._param_types = param_types
+        self._lowerer = lowerer
+        self._work_group_size = reductionHelperList[0].work_group_size
+
+    @property
+    def parfor_reddict(self):
+        return self._parfor_reddict
+
+    @property
+    def parfor_redvars(self):
+        return self._parfor_redvars
+
+    @property
+    def redvars_legal_dict(self):
+        return self._redvars_legal_dict
+
+    @property
+    def final_sum_names(self):
+        return self._final_sum_names
+
+    @property
+    def parfor_redarrs_legal_dict(self):
+        return self._parfor_redarrs_legal_dict
+
+    @property
+    def parfor_redvars_to_redarrs(self):
+        return self._parfor_redvars_to_redarrs
+
+    @property
+    def legal_loop_indices(self):
+        return self._legal_loop_indices
+
+    @property
+    def loop_body(self):
+        return copy.deepcopy(self._loop_body)
+
+    @property
+    def func_arg_types(self):
+        return self._func_arg_types
+
+    @property
+    def ind_dict(self):
+        return self._ind_dict
+
+    @property
+    def param_dict(self):
+        return self._param_dict
+
+    @property
+    def parfor_legalized_params(self):
+        return self._parfor_legalized_params
+
+    @property
+    def param_types(self):
+        return self._param_types
+
+    @property
+    def lowerer(self):
+        return self._lowerer
+
+    @property
+    def work_group_size(self):
+        return self._work_group_size
+
+    def copy_final_sum_to_host(self, psrfor_kernel):
+        lowerer = self.lowerer
+        ir_builder = KernelLaunchIRBuilder(lowerer, psrfor_kernel.kernel)
+
+        # Create a local variable storing a pointer to a DPCTLSyclQueueRef
+        # pointer.
+        curr_queue = ir_builder.get_queue(exec_queue=psrfor_kernel.queue)
+
+        builder = lowerer.builder
+        context = lowerer.context
+
+        memcpy_fn = DpctlCAPIFnBuilder.get_dpctl_queue_memcpy(
+            builder=builder, context=context
+        )
+        event_del_fn = DpctlCAPIFnBuilder.get_dpctl_event_delete(
+            builder=builder, context=context
+        )
+        event_wait_fn = DpctlCAPIFnBuilder.get_dpctl_event_wait(
+            builder=builder, context=context
+        )
+
+        for i, redvar in enumerate(self.parfor_redvars):
+            srcVar = self.final_sum_names[i]
+
+            item_size = builder.gep(
+                lowerer.getvar(srcVar),
+                [
+                    context.get_constant(types.int32, 0),
+                    context.get_constant(types.int32, 3),  # itmesize
+                ],
+            )
+
+            array_attr = builder.gep(
+                lowerer.getvar(srcVar),
+                [
+                    context.get_constant(types.int32, 0),
+                    context.get_constant(types.int32, 4),  # data
+                ],
+            )
+
+            dest = builder.bitcast(
+                lowerer.getvar(redvar),
+                utils.get_llvm_type(context=context, type=types.voidptr),
+            )
+            src = builder.bitcast(
+                builder.load(array_attr),
+                utils.get_llvm_type(context=context, type=types.voidptr),
+            )
+
+            args = [
+                builder.load(curr_queue),
+                dest,
+                src,
+                builder.load(item_size),
+            ]
+
+            event_ref = builder.call(memcpy_fn, args)
+
+            builder.call(event_wait_fn, [event_ref])
+            builder.call(event_del_fn, [event_ref])
+
+        ir_builder.free_queue(sycl_queue_val=curr_queue)

--- a/numba_dpex/core/utils/reduction_kernel_builder.py
+++ b/numba_dpex/core/utils/reduction_kernel_builder.py
@@ -1,0 +1,357 @@
+# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import warnings
+
+from numba.core import types
+from numba.core.errors import NumbaParallelSafetyWarning
+from numba.core.ir_utils import (
+    add_offset_to_labels,
+    get_name_var_table,
+    get_unused_var_name,
+    legalize_names,
+    mk_unique_var,
+    remove_dels,
+    rename_labels,
+    replace_var_names,
+)
+from numba.core.typing import signature
+
+from .kernel_builder import _print_body  # saved for debug
+from .kernel_builder import (
+    ParforKernel,
+    _compile_kernel_parfor,
+    _to_scalar_from_0d,
+    update_sentinel,
+)
+from .kernel_templates.reduction_template import (
+    RemainderReduceIntermediateKernelTemplate,
+    TreeReduceIntermediateKernelTemplate,
+)
+
+
+def create_reduction_main_kernel_for_parfor(
+    loop_ranges,
+    parfor_node,
+    typemap,
+    flags,
+    has_aliases,
+    reductionKernelVar,
+    parfor_reddict=None,
+):
+    """
+    Creates a numba_dpex.kernel function for reduction main kernel.
+    """
+
+    loc = parfor_node.init_block.loc
+
+    for race in parfor_node.races:
+        msg = (
+            "Variable %s used in parallel loop may be written "
+            "to simultaneously by multiple workers and may result "
+            "in non-deterministic or unintended results." % race
+        )
+        warnings.warn(NumbaParallelSafetyWarning(msg, loc))
+
+    loop_body_var_table = get_name_var_table(reductionKernelVar.loop_body)
+    sentinel_name = get_unused_var_name("__sentinel__", loop_body_var_table)
+
+    # Determine the unique names of the scheduling and gufunc functions.
+    kernel_name = "__numba_parfor_gufunc_%s" % (parfor_node.id)
+
+    # swap s.2 (redvar) with partial_sum
+    for i, name in enumerate(reductionKernelVar.parfor_params):
+        try:
+            tmp = reductionKernelVar.parfor_redvars_to_redarrs[name][0]
+            nameNew = reductionKernelVar.parfor_redarrs_legal_dict[tmp]
+            reductionKernelVar.parfor_legalized_params[i] = nameNew
+            reductionKernelVar.param_types[i] = _to_scalar_from_0d(typemap[tmp])
+            reductionKernelVar.func_arg_types[i] = _to_scalar_from_0d(
+                typemap[tmp]
+            )
+
+        except KeyError:
+            pass
+
+    kernel_template = TreeReduceIntermediateKernelTemplate(
+        kernel_name=kernel_name,
+        kernel_params=reductionKernelVar.parfor_legalized_params,
+        ivar_names=reductionKernelVar.legal_loop_indices,
+        sentinel_name=sentinel_name,
+        loop_ranges=loop_ranges,
+        param_dict=reductionKernelVar.param_dict,
+        parfor_dim=len(parfor_node.loop_nests),
+        redvars=reductionKernelVar.parfor_redvars,
+        parfor_args=reductionKernelVar.parfor_params,
+        parfor_reddict=parfor_reddict,
+        redvars_dict=reductionKernelVar.redvars_legal_dict,
+        typemap=typemap,
+        work_group_size=reductionKernelVar.work_group_size,
+    )
+    kernel_ir = kernel_template.kernel_ir
+
+    for i, name in enumerate(reductionKernelVar.parfor_params):
+        try:
+            tmp = reductionKernelVar.parfor_redvars_to_redarrs[name][0]
+            reductionKernelVar.parfor_params[i] = tmp
+        except KeyError:
+            pass
+
+    # rename all variables in kernel_ir afresh
+    var_table = get_name_var_table(kernel_ir.blocks)
+    new_var_dict = {}
+    reserved_names = (
+        [sentinel_name]
+        + list(reductionKernelVar.param_dict.values())
+        + reductionKernelVar.legal_loop_indices
+    )
+    for name, _ in var_table.items():
+        if not (name in reserved_names):
+            new_var_dict[name] = mk_unique_var(name)
+
+    replace_var_names(kernel_ir.blocks, new_var_dict)
+    kernel_param_types = reductionKernelVar.param_types
+    gufunc_stub_last_label = max(kernel_ir.blocks.keys()) + 1
+    # Add gufunc stub last label to each parfor.loop_body label to prevent
+    # label conflicts.
+    loop_body = add_offset_to_labels(
+        reductionKernelVar.loop_body, gufunc_stub_last_label
+    )
+    # new label for splitting sentinel block
+    new_label = max(loop_body.keys()) + 1
+
+    update_sentinel(kernel_ir, sentinel_name, loop_body, new_label)
+
+    # FIXME: Why rename and remove dels causes the partial_sum array update
+    # instructions to be removed.
+    kernel_ir.blocks = rename_labels(kernel_ir.blocks)
+    remove_dels(kernel_ir.blocks)
+
+    old_alias = flags.noalias
+
+    if not has_aliases:
+        flags.noalias = True
+
+    kernel_sig = signature(types.none, *kernel_param_types)
+    exec_queue = typemap[reductionKernelVar.parfor_params[0]].queue
+
+    sycl_kernel = _compile_kernel_parfor(
+        exec_queue,
+        kernel_name,
+        kernel_ir,
+        kernel_param_types,
+        debug=flags.debuginfo,
+    )
+
+    flags.noalias = old_alias
+
+    return ParforKernel(
+        name=kernel_name,
+        kernel=sycl_kernel,
+        signature=kernel_sig,
+        kernel_args=reductionKernelVar.parfor_params,
+        kernel_arg_types=reductionKernelVar.func_arg_types,
+        queue=exec_queue,
+    )
+
+
+def create_reduction_remainder_kernel_for_parfor(
+    parfor_node,
+    typemap,
+    flags,
+    has_aliases,
+    reductionKernelVar,
+    parfor_reddict,
+    reductionHelperList,
+):
+    """
+    Creates a numba_dpex.kernel function for a reduction remainder kernel.
+    """
+
+    loc = parfor_node.init_block.loc
+
+    for race in parfor_node.races:
+        msg = (
+            "Variable %s used in parallel loop may be written "
+            "to simultaneously by multiple workers and may result "
+            "in non-deterministic or unintended results." % race
+        )
+        warnings.warn(NumbaParallelSafetyWarning(msg, loc))
+
+    loop_body_var_table = get_name_var_table(reductionKernelVar.loop_body)
+    sentinel_name = get_unused_var_name("__sentinel__", loop_body_var_table)
+
+    global_size_var_name = []
+    global_size_mod_var_name = []
+    partial_sum_var_name = []
+    partial_sum_size_var_name = []
+    final_sum_var_name = []
+
+    for i, _ in enumerate(reductionKernelVar.parfor_redvars):
+        reductionHelper = reductionHelperList[i]
+        name = reductionHelper.partial_sum_var.name
+        partial_sum_var_name.append(name)
+
+        name = reductionHelper.global_size_var.name
+        global_size_var_name.append(name)
+
+        name = reductionHelper.global_size_mod_var.name
+        global_size_mod_var_name.append(name)
+
+        name = reductionHelper.partial_sum_size_var.name
+        partial_sum_size_var_name.append(name)
+
+        name = reductionHelper.final_sum_var.name
+        final_sum_var_name.append(name)
+
+    kernel_name = "__numba_parfor_gufunc_%s_sum2" % (parfor_node.id)
+
+    partial_sum_var_dict = legalize_names(partial_sum_var_name)
+    global_size_var_dict = legalize_names(global_size_var_name)
+    global_size_mod_var_dict = legalize_names(global_size_mod_var_name)
+    partial_sum_size_var_dict = legalize_names(partial_sum_size_var_name)
+    final_sum_var_dict = legalize_names(final_sum_var_name)
+
+    partial_sum_var_legal_name = [
+        partial_sum_var_dict[v] for v in partial_sum_var_dict
+    ]
+
+    global_size_var_legal_name = [
+        global_size_var_dict[v] for v in global_size_var_dict
+    ]
+    global_size_mod_var_legal_name = [
+        global_size_mod_var_dict[v] for v in global_size_mod_var_dict
+    ]
+    partial_sum_size_var_legal_name = [
+        partial_sum_size_var_dict[v] for v in partial_sum_size_var_dict
+    ]
+    final_sum_var_legal_name = [
+        final_sum_var_dict[v] for v in final_sum_var_dict
+    ]
+
+    kernel_template = RemainderReduceIntermediateKernelTemplate(
+        kernel_name=kernel_name,
+        kernel_params=reductionKernelVar.parfor_legalized_params,
+        sentinel_name=sentinel_name,
+        legal_loop_indices=reductionKernelVar.legal_loop_indices,
+        redvars_dict=reductionKernelVar.redvars_legal_dict,
+        redvars=reductionKernelVar.parfor_redvars,
+        parfor_reddict=parfor_reddict,
+        typemap=typemap,
+        global_size_var_name=global_size_var_legal_name,
+        global_size_mod_var_name=global_size_mod_var_legal_name,
+        partial_sum_size_var_name=partial_sum_size_var_legal_name,
+        partial_sum_var_name=partial_sum_var_legal_name,
+        final_sum_var_name=final_sum_var_legal_name,
+        reductionKernelVar=reductionKernelVar,
+    )
+    kernel_ir = kernel_template.kernel_ir
+
+    var_table = get_name_var_table(kernel_ir.blocks)
+    new_var_dict = {}
+    reserved_names = (
+        [sentinel_name]
+        + list(reductionKernelVar.param_dict.values())
+        + reductionKernelVar.legal_loop_indices
+    )
+    for name, _ in var_table.items():
+        if not (name in reserved_names):
+            new_var_dict[name] = mk_unique_var(name)
+    replace_var_names(kernel_ir.blocks, new_var_dict)
+
+    for i, _ in enumerate(reductionKernelVar.parfor_redvars):
+        if reductionHelperList[i].global_size_var is not None:
+            reductionKernelVar.parfor_params.append(global_size_var_name[i])
+            reductionKernelVar.parfor_legalized_params.append(
+                global_size_var_legal_name[i]
+            )
+            reductionKernelVar.param_types.append(
+                _to_scalar_from_0d(typemap[global_size_var_name[i]])
+            )
+            reductionKernelVar.func_arg_types.append(
+                _to_scalar_from_0d(typemap[global_size_var_name[i]])
+            )
+
+        if reductionHelperList[i].global_size_mod_var is not None:
+            reductionKernelVar.parfor_params.append(global_size_mod_var_name[i])
+            reductionKernelVar.parfor_legalized_params.append(
+                global_size_mod_var_legal_name[i]
+            )
+
+            reductionKernelVar.param_types.append(
+                _to_scalar_from_0d(typemap[global_size_mod_var_name[i]])
+            )
+            reductionKernelVar.func_arg_types.append(
+                _to_scalar_from_0d(typemap[global_size_mod_var_name[i]])
+            )
+
+        if reductionHelperList[i].partial_sum_size_var is not None:
+            reductionKernelVar.parfor_params.append(
+                partial_sum_size_var_name[i]
+            )
+            reductionKernelVar.parfor_legalized_params.append(
+                partial_sum_size_var_legal_name[i]
+            )
+            reductionKernelVar.param_types.append(
+                _to_scalar_from_0d(typemap[partial_sum_size_var_name[i]])
+            )
+            reductionKernelVar.func_arg_types.append(
+                _to_scalar_from_0d(typemap[partial_sum_size_var_name[i]])
+            )
+        if reductionHelperList[i].final_sum_var is not None:
+            reductionKernelVar.parfor_params.append(final_sum_var_name[i])
+            reductionKernelVar.parfor_legalized_params.append(
+                final_sum_var_legal_name[i]
+            )
+            reductionKernelVar.param_types.append(
+                _to_scalar_from_0d(typemap[final_sum_var_name[i]])
+            )
+            reductionKernelVar.func_arg_types.append(
+                _to_scalar_from_0d(typemap[final_sum_var_name[i]])
+            )
+
+    kernel_param_types = reductionKernelVar.param_types
+
+    gufunc_stub_last_label = max(kernel_ir.blocks.keys()) + 1
+
+    # Add gufunc stub last label to each parfor.loop_body label to prevent
+    # label conflicts.
+    loop_body = add_offset_to_labels(
+        reductionKernelVar.loop_body, gufunc_stub_last_label
+    )
+    # new label for splitting sentinel block
+    new_label = max(loop_body.keys()) + 1
+
+    update_sentinel(kernel_ir, sentinel_name, loop_body, new_label)
+
+    old_alias = flags.noalias
+    if not has_aliases:
+        flags.noalias = True
+
+    kernel_sig = signature(types.none, *kernel_param_types)
+
+    # FIXME: Enable check after CFD pass has been added
+    # exec_queue = determine_kernel_launch_queue(
+    #     args=parfor_args, argtypes=kernel_param_types, kernel_name=kernel_name
+    # )
+    exec_queue = typemap[reductionKernelVar.parfor_params[0]].queue
+
+    sycl_kernel = _compile_kernel_parfor(
+        exec_queue,
+        kernel_name,
+        kernel_ir,
+        kernel_param_types,
+        debug=flags.debuginfo,
+    )
+
+    flags.noalias = old_alias
+
+    return ParforKernel(
+        name=kernel_name,
+        kernel=sycl_kernel,
+        signature=kernel_sig,
+        kernel_args=reductionKernelVar.parfor_params,
+        kernel_arg_types=reductionKernelVar.func_arg_types,
+        queue=exec_queue,
+    )

--- a/numba_dpex/dpnp_iface/arrayobj.py
+++ b/numba_dpex/dpnp_iface/arrayobj.py
@@ -338,8 +338,8 @@ def ol_dpnp_zeros(
     """
 
     _ndim = _ty_parse_shape(shape)
-    _layout = _parse_layout(order)
     _dtype = _parse_dtype(dtype)
+    _layout = _parse_layout(order)
     _usm_type = _parse_usm_type(usm_type) if usm_type is not None else "device"
     _device = (
         _parse_device_filter_string(device) if device is not None else "unknown"

--- a/numba_dpex/tests/dpjit_tests/test_dpjit_reduction.py
+++ b/numba_dpex/tests/dpjit_tests/test_dpjit_reduction.py
@@ -1,0 +1,105 @@
+# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import dpnp
+import numba as nb
+import numpy
+import pytest
+
+import numba_dpex as dpex
+
+N = 100
+
+
+@dpex.dpjit
+def vecadd_prange(a, b):
+    s = 0
+    t = 0
+    for i in nb.prange(a.shape[0]):
+        s += a[i] + b[i]
+    for i in nb.prange(a.shape[0]):
+        t += a[i] - b[i]
+    return s - t
+
+
+@dpex.dpjit
+def vecmul_prange(a, b):
+    t = 0
+    for i in nb.prange(a.shape[0]):
+        t += a[i] * b[i]
+    return t
+
+
+@dpex.dpjit
+def vecadd_prange_float(a, b):
+    s = numpy.float32(0)
+    t = numpy.float32(0)
+    for i in nb.prange(a.shape[0]):
+        s += a[i] + b[i]
+    for i in nb.prange(a.shape[0]):
+        t += a[i] - b[i]
+    return s - t
+
+
+list_of_dtypes = [
+    dpnp.int32,
+    dpnp.int64,
+    dpnp.float64,
+]
+
+
+@pytest.fixture(params=list_of_dtypes)
+def input_arrays(request):
+    a = dpnp.arange(N, dtype=request.param)
+    b = dpnp.ones(N, dtype=request.param)
+
+    return a, b
+
+
+def test_dpjit_array_arg_types(input_arrays):
+    """Tests passing float and int type dpnp arrays to a dpjit
+    prange function.
+
+    Args:
+        input_arrays (dpnp.ndarray): Array arguments to be passed to a kernel.
+    """
+    s = 200
+
+    a, b = input_arrays
+
+    c = vecadd_prange(a, b)
+
+    assert s == c
+
+
+def test_dpjit_array_arg_types_mul(input_arrays):
+    """Tests passing float and int type dpnp arrays to a dpjit
+    prange function.
+
+    Args:
+        input_arrays (dpnp.ndarray): Array arguments to be passed to a kernel.
+    """
+    s = 4950
+
+    a, b = input_arrays
+
+    c = vecmul_prange(a, b)
+
+    assert s == c
+
+
+def test_dpjit_array_arg_float32_types(input_arrays):
+    """Tests passing float32 type dpnp arrays to a dpjit
+    prange function.Local variable has to be casted to float32.
+
+    Args:
+        input_arrays (dpnp.ndarray): Array arguments to be passed to a kernel.
+    """
+    s = 9900
+    a = dpnp.arange(N, dtype=dpnp.float32)
+    b = dpnp.arange(N, dtype=dpnp.float32)
+
+    c = vecadd_prange_float(a, b)
+
+    assert s == c


### PR DESCRIPTION
- [x] Have you provided a meaningful PR description?

1. New config to run the ConstantSizeStaticLocalMemoryPass optionally.
2. Adds support for prange reduction loops to numba-dpex.
   - Adds a template to generate a tree-reduction kernel for reduction loops that use the "+" or "*" operators.
   - Adds code generation for nd-range kernels in the parfor lowerer.
   - Refactoring of the parfor lowerer and kernel builder modules.
   - New unit test cases.

- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
