### PR TITLE
Replace parent package for cached_property import

### DIFF
--- a/numba_dpex/core/descriptor.py
+++ b/numba_dpex/core/descriptor.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from functools import cached_property
+
 from numba.core import typing, utils
 from numba.core.cpu import CPUTargetOptions
 from numba.core.descriptors import TargetDescriptor
@@ -21,12 +23,12 @@ class DpexKernelTarget(TargetDescriptor):
 
     options = CPUTargetOptions
 
-    @utils.cached_property
+    @cached_property
     def _toplevel_target_context(self):
         """Lazily-initialized top-level target context, for all threads."""
         return DpexKernelTargetContext(self.typing_context, self._target_name)
 
-    @utils.cached_property
+    @cached_property
     def _toplevel_typing_context(self):
         """Lazily-initialized top-level typing context, for all threads."""
         return DpexKernelTypingContext()
@@ -53,12 +55,12 @@ class DpexTarget(TargetDescriptor):
 
     options = CPUTargetOptions
 
-    @utils.cached_property
+    @cached_property
     def _toplevel_target_context(self):
         # Lazily-initialized top-level target context, for all threads
         return DpexTargetContext(self.typing_context, self._target_name)
 
-    @utils.cached_property
+    @cached_property
     def _toplevel_typing_context(self):
         # Lazily-initialized top-level typing context, for all threads
         return typing.Context()

--- a/numba_dpex/core/targets/dpjit_target.py
+++ b/numba_dpex/core/targets/dpjit_target.py
@@ -5,6 +5,8 @@
 """Defines the target and typing contexts for numba_dpex's dpjit decorator.
 """
 
+from functools import cached_property
+
 from numba.core import utils
 from numba.core.codegen import JITCPUCodegen
 from numba.core.compiler_lock import global_compiler_lock
@@ -40,7 +42,7 @@ class DpexTargetContext(CPUContext):
         # rtsys.initialize(self)
         self.refresh()
 
-    @utils.cached_property
+    @cached_property
     def dpexrt(self):
         from numba_dpex.core.runtime.context import DpexRTContext
 

--- a/numba_dpex/core/targets/kernel_target.py
+++ b/numba_dpex/core/targets/kernel_target.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import re
+from functools import cached_property
 
 import numpy as np
 from llvmlite import binding as ll
@@ -13,7 +14,6 @@ from numba.core.base import BaseContext
 from numba.core.callconv import MinimalCallConv
 from numba.core.registry import cpu_target
 from numba.core.target_extension import GPU, target_registry
-from numba.core.utils import cached_property
 
 from numba_dpex.core.datamodel.models import _init_data_model_manager
 from numba_dpex.core.exceptions import UnsupportedKernelArgumentError


### PR DESCRIPTION
For some reason it is no longer available via `numba.core.utils` import. Anyway, it looks like clean up change.
https://github.com/IntelPython/numba-dpex/issues/1000

~UPD: there are few places to face similar issue.~

- [ ] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
