### PR TITLE
Directly invoke pytest in package build workflow.

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -139,7 +139,7 @@ jobs:
           source $CONDA/etc/profile.d/conda.sh
           conda activate numba_dpex_env
           # echo "libintelocl.so" | tee /etc/OpenCL/vendors/intel-cpu.icd
-          python -m pytest -q -ra --disable-warnings --pyargs $MODULE_NAME -vv
+          pytest -q -ra --disable-warnings --pyargs $MODULE_NAME -vv
       - name: Run examples
         run: |
           ls
@@ -209,7 +209,7 @@ jobs:
             ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-
       - name: Install numba-dpex
         run: |
-          conda install ${{ env.PACKAGE_NAME }} pytest dpcpp_win-64 dpcpp-llvm-spirv python=${{ matrix.python }} dpctl ${{ matrix.dependencies }} -c $env:GITHUB_WORKSPACE/channel ${{ env.CHANNELS }}
+          conda install ${{ env.PACKAGE_NAME }} pytest dpcpp_win-64 dpcpp-llvm-spirv python=${{ matrix.python }} dpctl -c $env:GITHUB_WORKSPACE/channel ${{ env.CHANNELS }}
           # Test installed packages
           conda list
       - name: Install opencl_rt
@@ -232,7 +232,7 @@ jobs:
         run: python -c "import dpcpp_llvm_spirv as p; print(p.get_llvm_spirv_path())"
       - name: Run tests
         run: |
-          python -m pytest -q -ra --disable-warnings --pyargs ${{ env.MODULE_NAME }} -vv
+          pytest -q -ra --disable-warnings --pyargs ${{ env.MODULE_NAME }} -vv
 
   upload_linux:
     needs: test_linux


### PR DESCRIPTION
Changes how pytest is invoked in the test_linux and test_windows workflows. using `python -m pytest` leads to directories that do not have `__init__.py` in them getting skipped. The difference in invocation was the cause we see different results in coverage v/s test package workflows.
