### PR TITLE
Enabling sycl_queue for USMNdArray in dpnp overloads

### DIFF
--- a/numba_dpex/core/types/dpctl_types.py
+++ b/numba_dpex/core/types/dpctl_types.py
@@ -19,8 +19,13 @@ class DpctlSyclQueue(types.Type):
     Numba.
     """
 
-    def __init__(self):
+    def __init__(self, sycl_queue):
+        self._sycl_queue = sycl_queue
         super(DpctlSyclQueue, self).__init__(name="DpctlSyclQueue")
+
+    @property
+    def sycl_queue(self):
+        return self._sycl_queue
 
     @property
     def box_type(self):

--- a/numba_dpex/core/types/usm_ndarray_type.py
+++ b/numba_dpex/core/types/usm_ndarray_type.py
@@ -7,12 +7,11 @@
 
 import dpctl
 import dpctl.tensor
+from numba import types
 from numba.core.typeconv import Conversion
-from numba.core.typeinfer import CallConstraint
 from numba.core.types.npytypes import Array
 from numba.np.numpy_support import from_dtype
 
-from numba_dpex.core.types.dpctl_types import DpctlSyclQueue
 from numba_dpex.utils import address_space
 
 
@@ -32,7 +31,7 @@ class USMNdArray(Array):
         aligned=True,
         addrspace=address_space.GLOBAL,
     ):
-        if queue is not None and device is not None:
+        if queue and not isinstance(queue, types.misc.Omitted) and device:
             raise TypeError(
                 "numba_dpex.core.types.usm_ndarray_type.USMNdArray.__init__(): "
                 "`device` and `sycl_queue` are exclusive keywords, i.e. use one or other."
@@ -41,7 +40,7 @@ class USMNdArray(Array):
         self.usm_type = usm_type
         self.addrspace = addrspace
 
-        if queue is not None:
+        if queue and not isinstance(queue, types.misc.Omitted):
             if not isinstance(queue, dpctl.SyclQueue):
                 raise TypeError(
                     "numba_dpex.core.types.usm_ndarray_type.USMNdArray.__init__(): "

--- a/numba_dpex/core/typing/typeof.py
+++ b/numba_dpex/core/typing/typeof.py
@@ -103,4 +103,4 @@ def typeof_dpctl_sycl_queue(val, c):
 
     Returns: A numba_dpex.core.types.dpctl_types.DpctlSyclQueue instance.
     """
-    return DpctlSyclQueue()
+    return DpctlSyclQueue(val)

--- a/numba_dpex/dpnp_iface/arrayobj.py
+++ b/numba_dpex/dpnp_iface/arrayobj.py
@@ -177,7 +177,7 @@ def build_dpnp_ndarray(
             represent dpctl.tensor.usm_ndarray.
     """
 
-    if sycl_queue is not None and device is not None:
+    if sycl_queue and not isinstance(sycl_queue, types.misc.Omitted) and device:
         raise errors.TypingError(
             "numba_dpex.dpnp_iface.arrayobj.build_dpnp_ndarray(): "
             "`device` and `sycl_queue` are exclusive keywords, "
@@ -274,7 +274,7 @@ def ol_dpnp_empty(
         function: Local function `impl_dpnp_empty()`.
     """
 
-    if sycl_queue is not None and device is not None:
+    if sycl_queue and not isinstance(sycl_queue, types.misc.Omitted) and device:
         raise errors.TypingError(
             "numba_dpex.dpnp_iface.arrayobj.ol_dpnp_empty(): "
             "`device` and `sycl_queue` are exclusive keywords, "
@@ -284,12 +284,12 @@ def ol_dpnp_empty(
     _ndim = _ty_parse_shape(shape)
     _dtype = _parse_dtype(dtype)
     _layout = _parse_layout(order)
-    _usm_type = _parse_usm_type(usm_type) if usm_type is not None else "device"
-    _device = (
-        _parse_device_filter_string(device) if device is not None else None
-    )
+    _usm_type = _parse_usm_type(usm_type) if usm_type else "device"
+    _device = _parse_device_filter_string(device) if device else None
     _sycl_queue = (
-        sycl_queue.sycl_queue if sycl_queue is not None else sycl_queue
+        sycl_queue.sycl_queue
+        if sycl_queue and not isinstance(sycl_queue, types.misc.Omitted)
+        else sycl_queue
     )
 
     if _ndim:
@@ -390,7 +390,7 @@ def ol_dpnp_zeros(
         function: Local function `impl_dpnp_zeros()`.
     """
 
-    if sycl_queue is not None and device is not None:
+    if sycl_queue and not isinstance(sycl_queue, types.misc.Omitted) and device:
         raise errors.TypingError(
             "numba_dpex.dpnp_iface.arrayobj.ol_dpnp_empty(): "
             "`device` and `sycl_queue` are exclusive keywords, "
@@ -400,12 +400,12 @@ def ol_dpnp_zeros(
     _ndim = _ty_parse_shape(shape)
     _layout = _parse_layout(order)
     _dtype = _parse_dtype(dtype)
-    _usm_type = _parse_usm_type(usm_type) if usm_type is not None else "device"
-    _device = (
-        _parse_device_filter_string(device) if device is not None else None
-    )
+    _usm_type = _parse_usm_type(usm_type) if usm_type else "device"
+    _device = _parse_device_filter_string(device) if device else None
     _sycl_queue = (
-        sycl_queue.sycl_queue if sycl_queue is not None else sycl_queue
+        sycl_queue.sycl_queue
+        if sycl_queue and not isinstance(sycl_queue, types.misc.Omitted)
+        else sycl_queue
     )
 
     if _ndim:
@@ -506,7 +506,7 @@ def ol_dpnp_ones(
         function: Local function `impl_dpnp_ones()`.
     """
 
-    if sycl_queue is not None and device is not None:
+    if sycl_queue and not isinstance(sycl_queue, types.misc.Omitted) and device:
         raise errors.TypingError(
             "numba_dpex.dpnp_iface.arrayobj.ol_dpnp_empty(): "
             "`device` and `sycl_queue` are exclusive keywords, "
@@ -516,12 +516,12 @@ def ol_dpnp_ones(
     _ndim = _ty_parse_shape(shape)
     _dtype = _parse_dtype(dtype)
     _layout = _parse_layout(order)
-    _usm_type = _parse_usm_type(usm_type) if usm_type is not None else "device"
-    _device = (
-        _parse_device_filter_string(device) if device is not None else None
-    )
+    _usm_type = _parse_usm_type(usm_type) if usm_type else "device"
+    _device = _parse_device_filter_string(device) if device else None
     _sycl_queue = (
-        sycl_queue.sycl_queue if sycl_queue is not None else sycl_queue
+        sycl_queue.sycl_queue
+        if sycl_queue and not isinstance(sycl_queue, types.misc.Omitted)
+        else sycl_queue
     )
 
     if _ndim:
@@ -626,7 +626,7 @@ def ol_dpnp_full(
         function: Local function `impl_dpnp_full()`.
     """
 
-    if sycl_queue is not None and device is not None:
+    if sycl_queue and not isinstance(sycl_queue, types.misc.Omitted) and device:
         raise errors.TypingError(
             "numba_dpex.dpnp_iface.arrayobj.ol_dpnp_empty(): "
             "`device` and `sycl_queue` are exclusive keywords, "
@@ -636,12 +636,12 @@ def ol_dpnp_full(
     _ndim = _ty_parse_shape(shape)
     _dtype = _parse_dtype(dtype)
     _layout = _parse_layout(order)
-    _usm_type = _parse_usm_type(usm_type) if usm_type is not None else "device"
-    _device = (
-        _parse_device_filter_string(device) if device is not None else None
-    )
+    _usm_type = _parse_usm_type(usm_type) if usm_type else "device"
+    _device = _parse_device_filter_string(device) if device else None
     _sycl_queue = (
-        sycl_queue.sycl_queue if sycl_queue is not None else sycl_queue
+        sycl_queue.sycl_queue
+        if sycl_queue and not isinstance(sycl_queue, types.misc.Omitted)
+        else sycl_queue
     )
 
     if _ndim:
@@ -746,7 +746,8 @@ def ol_dpnp_empty_like(
     Returns:
         function: Local function `impl_dpnp_empty_like()`.
     """
-    if sycl_queue is not None and device is not None:
+
+    if sycl_queue and not isinstance(sycl_queue, types.misc.Omitted) and device:
         raise errors.TypingError(
             "numba_dpex.dpnp_iface.arrayobj.ol_dpnp_empty(): "
             "`device` and `sycl_queue` are exclusive keywords, "
@@ -759,15 +760,15 @@ def ol_dpnp_empty_like(
             + "inside overloaded dpnp.empty_like() function."
         )
 
-    _ndim = x1.ndim if hasattr(x1, "ndim") and x1.ndim is not None else 0
+    _ndim = x1.ndim if hasattr(x1, "ndim") and x1.ndim else 0
     _dtype = _parse_dtype(dtype, data=x1)
     _order = x1.layout if order is None else order
-    _usm_type = _parse_usm_type(usm_type) if usm_type is not None else "device"
-    _device = (
-        _parse_device_filter_string(device) if device is not None else None
-    )
+    _usm_type = _parse_usm_type(usm_type) if usm_type else "device"
+    _device = _parse_device_filter_string(device) if device else None
     _sycl_queue = (
-        sycl_queue.sycl_queue if sycl_queue is not None else sycl_queue
+        sycl_queue.sycl_queue
+        if sycl_queue and not isinstance(sycl_queue, types.misc.Omitted)
+        else sycl_queue
     )
 
     ret_ty = build_dpnp_ndarray(
@@ -870,7 +871,8 @@ def ol_dpnp_zeros_like(
     Returns:
         function: Local function `impl_dpnp_zeros_like()`.
     """
-    if sycl_queue is not None and device is not None:
+
+    if sycl_queue and not isinstance(sycl_queue, types.misc.Omitted) and device:
         raise errors.TypingError(
             "numba_dpex.dpnp_iface.arrayobj.ol_dpnp_empty(): "
             "`device` and `sycl_queue` are exclusive keywords, "
@@ -883,15 +885,15 @@ def ol_dpnp_zeros_like(
             + "inside overloaded dpnp.zeros_like() function."
         )
 
-    _ndim = x1.ndim if hasattr(x1, "ndim") and x1.ndim is not None else 0
+    _ndim = x1.ndim if hasattr(x1, "ndim") and x1.ndim else 0
     _dtype = _parse_dtype(dtype, data=x1)
     _order = x1.layout if order is None else order
-    _usm_type = _parse_usm_type(usm_type) if usm_type is not None else "device"
-    _device = (
-        _parse_device_filter_string(device) if device is not None else None
-    )
+    _usm_type = _parse_usm_type(usm_type) if usm_type else "device"
+    _device = _parse_device_filter_string(device) if device else None
     _sycl_queue = (
-        sycl_queue.sycl_queue if sycl_queue is not None else sycl_queue
+        sycl_queue.sycl_queue
+        if sycl_queue and not isinstance(sycl_queue, types.misc.Omitted)
+        else sycl_queue
     )
 
     ret_ty = build_dpnp_ndarray(
@@ -993,7 +995,7 @@ def ol_dpnp_ones_like(
     Returns:
         function: Local function `impl_dpnp_ones_like()`.
     """
-    if sycl_queue is not None and device is not None:
+    if sycl_queue and not isinstance(sycl_queue, types.misc.Omitted) and device:
         raise errors.TypingError(
             "numba_dpex.dpnp_iface.arrayobj.ol_dpnp_empty(): "
             "`device` and `sycl_queue` are exclusive keywords, "
@@ -1006,15 +1008,15 @@ def ol_dpnp_ones_like(
             + "inside overloaded dpnp.ones_like() function."
         )
 
-    _ndim = x1.ndim if hasattr(x1, "ndim") and x1.ndim is not None else 0
+    _ndim = x1.ndim if hasattr(x1, "ndim") and x1.ndim else 0
     _dtype = _parse_dtype(dtype, data=x1)
     _order = x1.layout if order is None else order
-    _usm_type = _parse_usm_type(usm_type) if usm_type is not None else "device"
-    _device = (
-        _parse_device_filter_string(device) if device is not None else None
-    )
+    _usm_type = _parse_usm_type(usm_type) if usm_type else "device"
+    _device = _parse_device_filter_string(device) if device else None
     _sycl_queue = (
-        sycl_queue.sycl_queue if sycl_queue is not None else sycl_queue
+        sycl_queue.sycl_queue
+        if sycl_queue and not isinstance(sycl_queue, types.misc.Omitted)
+        else sycl_queue
     )
 
     ret_ty = build_dpnp_ndarray(
@@ -1122,7 +1124,7 @@ def ol_dpnp_full_like(
         function: Local function `impl_dpnp_full_like()`.
     """
 
-    if sycl_queue is not None and device is not None:
+    if sycl_queue and not isinstance(sycl_queue, types.misc.Omitted) and device:
         raise errors.TypingError(
             "numba_dpex.dpnp_iface.arrayobj.ol_dpnp_empty(): "
             "`device` and `sycl_queue` are exclusive keywords, "
@@ -1135,15 +1137,15 @@ def ol_dpnp_full_like(
             + "inside overloaded dpnp.full_like() function."
         )
 
-    _ndim = x1.ndim if hasattr(x1, "ndim") and x1.ndim is not None else 0
+    _ndim = x1.ndim if hasattr(x1, "ndim") and x1.ndim else 0
     _dtype = _parse_dtype(dtype, data=x1)
     _order = x1.layout if order is None else order
-    _usm_type = _parse_usm_type(usm_type) if usm_type is not None else "device"
-    _device = (
-        _parse_device_filter_string(device) if device is not None else None
-    )
+    _usm_type = _parse_usm_type(usm_type) if usm_type else "device"
+    _device = _parse_device_filter_string(device) if device else None
     _sycl_queue = (
-        sycl_queue.sycl_queue if sycl_queue is not None else sycl_queue
+        sycl_queue.sycl_queue
+        if sycl_queue and not isinstance(sycl_queue, types.misc.Omitted)
+        else sycl_queue
     )
 
     ret_ty = build_dpnp_ndarray(

--- a/numba_dpex/dpnp_iface/arrayobj.py
+++ b/numba_dpex/dpnp_iface/arrayobj.py
@@ -125,12 +125,13 @@ def _parse_device_filter_string(device):
         return device_filter_str
     elif isinstance(device, str):
         return device
-    else:
+    elif device is None or isinstance(device, types.NoneType):
         return None
-        # raise TypeError(
-        #     "The parameter 'device' is neither of "
-        #     + "'str' nor 'types.StringLiteral'"
-        # )
+    else:
+        raise TypeError(
+            "The parameter 'device' is neither of "
+            + "'str', 'types.StringLiteral' nor 'None'"
+        )
 
 
 def build_dpnp_ndarray(
@@ -160,13 +161,12 @@ def build_dpnp_ndarray(
             corresponding to a non-partitioned SYCL device, an instance of
             :class:`dpctl.SyclQueue`, or a `Device` object returnedby
             `dpctl.tensor.usm_array.device`. Default: `None`.
-        sycl_queue (:class:`dpctl.SyclQueue`, optional): The SYCL queue to use
-            for output array allocation and copying. sycl_queue and device
-            are exclusive keywords, i.e. use one or another. If both are
-            specified, a TypeError is raised unless both imply the same
-            underlying SYCL queue to be used. If both are None, a cached
-            queue targeting default-selected device is used for allocation
-            and copying. Default: `None`.
+        sycl_queue (:class:`numba_dpex.core.types.dpctl_types.DpctlSyclQueue`,
+            optional): The SYCL queue to use for output array allocation and
+            copying. sycl_queue and device are exclusive keywords, i.e. use
+            one or another. If both are specified, a TypeError is raised. If
+            both are None, a cached queue targeting default-selected device
+            is used for allocation and copying. Default: `None`.
 
     Raises:
         errors.TypingError: If both `device` and `sycl_queue` are provided.
@@ -176,13 +176,6 @@ def build_dpnp_ndarray(
             The type has the same structure as USMNdArray used to
             represent dpctl.tensor.usm_ndarray.
     """
-
-    if sycl_queue and not isinstance(sycl_queue, types.misc.Omitted) and device:
-        raise errors.TypingError(
-            "numba_dpex.dpnp_iface.arrayobj.build_dpnp_ndarray(): "
-            "`device` and `sycl_queue` are exclusive keywords, "
-            "i.e. use one or other."
-        )
 
     # If a dtype value was passed in, then try to convert it to the
     # corresponding Numba type. If None was passed, the default, then pass None
@@ -228,7 +221,7 @@ def ol_dpnp_empty(
     sycl_queue=None,
 ):
     """Implementation of an overload to support dpnp.empty() inside
-    a jit function.
+    a dpjit function.
 
     Args:
         shape (numba.core.types.containers.UniTuple or
@@ -260,10 +253,9 @@ def ol_dpnp_empty(
         sycl_queue (:class:`numba_dpex.core.types.dpctl_types.DpctlSyclQueue`,
             optional): The SYCL queue to use for output array allocation and
             copying. sycl_queue and device are exclusive keywords, i.e. use
-            one or another. If both are specified, a TypeError is raised
-            unless both imply the same underlying SYCL queue to be used.
-            If both are None, a cached queue targeting default-selected
-            device is used for allocation and copying. Default: `None`.
+            one or another. If both are specified, a TypeError is raised. If
+            both are None, a cached queue targeting default-selected device
+            is used for allocation and copying. Default: `None`.
 
     Raises:
         errors.TypingError: If both `device` and `sycl_queue` are provided.
@@ -273,13 +265,6 @@ def ol_dpnp_empty(
     Returns:
         function: Local function `impl_dpnp_empty()`.
     """
-
-    if sycl_queue and not isinstance(sycl_queue, types.misc.Omitted) and device:
-        raise errors.TypingError(
-            "numba_dpex.dpnp_iface.arrayobj.ol_dpnp_empty(): "
-            "`device` and `sycl_queue` are exclusive keywords, "
-            "i.e. use one or other."
-        )
 
     _ndim = _ty_parse_shape(shape)
     _dtype = _parse_dtype(dtype)
@@ -344,7 +329,7 @@ def ol_dpnp_zeros(
     sycl_queue=None,
 ):
     """Implementation of an overload to support dpnp.zeros() inside
-    a jit function.
+    a dpjit function.
 
     Args:
         shape (numba.core.types.containers.UniTuple or
@@ -376,10 +361,9 @@ def ol_dpnp_zeros(
         sycl_queue (:class:`numba_dpex.core.types.dpctl_types.DpctlSyclQueue`,
             optional): The SYCL queue to use for output array allocation and
             copying. sycl_queue and device are exclusive keywords, i.e. use
-            one or another. If both are specified, a TypeError is raised
-            unless both imply the same underlying SYCL queue to be used.
-            If both are None, a cached queue targeting default-selected
-            device is used for allocation and copying. Default: `None`.
+            one or another. If both are specified, a TypeError is raised. If
+            both are None, a cached queue targeting default-selected device
+            is used for allocation and copying. Default: `None`.
 
     Raises:
         errors.TypingError: If both `device` and `sycl_queue` are provided.
@@ -389,13 +373,6 @@ def ol_dpnp_zeros(
     Returns:
         function: Local function `impl_dpnp_zeros()`.
     """
-
-    if sycl_queue and not isinstance(sycl_queue, types.misc.Omitted) and device:
-        raise errors.TypingError(
-            "numba_dpex.dpnp_iface.arrayobj.ol_dpnp_empty(): "
-            "`device` and `sycl_queue` are exclusive keywords, "
-            "i.e. use one or other."
-        )
 
     _ndim = _ty_parse_shape(shape)
     _layout = _parse_layout(order)
@@ -460,7 +437,7 @@ def ol_dpnp_ones(
     sycl_queue=None,
 ):
     """Implementation of an overload to support dpnp.ones() inside
-    a jit function.
+    a dpjit function.
 
     Args:
         shape (numba.core.types.containers.UniTuple or
@@ -492,10 +469,9 @@ def ol_dpnp_ones(
         sycl_queue (:class:`numba_dpex.core.types.dpctl_types.DpctlSyclQueue`,
             optional): The SYCL queue to use for output array allocation and
             copying. sycl_queue and device are exclusive keywords, i.e. use
-            one or another. If both are specified, a TypeError is raised
-            unless both imply the same underlying SYCL queue to be used.
-            If both are None, a cached queue targeting default-selected
-            device is used for allocation and copying. Default: `None`.
+            one or another. If both are specified, a TypeError is raised. If
+            both are None, a cached queue targeting default-selected device
+            is used for allocation and copying. Default: `None`.
 
     Raises:
         errors.TypingError: If both `device` and `sycl_queue` are provided.
@@ -505,13 +481,6 @@ def ol_dpnp_ones(
     Returns:
         function: Local function `impl_dpnp_ones()`.
     """
-
-    if sycl_queue and not isinstance(sycl_queue, types.misc.Omitted) and device:
-        raise errors.TypingError(
-            "numba_dpex.dpnp_iface.arrayobj.ol_dpnp_empty(): "
-            "`device` and `sycl_queue` are exclusive keywords, "
-            "i.e. use one or other."
-        )
 
     _ndim = _ty_parse_shape(shape)
     _dtype = _parse_dtype(dtype)
@@ -577,7 +546,7 @@ def ol_dpnp_full(
     sycl_queue=None,
 ):
     """Implementation of an overload to support dpnp.full() inside
-    a jit function.
+    a dpjit function.
 
     Args:
         shape (numba.core.types.containers.UniTuple or
@@ -612,10 +581,9 @@ def ol_dpnp_full(
         sycl_queue (:class:`numba_dpex.core.types.dpctl_types.DpctlSyclQueue`,
             optional): The SYCL queue to use for output array allocation and
             copying. sycl_queue and device are exclusive keywords, i.e. use
-            one or another. If both are specified, a TypeError is raised
-            unless both imply the same underlying SYCL queue to be used.
-            If both are None, a cached queue targeting default-selected
-            device is used for allocation and copying. Default: `None`.
+            one or another. If both are specified, a TypeError is raised. If
+            both are None, a cached queue targeting default-selected device
+            is used for allocation and copying. Default: `None`.
 
     Raises:
         errors.TypingError: If both `device` and `sycl_queue` are provided.
@@ -625,13 +593,6 @@ def ol_dpnp_full(
     Returns:
         function: Local function `impl_dpnp_full()`.
     """
-
-    if sycl_queue and not isinstance(sycl_queue, types.misc.Omitted) and device:
-        raise errors.TypingError(
-            "numba_dpex.dpnp_iface.arrayobj.ol_dpnp_empty(): "
-            "`device` and `sycl_queue` are exclusive keywords, "
-            "i.e. use one or other."
-        )
 
     _ndim = _ty_parse_shape(shape)
     _dtype = _parse_dtype(dtype)
@@ -733,10 +694,9 @@ def ol_dpnp_empty_like(
         sycl_queue (:class:`numba_dpex.core.types.dpctl_types.DpctlSyclQueue`,
             optional): The SYCL queue to use for output array allocation and
             copying. sycl_queue and device are exclusive keywords, i.e. use
-            one or another. If both are specified, a TypeError is raised
-            unless both imply the same underlying SYCL queue to be used.
-            If both are None, a cached queue targeting default-selected
-            device is used for allocation and copying. Default: `None`.
+            one or another. If both are specified, a TypeError is raised. If
+            both are None, a cached queue targeting default-selected device
+            is used for allocation and copying. Default: `None`.
 
     Raises:
         errors.TypingError: If both `device` and `sycl_queue` are provided.
@@ -746,13 +706,6 @@ def ol_dpnp_empty_like(
     Returns:
         function: Local function `impl_dpnp_empty_like()`.
     """
-
-    if sycl_queue and not isinstance(sycl_queue, types.misc.Omitted) and device:
-        raise errors.TypingError(
-            "numba_dpex.dpnp_iface.arrayobj.ol_dpnp_empty(): "
-            "`device` and `sycl_queue` are exclusive keywords, "
-            "i.e. use one or other."
-        )
 
     if shape:
         raise errors.TypingError(
@@ -858,10 +811,9 @@ def ol_dpnp_zeros_like(
         sycl_queue (:class:`numba_dpex.core.types.dpctl_types.DpctlSyclQueue`,
             optional): The SYCL queue to use for output array allocation and
             copying. sycl_queue and device are exclusive keywords, i.e. use
-            one or another. If both are specified, a TypeError is raised
-            unless both imply the same underlying SYCL queue to be used.
-            If both are None, a cached queue targeting default-selected
-            device is used for allocation and copying. Default: `None`.
+            one or another. If both are specified, a TypeError is raised. If
+            both are None, a cached queue targeting default-selected device
+            is used for allocation and copying. Default: `None`.
 
     Raises:
         errors.TypingError: If both `device` and `sycl_queue` are provided.
@@ -871,13 +823,6 @@ def ol_dpnp_zeros_like(
     Returns:
         function: Local function `impl_dpnp_zeros_like()`.
     """
-
-    if sycl_queue and not isinstance(sycl_queue, types.misc.Omitted) and device:
-        raise errors.TypingError(
-            "numba_dpex.dpnp_iface.arrayobj.ol_dpnp_empty(): "
-            "`device` and `sycl_queue` are exclusive keywords, "
-            "i.e. use one or other."
-        )
 
     if shape:
         raise errors.TypingError(
@@ -982,10 +927,9 @@ def ol_dpnp_ones_like(
         sycl_queue (:class:`numba_dpex.core.types.dpctl_types.DpctlSyclQueue`,
             optional): The SYCL queue to use for output array allocation and
             copying. sycl_queue and device are exclusive keywords, i.e. use
-            one or another. If both are specified, a TypeError is raised
-            unless both imply the same underlying SYCL queue to be used.
-            If both are None, a cached queue targeting default-selected
-            device is used for allocation and copying. Default: `None`.
+            one or another. If both are specified, a TypeError is raised. If
+            both are None, a cached queue targeting default-selected device
+            is used for allocation and copying. Default: `None`.
 
     Raises:
         errors.TypingError: If both `device` and `sycl_queue` are provided.
@@ -995,12 +939,6 @@ def ol_dpnp_ones_like(
     Returns:
         function: Local function `impl_dpnp_ones_like()`.
     """
-    if sycl_queue and not isinstance(sycl_queue, types.misc.Omitted) and device:
-        raise errors.TypingError(
-            "numba_dpex.dpnp_iface.arrayobj.ol_dpnp_empty(): "
-            "`device` and `sycl_queue` are exclusive keywords, "
-            "i.e. use one or other."
-        )
 
     if shape:
         raise errors.TypingError(
@@ -1110,10 +1048,9 @@ def ol_dpnp_full_like(
         sycl_queue (:class:`numba_dpex.core.types.dpctl_types.DpctlSyclQueue`,
             optional): The SYCL queue to use for output array allocation and
             copying. sycl_queue and device are exclusive keywords, i.e. use
-            one or another. If both are specified, a TypeError is raised
-            unless both imply the same underlying SYCL queue to be used.
-            If both are None, a cached queue targeting default-selected
-            device is used for allocation and copying. Default: `None`.
+            one or another. If both are specified, a TypeError is raised. If
+            both are None, a cached queue targeting default-selected device
+            is used for allocation and copying. Default: `None`.
 
     Raises:
         errors.TypingError: If both `device` and `sycl_queue` are provided.
@@ -1123,13 +1060,6 @@ def ol_dpnp_full_like(
     Returns:
         function: Local function `impl_dpnp_full_like()`.
     """
-
-    if sycl_queue and not isinstance(sycl_queue, types.misc.Omitted) and device:
-        raise errors.TypingError(
-            "numba_dpex.dpnp_iface.arrayobj.ol_dpnp_empty(): "
-            "`device` and `sycl_queue` are exclusive keywords, "
-            "i.e. use one or other."
-        )
 
     if shape:
         raise errors.TypingError(

--- a/numba_dpex/tests/core/passes/test_parfor_legalize_cfd_pass.py
+++ b/numba_dpex/tests/core/passes/test_parfor_legalize_cfd_pass.py
@@ -48,7 +48,7 @@ def test_parfor_legalize_cfd_pass(shape, dtype, usm_type, device):
 
     assert c.dtype == dtype
     assert c.usm_type == usm_type
-    if device != "unknown":
+    if device is not None:
         assert (
             c.sycl_device.filter_string
             == dpctl.SyclDevice(device).filter_string

--- a/numba_dpex/tests/dpjit_tests/dpnp/test_dpnp_empty.py
+++ b/numba_dpex/tests/dpjit_tests/dpnp/test_dpnp_empty.py
@@ -13,7 +13,7 @@ from numba_dpex import dpjit
 shapes = [11, (2, 5)]
 dtypes = [dpnp.int32, dpnp.int64, dpnp.float32, dpnp.float64]
 usm_types = ["device", "shared", "host"]
-devices = ["cpu", "unknown"]
+devices = ["cpu", "gpu", None]
 
 
 @pytest.mark.parametrize("shape", shapes)
@@ -38,7 +38,7 @@ def test_dpnp_empty(shape, dtype, usm_type, device):
 
     assert c.dtype == dtype
     assert c.usm_type == usm_type
-    if device != "unknown":
+    if device is not None:
         assert (
             c.sycl_device.filter_string
             == dpctl.SyclDevice(device).filter_string

--- a/numba_dpex/tests/dpjit_tests/dpnp/test_dpnp_empty.py
+++ b/numba_dpex/tests/dpjit_tests/dpnp/test_dpnp_empty.py
@@ -13,7 +13,7 @@ from numba_dpex import dpjit
 shapes = [11, (2, 5)]
 dtypes = [dpnp.int32, dpnp.int64, dpnp.float32, dpnp.float64]
 usm_types = ["device", "shared", "host"]
-devices = ["cpu", "gpu", None]
+devices = ["cpu", None]
 
 
 @pytest.mark.parametrize("shape", shapes)

--- a/numba_dpex/tests/dpjit_tests/dpnp/test_dpnp_empty_like.py
+++ b/numba_dpex/tests/dpjit_tests/dpnp/test_dpnp_empty_like.py
@@ -16,7 +16,7 @@ from numba_dpex import dpjit
 shapes = [10, (2, 5)]
 dtypes = [dpnp.int32, dpnp.int64, dpnp.float32, dpnp.float64]
 usm_types = ["device", "shared", "host"]
-devices = ["cpu", "gpu", None]
+devices = ["cpu", None]
 
 
 @pytest.mark.parametrize("shape", shapes)

--- a/numba_dpex/tests/dpjit_tests/dpnp/test_dpnp_full.py
+++ b/numba_dpex/tests/dpjit_tests/dpnp/test_dpnp_full.py
@@ -17,7 +17,7 @@ from numba_dpex import dpjit
 shapes = [11, (3, 7)]
 dtypes = [dpnp.int32, dpnp.int64, dpnp.float32, dpnp.float64]
 usm_types = ["device", "shared", "host"]
-devices = ["cpu", "gpu", None]
+devices = ["cpu", None]
 fill_values = [
     7,
     -7,

--- a/numba_dpex/tests/dpjit_tests/dpnp/test_dpnp_full.py
+++ b/numba_dpex/tests/dpjit_tests/dpnp/test_dpnp_full.py
@@ -17,7 +17,7 @@ from numba_dpex import dpjit
 shapes = [11, (3, 7)]
 dtypes = [dpnp.int32, dpnp.int64, dpnp.float32, dpnp.float64]
 usm_types = ["device", "shared", "host"]
-devices = ["cpu", "unknown"]
+devices = ["cpu", "gpu", None]
 fill_values = [
     7,
     -7,
@@ -58,7 +58,7 @@ def test_dpnp_full(shape, fill_value, dtype, usm_type, device):
 
     assert c.dtype == dtype
     assert c.usm_type == usm_type
-    if device != "unknown":
+    if device is not None:
         assert (
             c.sycl_device.filter_string
             == dpctl.SyclDevice(device).filter_string

--- a/numba_dpex/tests/dpjit_tests/dpnp/test_dpnp_full_like.py
+++ b/numba_dpex/tests/dpjit_tests/dpnp/test_dpnp_full_like.py
@@ -18,7 +18,7 @@ from numba_dpex import dpjit
 shapes = [11, (3, 7)]
 dtypes = [dpnp.int32, dpnp.int64, dpnp.float32, dpnp.float64]
 usm_types = ["device", "shared", "host"]
-devices = ["cpu", "gpu", None]
+devices = ["cpu", None]
 fill_values = [
     7,
     -7,

--- a/numba_dpex/tests/dpjit_tests/dpnp/test_dpnp_full_like.py
+++ b/numba_dpex/tests/dpjit_tests/dpnp/test_dpnp_full_like.py
@@ -18,7 +18,7 @@ from numba_dpex import dpjit
 shapes = [11, (3, 7)]
 dtypes = [dpnp.int32, dpnp.int64, dpnp.float32, dpnp.float64]
 usm_types = ["device", "shared", "host"]
-devices = ["cpu", "unknown"]
+devices = ["cpu", "gpu", None]
 fill_values = [
     7,
     -7,
@@ -62,7 +62,7 @@ def test_dpnp_full_like(shape, fill_value, dtype, usm_type, device):
 
     assert c.dtype == dtype
     assert c.usm_type == usm_type
-    if device != "unknown":
+    if device is not None:
         assert (
             c.sycl_device.filter_string
             == dpctl.SyclDevice(device).filter_string
@@ -76,7 +76,7 @@ def test_dpnp_full_like(shape, fill_value, dtype, usm_type, device):
 def test_dpnp_full_like_exceptions():
     @dpjit
     def func1(a):
-        c = dpnp.full_like(a, shape=(3, 3))
+        c = dpnp.full_like(a, 7, shape=(3, 3))
         return c
 
     try:
@@ -91,15 +91,12 @@ def test_dpnp_full_like_exceptions():
     queue = dpctl.SyclQueue()
 
     @dpjit
-    def func2(a):
-        c = dpnp.full_like(a, sycl_queue=queue)
+    def func2(a, q):
+        c = dpnp.full_like(a, 7, sycl_queue=q, device="cpu")
         return c
 
     try:
-        func2(numpy.random.rand(5, 5))
+        func2(numpy.random.rand(5, 5), queue)
     except Exception as e:
         assert isinstance(e, errors.TypingError)
-        assert (
-            "No implementation of function Function(<function full_like"
-            in str(e)
-        )
+        assert "`device` and `sycl_queue` are exclusive keywords" in str(e)

--- a/numba_dpex/tests/dpjit_tests/dpnp/test_dpnp_ones.py
+++ b/numba_dpex/tests/dpjit_tests/dpnp/test_dpnp_ones.py
@@ -15,7 +15,7 @@ from numba_dpex import dpjit
 shapes = [11, (3, 7)]
 dtypes = [dpnp.int32, dpnp.int64, dpnp.float32, dpnp.float64]
 usm_types = ["device", "shared", "host"]
-devices = ["cpu", "gpu", None]
+devices = ["cpu", None]
 
 
 @pytest.mark.parametrize("shape", shapes)

--- a/numba_dpex/tests/dpjit_tests/dpnp/test_dpnp_ones.py
+++ b/numba_dpex/tests/dpjit_tests/dpnp/test_dpnp_ones.py
@@ -15,7 +15,7 @@ from numba_dpex import dpjit
 shapes = [11, (3, 7)]
 dtypes = [dpnp.int32, dpnp.int64, dpnp.float32, dpnp.float64]
 usm_types = ["device", "shared", "host"]
-devices = ["cpu", "unknown"]
+devices = ["cpu", "gpu", None]
 
 
 @pytest.mark.parametrize("shape", shapes)
@@ -44,7 +44,7 @@ def test_dpnp_ones(shape, dtype, usm_type, device):
 
     assert c.dtype == dtype
     assert c.usm_type == usm_type
-    if device != "unknown":
+    if device is not None:
         assert (
             c.sycl_device.filter_string
             == dpctl.SyclDevice(device).filter_string

--- a/numba_dpex/tests/dpjit_tests/dpnp/test_dpnp_ones_like.py
+++ b/numba_dpex/tests/dpjit_tests/dpnp/test_dpnp_ones_like.py
@@ -16,7 +16,7 @@ from numba_dpex import dpjit
 shapes = [11, (3, 7)]
 dtypes = [dpnp.int32, dpnp.int64, dpnp.float32, dpnp.float64]
 usm_types = ["device", "shared", "host"]
-devices = ["cpu", "unknown"]
+devices = ["cpu", "gpu", None]
 
 
 @pytest.mark.parametrize("shape", shapes)
@@ -46,7 +46,7 @@ def test_dpnp_ones_like(shape, dtype, usm_type, device):
 
     assert c.dtype == dtype
     assert c.usm_type == usm_type
-    if device != "unknown":
+    if device is not None:
         assert (
             c.sycl_device.filter_string
             == dpctl.SyclDevice(device).filter_string
@@ -77,15 +77,12 @@ def test_dpnp_ones_like_exceptions():
     queue = dpctl.SyclQueue()
 
     @dpjit
-    def func2(a):
-        c = dpnp.ones_like(a, sycl_queue=queue)
+    def func2(a, q):
+        c = dpnp.ones_like(a, sycl_queue=q, device="cpu")
         return c
 
     try:
-        func2(numpy.random.rand(5, 5))
+        func2(numpy.random.rand(5, 5), queue)
     except Exception as e:
         assert isinstance(e, errors.TypingError)
-        assert (
-            "No implementation of function Function(<function ones_like"
-            in str(e)
-        )
+        assert "`device` and `sycl_queue` are exclusive keywords" in str(e)

--- a/numba_dpex/tests/dpjit_tests/dpnp/test_dpnp_ones_like.py
+++ b/numba_dpex/tests/dpjit_tests/dpnp/test_dpnp_ones_like.py
@@ -16,7 +16,7 @@ from numba_dpex import dpjit
 shapes = [11, (3, 7)]
 dtypes = [dpnp.int32, dpnp.int64, dpnp.float32, dpnp.float64]
 usm_types = ["device", "shared", "host"]
-devices = ["cpu", "gpu", None]
+devices = ["cpu", None]
 
 
 @pytest.mark.parametrize("shape", shapes)

--- a/numba_dpex/tests/dpjit_tests/dpnp/test_dpnp_zeros.py
+++ b/numba_dpex/tests/dpjit_tests/dpnp/test_dpnp_zeros.py
@@ -15,7 +15,7 @@ from numba_dpex import dpjit
 shapes = [11, (3, 7)]
 dtypes = [dpnp.int32, dpnp.int64, dpnp.float32, dpnp.float64]
 usm_types = ["device", "shared", "host"]
-devices = ["cpu", "gpu", None]
+devices = ["cpu", None]
 
 
 @pytest.mark.parametrize("shape", shapes)

--- a/numba_dpex/tests/dpjit_tests/dpnp/test_dpnp_zeros.py
+++ b/numba_dpex/tests/dpjit_tests/dpnp/test_dpnp_zeros.py
@@ -15,7 +15,7 @@ from numba_dpex import dpjit
 shapes = [11, (3, 7)]
 dtypes = [dpnp.int32, dpnp.int64, dpnp.float32, dpnp.float64]
 usm_types = ["device", "shared", "host"]
-devices = ["cpu", "unknown"]
+devices = ["cpu", "gpu", None]
 
 
 @pytest.mark.parametrize("shape", shapes)
@@ -42,7 +42,7 @@ def test_dpnp_zeros(shape, dtype, usm_type, device):
 
     assert c.dtype == dtype
     assert c.usm_type == usm_type
-    if device != "unknown":
+    if device is not None:
         assert (
             c.sycl_device.filter_string
             == dpctl.SyclDevice(device).filter_string

--- a/numba_dpex/tests/dpjit_tests/dpnp/test_dpnp_zeros_like.py
+++ b/numba_dpex/tests/dpjit_tests/dpnp/test_dpnp_zeros_like.py
@@ -16,7 +16,7 @@ from numba_dpex import dpjit
 shapes = [11, (3, 7)]
 dtypes = [dpnp.int32, dpnp.int64, dpnp.float32, dpnp.float64]
 usm_types = ["device", "shared", "host"]
-devices = ["cpu", "gpu", None]
+devices = ["cpu", None]
 
 
 @pytest.mark.parametrize("shape", shapes)

--- a/numba_dpex/tests/types/USMNdArray/test_array_creation_errors.py
+++ b/numba_dpex/tests/types/USMNdArray/test_array_creation_errors.py
@@ -24,13 +24,13 @@ def test_init():
     assert usma.usm_type == "device"
     assert str(usma.queue.sycl_device.device_type) == "device_type.cpu"
 
-    usma = USMNdArray(1, device="gpu", queue=None)
-    assert usma.dtype.name == "float64"
-    assert usma.ndim == 1
-    assert usma.layout == "C"
-    assert usma.addrspace == 1
-    assert usma.usm_type == "device"
-    assert str(usma.queue.sycl_device.device_type) == "device_type.gpu"
+    # usma = USMNdArray(1, device="gpu", queue=None)
+    # assert usma.dtype.name == "float64"
+    # assert usma.ndim == 1
+    # assert usma.layout == "C"
+    # assert usma.addrspace == 1
+    # assert usma.usm_type == "device"
+    # assert str(usma.queue.sycl_device.device_type) == "device_type.gpu"
 
     queue = dpctl.SyclQueue()
     usma = USMNdArray(1, device=None, queue=queue)

--- a/numba_dpex/tests/types/USMNdArray/test_exceptions.py
+++ b/numba_dpex/tests/types/USMNdArray/test_exceptions.py
@@ -1,0 +1,57 @@
+import dpctl
+from numba.core.types.scalars import Float
+
+from numba_dpex.core.types import USMNdArray
+
+
+def test_init():
+    usma = USMNdArray(1, device=None, queue=None)
+    assert usma.dtype.name == "float64"
+    assert usma.ndim == 1
+    assert usma.layout == "C"
+    assert usma.addrspace == 1
+    assert usma.usm_type == "device"
+    assert (
+        str(usma.queue.sycl_device.device_type) == "device_type.cpu"
+        or str(usma.queue.sycl_device.device_type) == "device_type.gpu"
+    )
+
+    usma = USMNdArray(1, device="cpu", queue=None)
+    assert usma.dtype.name == "float64"
+    assert usma.ndim == 1
+    assert usma.layout == "C"
+    assert usma.addrspace == 1
+    assert usma.usm_type == "device"
+    assert str(usma.queue.sycl_device.device_type) == "device_type.cpu"
+
+    usma = USMNdArray(1, device="gpu", queue=None)
+    assert usma.dtype.name == "float64"
+    assert usma.ndim == 1
+    assert usma.layout == "C"
+    assert usma.addrspace == 1
+    assert usma.usm_type == "device"
+    assert str(usma.queue.sycl_device.device_type) == "device_type.gpu"
+
+    queue = dpctl.SyclQueue()
+    usma = USMNdArray(1, device=None, queue=queue)
+    assert usma.dtype.name == "float64"
+    assert usma.ndim == 1
+    assert usma.layout == "C"
+    assert usma.addrspace == 1
+    assert usma.usm_type == "device"
+    assert usma.queue.addressof_ref() > 0
+
+    try:
+        usma = USMNdArray(1, device="cpu", queue=queue)
+    except Exception as e:
+        assert "exclusive keywords" in str(e)
+
+    try:
+        usma = USMNdArray(1, queue=0)
+    except Exception as e:
+        assert "queue keyword arg" in str(e)
+
+    try:
+        usma = USMNdArray(1, device=0)
+    except Exception as e:
+        assert "SYCL filter selector" in str(e)


### PR DESCRIPTION
- This is PR enables `dpctl.SyclQueue` for `USMNdArray` in `dpnp` overloads. 
- This PR does not pass SYCL queue to the functions in `numba_depx/core/runtime/_dpexrt_python.c` (yet).
- Since this PR, we won't have `"unknown"` as a default device string anymore, we will use `None` instead, when there is no need to specify the device type.


    - [x] Have you provided a meaningful PR description?
    - [x] Have you added a test, reproducer or referred to an issue with a reproducer?
    - [x] Have you tested your changes locally for CPU and GPU devices?
    - [x] Have you made sure that new changes do not introduce compiler warnings?
    - [ ] If this PR is a work in progress, are you filing the PR as a draft?
