### PR TITLE
Change the order of channels in coverage's environment yaml

### DIFF
--- a/environment/coverage.yml
+++ b/environment/coverage.yml
@@ -1,19 +1,20 @@
 name: dev
 channels:
-  - defaults
   - dppy/label/dev
   - numba
   - intel
   - numba/label/dev
+  - pkgs/main
   - nodefaults
 dependencies:
   - python=3.9
+  - defaults:libffi
   - gxx_linux-64
   - dpcpp_linux-64
   - cython
   - numba 0.56*
-  - dpctl >=0.14*
-  - dpnp >=0.10.2
+  - dppy/label/dev:dpctl
+  - dppy/label/dev:dpnp
   - spirv-tools
   - dpcpp-llvm-spirv
   - packaging


### PR DESCRIPTION
Changes the order in which channels are searched when installing packages for the coverage workflow. The change should allow us to get latest dpctl and dpnp packages from `dppy/label/dev`