### PR TITLE
Feature/add numba rc support

### DIFF
--- a/numba_dpex/__init__.py
+++ b/numba_dpex/__init__.py
@@ -9,6 +9,8 @@ import glob
 import logging
 import os
 import platform as plt
+import re
+from typing import Tuple
 
 import dpctl
 import llvmlite.binding as ll
@@ -59,7 +61,22 @@ def load_dpctl_sycl_interface():
     Vectorize.target_registry.ondemand["dpex"] = lambda: DpexVectorize
 
 
-numba_version = tuple(map(int, numba.__version__.split(".")[:3]))
+def parse_sem_version(version_string: str) -> Tuple[int, int, int]:
+    """Parse sem version into tuple of three integers. If there is a suffix like
+    rc1, dev0 - it will be ignored."""
+    return tuple(
+        map(
+            int,
+            re.sub(
+                "([0-9]+\\.[0-9]+\\.[0-9]+).*",
+                "\\g<1>",
+                version_string,
+            ).split(".")[:3],
+        )
+    )
+
+
+numba_version = parse_sem_version(numba.__version__)
 if numba_version < (0, 56, 4):
     logging.warning(
         "numba_dpex needs numba 0.56.4, using "

--- a/numba_dpex/tests/test_parse_sem_version.py
+++ b/numba_dpex/tests/test_parse_sem_version.py
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from numba_dpex import parse_sem_version
+
+
+class TestParseSemVersion:
+    def test_parse_sem_version(self):
+        assert parse_sem_version("0.56.4") == (0, 56, 4)
+        assert parse_sem_version("0.57.0") == (0, 57, 0)
+        assert parse_sem_version("0.57.0rc1") == (0, 57, 0)
+        assert parse_sem_version("0.58.1dev0") == (0, 58, 1)


### PR DESCRIPTION
Resolves numba version parsing that contains suffixes. One of the blockers to test all the compatibility issues with numba 0.57.0rc1.
https://github.com/IntelPython/numba-dpex/issues/1000

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
