### PR TITLE
[WIP] Use the DpexTargetContext inside dpjit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ numba_dpex/dpnp_iface/*.h
 .coverage
 coverage.xml
 htmlcov/
+.numba_config.yaml

--- a/driver.py
+++ b/driver.py
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests for checking enforcing CFD in parfor pass.
+"""
+
+import dpnp
+
+import numba_dpex as dpex
+
+
+@dpex.dpjit
+def f(a, b):
+    for i in dpex.prange(4):
+        b[i, 0] = a[i, 0] * 10
+    return
+
+
+@dpex.dpjit
+def g(a):
+    c = dpnp.empty(a.shape, dtype=a.dtype)
+    return c
+
+
+m = 8
+n = 8
+a = dpnp.ones((m, n))
+b = dpnp.ones((m, n))
+
+f(a, b)
+
+print(b)
+
+c = g(b)
+print(c)

--- a/numba_dpex/core/dpjit_dispatcher.py
+++ b/numba_dpex/core/dpjit_dispatcher.py
@@ -17,6 +17,9 @@ class DpjitDispatcher(dispatcher.Dispatcher):
     Dispatcher can lookup the global target_registry with that string and
     correctly use the DpexTarget context.
 
+    In addition, the dispatcher uses the `target_override` feature to set the
+    target to dpex for every use of dpjit.
+
     """
 
     targetdescr = dpex_target
@@ -29,14 +32,17 @@ class DpjitDispatcher(dispatcher.Dispatcher):
         impl_kind="direct",
         pipeline_class=compiler.Compiler,
     ):
-        dispatcher.Dispatcher.__init__(
-            self,
-            py_func,
-            locals=locals,
-            targetoptions=targetoptions,
-            impl_kind=impl_kind,
-            pipeline_class=pipeline_class,
-        )
+        from numba.core.target_extension import target_override
+
+        with target_override("dpex"):
+            dispatcher.Dispatcher.__init__(
+                self,
+                py_func,
+                locals=locals,
+                targetoptions=targetoptions,
+                impl_kind=impl_kind,
+                pipeline_class=pipeline_class,
+            )
 
 
 dispatcher_registry[target_registry[DPEX_TARGET_NAME]] = DpjitDispatcher

--- a/numba_dpex/core/passes/__init__.py
+++ b/numba_dpex/core/passes/__init__.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from .parfor_legalize_cfd_pass import ParforLegalizeCFDPass
+from .parfor_passes import PreParforPass
 from .passes import DumpParforDiagnostics, NoPythonBackend
 
 __all__ = [

--- a/numba_dpex/core/passes/parfor_passes.py
+++ b/numba_dpex/core/passes/parfor_passes.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+
+from numba.core.compiler_machinery import register_pass
+from numba.core.target_extension import target_override
+from numba.core.typed_passes import PreParforPass
+
+
+@register_pass(mutates_CFG=True, analysis_only=False)
+class PreParforPass(PreParforPass):
+    """
+    A wrapper around Numba's PreParforPass that runs the pass inside a
+    dpex target context.
+
+    The target_override context manager ensures that any function that is
+    compiled inside the Numba PreParforPass uses the DpexTargetContext.
+    """
+
+    _name = "dpex_pre_parfor_pass"
+
+    def run_pass(self, state):
+        with target_override("dpex"):
+            super().run_pass(state)
+
+        return True

--- a/numba_dpex/core/pipelines/dpjit_compiler.py
+++ b/numba_dpex/core/pipelines/dpjit_compiler.py
@@ -16,7 +16,6 @@ from numba.core.typed_passes import (
     ParforPass,
     ParforPreLoweringPass,
     PreLowerStripPhis,
-    PreParforPass,
 )
 
 from numba_dpex.core.exceptions import UnsupportedCompilationModeError
@@ -24,6 +23,7 @@ from numba_dpex.core.passes import (
     DumpParforDiagnostics,
     NoPythonBackend,
     ParforLegalizeCFDPass,
+    PreParforPass,
 )
 from numba_dpex.parfor_diagnostics import ExtendedParforDiagnostics
 

--- a/numba_dpex/core/targets/dpjit_target.py
+++ b/numba_dpex/core/targets/dpjit_target.py
@@ -38,8 +38,6 @@ class DpexTargetContext(CPUContext):
         self.is32bit = utils.MACHINE_BITS == 32
         self._internal_codegen = JITCPUCodegen("numba.exec")
         self.lower_extensions = {}
-        # Initialize NRT runtime
-        # rtsys.initialize(self)
         self.refresh()
 
     @cached_property

--- a/numba_dpex/decorators.py
+++ b/numba_dpex/decorators.py
@@ -142,6 +142,7 @@ def dpjit(*args, **kws):
         warnings.warn(
             "nopython is set for dpjit and is ignored", RuntimeWarning
         )
+        del kws["nopython"]
     if "forceobj" in kws:
         warnings.warn(
             "forceobj is set for dpjit and is ignored", RuntimeWarning
@@ -151,15 +152,12 @@ def dpjit(*args, **kws):
         warnings.warn(
             "pipeline class is set for dpjit and is ignored", RuntimeWarning
         )
-        del kws["forceobj"]
+        del kws["pipeline_class"]
     kws.update({"nopython": True})
     kws.update({"parallel": True})
     kws.update({"pipeline_class": DpjitCompiler})
 
-    # FIXME: When trying to use dpex's target context, overloads do not work
-    # properly. We will turn on dpex target once the issue is fixed.
-
-    # kws.update({"_target": "dpex"})
+    kws.update({"_target": "dpex"})
 
     return decorators.jit(*args, **kws)
 

--- a/numba_dpex/dpnp_iface/_intrinsic.py
+++ b/numba_dpex/dpnp_iface/_intrinsic.py
@@ -321,7 +321,7 @@ def _call_usm_allocator(arrtype, size, usm_type, queue):
 numba_config.DISABLE_PERFORMANCE_WARNINGS = 1
 
 
-@intrinsic
+@intrinsic(target="dpex")
 def intrin_usm_alloc(typingctx, allocsize, usm_type, queue):
     """Intrinsic to call into the allocator for Array"""
 
@@ -420,7 +420,7 @@ def fill_arrayobj(context, builder, ary, arrtype, queue_ref, fill_value):
     return ary, arrtype
 
 
-@intrinsic
+@intrinsic(target="dpex")
 def impl_dpnp_empty(
     ty_context,
     ty_shape,
@@ -493,7 +493,7 @@ def impl_dpnp_empty(
     return sig, codegen
 
 
-@intrinsic
+@intrinsic(target="dpex")
 def impl_dpnp_zeros(
     ty_context,
     ty_shape,
@@ -572,7 +572,7 @@ def impl_dpnp_zeros(
     return sig, codegen
 
 
-@intrinsic
+@intrinsic(target="dpex")
 def impl_dpnp_ones(
     ty_context,
     ty_shape,
@@ -652,7 +652,7 @@ def impl_dpnp_ones(
     return sig, codegen
 
 
-@intrinsic
+@intrinsic(target="dpex")
 def impl_dpnp_full(
     ty_context,
     ty_shape,
@@ -738,7 +738,7 @@ def impl_dpnp_full(
     return signature, codegen
 
 
-@intrinsic
+@intrinsic(target="dpex")
 def impl_dpnp_empty_like(
     ty_context,
     ty_x1,
@@ -820,7 +820,7 @@ def impl_dpnp_empty_like(
     return sig, codegen
 
 
-@intrinsic
+@intrinsic(target="dpex")
 def impl_dpnp_zeros_like(
     ty_context,
     ty_x1,
@@ -910,7 +910,7 @@ def impl_dpnp_zeros_like(
     return sig, codegen
 
 
-@intrinsic
+@intrinsic(target="dpex")
 def impl_dpnp_ones_like(
     ty_context,
     ty_x1,
@@ -999,7 +999,7 @@ def impl_dpnp_ones_like(
     return sig, codegen
 
 
-@intrinsic
+@intrinsic(target="dpex")
 def impl_dpnp_full_like(
     ty_context,
     ty_x1,

--- a/numba_dpex/dpnp_iface/arrayobj.py
+++ b/numba_dpex/dpnp_iface/arrayobj.py
@@ -161,9 +161,7 @@ def _parse_device_filter_string(device):
 # =========================================================================
 #                       Dpnp array constructor overloads
 # =========================================================================
-
-
-@overload(dpnp.empty, prefer_literal=True)
+@overload(dpnp.empty, prefer_literal=True, target="dpex")
 def ol_dpnp_empty(
     shape,
     dtype=None,
@@ -260,7 +258,7 @@ def ol_dpnp_empty(
         raise errors.TypingError("Could not infer the rank of the ndarray.")
 
 
-@overload(dpnp.zeros, prefer_literal=True)
+@overload(dpnp.zeros, prefer_literal=True, target="dpex")
 def ol_dpnp_zeros(
     shape,
     dtype=None,
@@ -354,7 +352,7 @@ def ol_dpnp_zeros(
         raise errors.TypingError("Could not infer the rank of the ndarray.")
 
 
-@overload(dpnp.ones, prefer_literal=True)
+@overload(dpnp.ones, prefer_literal=True, target="dpex")
 def ol_dpnp_ones(
     shape,
     dtype=None,
@@ -448,7 +446,7 @@ def ol_dpnp_ones(
         raise errors.TypingError("Could not infer the rank of the ndarray.")
 
 
-@overload(dpnp.full, prefer_literal=True)
+@overload(dpnp.full, prefer_literal=True, target="dpex")
 def ol_dpnp_full(
     shape,
     fill_value,
@@ -557,7 +555,7 @@ def ol_dpnp_full(
         raise errors.TypingError("Could not infer the rank of the ndarray.")
 
 
-@overload(dpnp.empty_like, prefer_literal=True)
+@overload(dpnp.empty_like, prefer_literal=True, target="dpex")
 def ol_dpnp_empty_like(
     x1,
     dtype=None,
@@ -682,7 +680,7 @@ def ol_dpnp_empty_like(
         )
 
 
-@overload(dpnp.zeros_like, prefer_literal=True)
+@overload(dpnp.zeros_like, prefer_literal=True, target="dpex")
 def ol_dpnp_zeros_like(
     x1,
     dtype=None,
@@ -806,7 +804,7 @@ def ol_dpnp_zeros_like(
         )
 
 
-@overload(dpnp.ones_like, prefer_literal=True)
+@overload(dpnp.ones_like, prefer_literal=True, target="dpex")
 def ol_dpnp_ones_like(
     x1,
     dtype=None,
@@ -931,7 +929,7 @@ def ol_dpnp_ones_like(
         )
 
 
-@overload(dpnp.full_like, prefer_literal=True)
+@overload(dpnp.full_like, prefer_literal=True, target="dpex")
 def ol_dpnp_full_like(
     x1,
     fill_value,


### PR DESCRIPTION
- [X] Have you provided a meaningful PR description?

The PR is a draft for the set of changes to ensure that numba_dpex.dpjit uses its own target that is isolated from Numba's
CPUTarget. The goal of the PR is to ensure numba-dpex does not have unintended side effects on Numba, and also free numba-dpex to implement custom dispatch, caching, function registry support.

- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?

- [ ] Have you tested your changes locally for CPU and GPU devices?
As yet minimally.
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [X] If this PR is a work in progress, are you filing the PR as a draft?'

Fixes #1024 
