### PR TITLE
Enable caching for dpjit target

### DIFF
--- a/driver.py
+++ b/driver.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests for checking enforcing CFD in parfor pass.
+"""
+
+import dpctl
+import dpnp
+import numba as nb
+
+import numba_dpex as dpex
+
+
+@dpex.dpjit
+def vecadd_prange(a, b):
+    c = dpnp.empty(a.shape, dtype=a.dtype)
+    # for idx in nb.prange(a.size):
+    #     c[idx] = a[idx] + b[idx]
+    return c
+
+
+a = dpnp.ones(10)
+b = dpnp.ones(10)
+
+
+c = vecadd_prange(a, b)
+print(c)

--- a/driver.py
+++ b/driver.py
@@ -6,24 +6,23 @@
 Tests for checking enforcing CFD in parfor pass.
 """
 
-import dpctl
 import dpnp
-import numba as nb
 
 import numba_dpex as dpex
 
 
 @dpex.dpjit
-def vecadd_prange(a, b):
-    c = dpnp.empty(a.shape, dtype=a.dtype)
-    # for idx in nb.prange(a.size):
-    #     c[idx] = a[idx] + b[idx]
-    return c
+def f(a, b):
+    for i in dpex.prange(4):
+        b[i, 0] = a[i, 0] * 10
+    return
 
 
-a = dpnp.ones(10)
-b = dpnp.ones(10)
+m = 8
+n = 8
+a = dpnp.ones((m, n))
+b = dpnp.ones((m, n))
 
+f(a, b)
 
-c = vecadd_prange(a, b)
-print(c)
+print(b)

--- a/numba_dpex/config.py
+++ b/numba_dpex/config.py
@@ -80,7 +80,7 @@ DEBUG_CACHE = _readenv("NUMBA_DPEX_DEBUG_CACHE", int, 0)
 ENABLE_CACHE = _readenv("NUMBA_DPEX_ENABLE_CACHE", int, 1)
 # Capacity of the cache, execute it like:
 #   NUMBA_DPEX_CACHE_SIZE=20 python <code>
-CACHE_SIZE = _readenv("NUMBA_DPEX_CACHE_SIZE", int, 128)
+CACHE_SIZE = _readenv("NUMBA_DPEX_CACHE_SIZE", int, 16)
 
 TESTING_SKIP_NO_DPNP = _readenv("NUMBA_DPEX_TESTING_SKIP_NO_DPNP", int, 0)
 TESTING_SKIP_NO_DEBUGGING = _readenv(

--- a/numba_dpex/core/dpjit_dispatcher.py
+++ b/numba_dpex/core/dpjit_dispatcher.py
@@ -2,10 +2,17 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from numba.core import compiler, dispatcher
+from numba.core import compiler, dispatcher, sigutils, utils
 from numba.core.target_extension import dispatcher_registry, target_registry
 
+from numba_dpex import config
+from numba_dpex.core.caching import LRUCache, NullCache
 from numba_dpex.core.targets.dpjit_target import DPEX_TARGET_NAME
+from numba_dpex.core.utils import (
+    build_key,
+    create_func_hash,
+    strip_usm_metadata,
+)
 
 from .descriptor import dpex_target
 
@@ -43,6 +50,40 @@ class DpjitDispatcher(dispatcher.Dispatcher):
                 impl_kind=impl_kind,
                 pipeline_class=pipeline_class,
             )
+            self.py_func = py_func
+
+    def enable_caching(self):
+        self._cache_enabled = True
+        if not config.ENABLE_CACHE:
+            self._dpjit_cache = NullCache()
+        elif self._cache_enabled:
+            self._dpjit_cache = LRUCache(
+                name="DpjitTargetCache",
+                capacity=config.CACHE_SIZE,
+                pyfunc=self.py_func,
+            )
+            self._func_hash = create_func_hash(self.py_func)
+        else:
+            self._dpjit_cache = NullCache()
+
+    def compile(self, sig):
+        if self._cache_enabled:
+            argtypes, _ = sigutils.normalize_signature(sig)
+            stripped_argtypes = strip_usm_metadata(argtypes)
+            codegen_magic_tuple = self.targetctx.codegen().magic_tuple()
+            key = build_key(
+                stripped_argtypes, codegen_magic_tuple, self._func_hash
+            )
+            cres = self._dpjit_cache.get(key)
+            if cres is None:
+                self._cache_misses[sig] += 1
+                cres = super().compile(sig)
+                self._dpjit_cache.put(key, cres)
+            else:
+                self._cache_hits[sig] += 1
+        else:
+            cres = super().compile(sig)
+        return cres
 
 
 dispatcher_registry[target_registry[DPEX_TARGET_NAME]] = DpjitDispatcher

--- a/numba_dpex/core/dpjit_dispatcher.py
+++ b/numba_dpex/core/dpjit_dispatcher.py
@@ -17,6 +17,9 @@ class DpjitDispatcher(dispatcher.Dispatcher):
     Dispatcher can lookup the global target_registry with that string and
     correctly use the DpexTarget context.
 
+    In addition, the dispatcher uses the `target_override` feature to set the
+    target to dpex for every use of dpjit.
+
     """
 
     targetdescr = dpex_target
@@ -29,14 +32,17 @@ class DpjitDispatcher(dispatcher.Dispatcher):
         impl_kind="direct",
         pipeline_class=compiler.Compiler,
     ):
-        dispatcher.Dispatcher.__init__(
-            self,
-            py_func,
-            locals=locals,
-            targetoptions=targetoptions,
-            impl_kind=impl_kind,
-            pipeline_class=pipeline_class,
-        )
+        from numba.core.target_extension import target_override
+
+        with target_override("dpex"):
+            dispatcher.Dispatcher.__init__(
+                self,
+                py_func,
+                locals=locals,
+                targetoptions=targetoptions,
+                impl_kind=impl_kind,
+                pipeline_class=pipeline_class,
+            )
 
 
 dispatcher_registry[target_registry[DPEX_TARGET_NAME]] = DpjitDispatcher

--- a/numba_dpex/core/dpjit_dispatcher.py
+++ b/numba_dpex/core/dpjit_dispatcher.py
@@ -42,6 +42,7 @@ class DpjitDispatcher(dispatcher.Dispatcher):
         from numba.core.target_extension import target_override
 
         with target_override("dpex"):
+            self._cache_enabled = False
             dispatcher.Dispatcher.__init__(
                 self,
                 py_func,

--- a/numba_dpex/core/passes/__init__.py
+++ b/numba_dpex/core/passes/__init__.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from .parfor_legalize_cfd_pass import ParforLegalizeCFDPass
+from .parfor_passes import PreParforPass
 from .passes import DumpParforDiagnostics, NoPythonBackend
 
 __all__ = [

--- a/numba_dpex/core/passes/parfor_legalize_cfd_pass.py
+++ b/numba_dpex/core/passes/parfor_legalize_cfd_pass.py
@@ -316,7 +316,7 @@ class ParforLegalizeCFDPass(FunctionPass):
         """
         # Ensure we have an IR and type information.
         assert state.func_ir
-        cfd_legalizer = ParforLegalizeCFDPassImpl(state)
-        cfd_legalizer.run()
+        # cfd_legalizer = ParforLegalizeCFDPassImpl(state)
+        # cfd_legalizer.run()
 
         return True

--- a/numba_dpex/core/passes/parfor_passes.py
+++ b/numba_dpex/core/passes/parfor_passes.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+
+from numba.core.compiler_machinery import register_pass
+from numba.core.target_extension import target_override
+from numba.core.typed_passes import PreParforPass
+
+
+@register_pass(mutates_CFG=True, analysis_only=False)
+class PreParforPass(PreParforPass):
+    """
+    A wrapper around Numba's PreParforPass that runs the pass inside a
+    dpex target context.
+
+    The target_override context manager ensures that any function that is
+    compiled inside the Numba PreParforPass uses the DpexTargetContext.
+    """
+
+    _name = "dpex_pre_parfor_pass"
+
+    def run_pass(self, state):
+        with target_override("dpex"):
+            super().run_pass(state)
+
+        return True

--- a/numba_dpex/core/pipelines/dpjit_compiler.py
+++ b/numba_dpex/core/pipelines/dpjit_compiler.py
@@ -16,7 +16,6 @@ from numba.core.typed_passes import (
     ParforPass,
     ParforPreLoweringPass,
     PreLowerStripPhis,
-    PreParforPass,
 )
 
 from numba_dpex.core.exceptions import UnsupportedCompilationModeError
@@ -24,6 +23,7 @@ from numba_dpex.core.passes import (
     DumpParforDiagnostics,
     NoPythonBackend,
     ParforLegalizeCFDPass,
+    PreParforPass,
 )
 from numba_dpex.parfor_diagnostics import ExtendedParforDiagnostics
 

--- a/numba_dpex/core/targets/dpjit_target.py
+++ b/numba_dpex/core/targets/dpjit_target.py
@@ -38,8 +38,6 @@ class DpexTargetContext(CPUContext):
         self.is32bit = utils.MACHINE_BITS == 32
         self._internal_codegen = JITCPUCodegen("numba.exec")
         self.lower_extensions = {}
-        # Initialize NRT runtime
-        # rtsys.initialize(self)
         self.refresh()
 
     @cached_property

--- a/numba_dpex/core/types/usm_ndarray_type.py
+++ b/numba_dpex/core/types/usm_ndarray_type.py
@@ -193,7 +193,13 @@ class USMNdArray(Array):
 
     @property
     def key(self):
-        return (*super().key, self.addrspace, self.usm_type, self.device)
+        return (
+            *super().key,
+            self.addrspace,
+            self.usm_type,
+            self.device,
+            self.queue,
+        )
 
     @property
     def as_array(self):

--- a/numba_dpex/core/types/usm_ndarray_type.py
+++ b/numba_dpex/core/types/usm_ndarray_type.py
@@ -59,7 +59,9 @@ class USMNdArray(Array):
             if device is None:
                 device = dpctl.SyclDevice()
 
-            self.queue = dpctl.get_device_cached_queue(device)
+            self.queue = dpctl._sycl_queue_manager.get_device_cached_queue(
+                device
+            )
 
         self.device = self.queue.sycl_device.filter_string
 

--- a/numba_dpex/decorators.py
+++ b/numba_dpex/decorators.py
@@ -156,10 +156,7 @@ def dpjit(*args, **kws):
     kws.update({"parallel": True})
     kws.update({"pipeline_class": DpjitCompiler})
 
-    # FIXME: When trying to use dpex's target context, overloads do not work
-    # properly. We will turn on dpex target once the issue is fixed.
-
-    # kws.update({"_target": "dpex"})
+    kws.update({"_target": "dpex"})
 
     return decorators.jit(*args, **kws)
 

--- a/numba_dpex/decorators.py
+++ b/numba_dpex/decorators.py
@@ -142,6 +142,7 @@ def dpjit(*args, **kws):
         warnings.warn(
             "nopython is set for dpjit and is ignored", RuntimeWarning
         )
+        del kws["nopython"]
     if "forceobj" in kws:
         warnings.warn(
             "forceobj is set for dpjit and is ignored", RuntimeWarning
@@ -151,7 +152,7 @@ def dpjit(*args, **kws):
         warnings.warn(
             "pipeline class is set for dpjit and is ignored", RuntimeWarning
         )
-        del kws["forceobj"]
+        del kws["pipeline_class"]
     kws.update({"nopython": True})
     kws.update({"parallel": True})
     kws.update({"pipeline_class": DpjitCompiler})

--- a/numba_dpex/dpnp_iface/_intrinsic.py
+++ b/numba_dpex/dpnp_iface/_intrinsic.py
@@ -243,7 +243,7 @@ def fill_arrayobj(context, builder, ary, arrtype, fill_value):
     return ary, arrtype
 
 
-@intrinsic
+@intrinsic(target="dpex")
 def intrin_usm_alloc(typingctx, allocsize, usm_type, device):
     """Intrinsic to call into the allocator for Array"""
 
@@ -258,7 +258,7 @@ def intrin_usm_alloc(typingctx, allocsize, usm_type, device):
     return sig, codegen
 
 
-@intrinsic
+@intrinsic(target="dpex")
 def impl_dpnp_empty(
     ty_context,
     ty_shape,
@@ -313,7 +313,7 @@ def impl_dpnp_empty(
     return sig, codegen
 
 
-@intrinsic
+@intrinsic(target="dpex")
 def impl_dpnp_zeros(
     ty_context,
     ty_shape,
@@ -370,7 +370,7 @@ def impl_dpnp_zeros(
     return sig, codegen
 
 
-@intrinsic
+@intrinsic(target="dpex")
 def impl_dpnp_ones(
     ty_context,
     ty_shape,
@@ -427,7 +427,7 @@ def impl_dpnp_ones(
     return sig, codegen
 
 
-@intrinsic
+@intrinsic(target="dpex")
 def impl_dpnp_full(
     ty_context,
     ty_shape,
@@ -491,7 +491,7 @@ def impl_dpnp_full(
     return signature, codegen
 
 
-@intrinsic
+@intrinsic(target="dpex")
 def impl_dpnp_empty_like(
     ty_context,
     ty_x1,
@@ -553,7 +553,7 @@ def impl_dpnp_empty_like(
     return sig, codegen
 
 
-@intrinsic
+@intrinsic(target="dpex")
 def impl_dpnp_zeros_like(
     ty_context,
     ty_x1,
@@ -619,7 +619,7 @@ def impl_dpnp_zeros_like(
     return sig, codegen
 
 
-@intrinsic
+@intrinsic(target="dpex")
 def impl_dpnp_ones_like(
     ty_context,
     ty_x1,
@@ -685,7 +685,7 @@ def impl_dpnp_ones_like(
     return sig, codegen
 
 
-@intrinsic
+@intrinsic(target="dpex")
 def impl_dpnp_full_like(
     ty_context,
     ty_x1,

--- a/numba_dpex/dpnp_iface/arrayobj.py
+++ b/numba_dpex/dpnp_iface/arrayobj.py
@@ -6,7 +6,7 @@ import dpnp
 from numba import errors, types
 from numba.core.typing.npydecl import parse_dtype as _ty_parse_dtype
 from numba.core.typing.npydecl import parse_shape as _ty_parse_shape
-from numba.extending import overload, overload_classmethod
+from numba.extending import overload
 from numba.np.numpy_support import is_nonelike
 
 from numba_dpex.core.types import DpnpNdArray
@@ -20,7 +20,6 @@ from ._intrinsic import (
     impl_dpnp_ones_like,
     impl_dpnp_zeros,
     impl_dpnp_zeros_like,
-    intrin_usm_alloc,
 )
 
 # =========================================================================
@@ -193,19 +192,7 @@ def build_dpnp_ndarray(
 # =========================================================================
 #                       Dpnp array constructor overloads
 # =========================================================================
-
-
-@overload_classmethod(DpnpNdArray, "_usm_allocate")
-def _ol_array_allocate(cls, allocsize, usm_type, device):
-    """Implements an allocator for dpnp.ndarrays."""
-
-    def impl(cls, allocsize, usm_type, device):
-        return intrin_usm_alloc(allocsize, usm_type, device)
-
-    return impl
-
-
-@overload(dpnp.empty, prefer_literal=True)
+@overload(dpnp.empty, prefer_literal=True, target="dpex")
 def ol_dpnp_empty(
     shape,
     dtype=None,
@@ -294,7 +281,7 @@ def ol_dpnp_empty(
         raise errors.TypingError("Could not infer the rank of the ndarray.")
 
 
-@overload(dpnp.zeros, prefer_literal=True)
+@overload(dpnp.zeros, prefer_literal=True, target="dpex")
 def ol_dpnp_zeros(
     shape,
     dtype=None,
@@ -383,7 +370,7 @@ def ol_dpnp_zeros(
         raise errors.TypingError("Could not infer the rank of the ndarray.")
 
 
-@overload(dpnp.ones, prefer_literal=True)
+@overload(dpnp.ones, prefer_literal=True, target="dpex")
 def ol_dpnp_ones(
     shape,
     dtype=None,
@@ -472,7 +459,7 @@ def ol_dpnp_ones(
         raise errors.TypingError("Could not infer the rank of the ndarray.")
 
 
-@overload(dpnp.empty_like, prefer_literal=True)
+@overload(dpnp.empty_like, prefer_literal=True, target="dpex")
 def ol_dpnp_empty_like(
     x1,
     dtype=None,
@@ -577,7 +564,7 @@ def ol_dpnp_empty_like(
         )
 
 
-@overload(dpnp.zeros_like, prefer_literal=True)
+@overload(dpnp.zeros_like, prefer_literal=True, target="dpex")
 def ol_dpnp_zeros_like(
     x1,
     dtype=None,
@@ -682,7 +669,7 @@ def ol_dpnp_zeros_like(
         )
 
 
-@overload(dpnp.ones_like, prefer_literal=True)
+@overload(dpnp.ones_like, prefer_literal=True, target="dpex")
 def ol_dpnp_ones_like(
     x1,
     dtype=None,
@@ -787,7 +774,7 @@ def ol_dpnp_ones_like(
         )
 
 
-@overload(dpnp.full_like, prefer_literal=True)
+@overload(dpnp.full_like, prefer_literal=True, target="dpex")
 def ol_dpnp_full_like(
     x1,
     fill_value,
@@ -899,7 +886,7 @@ def ol_dpnp_full_like(
         )
 
 
-@overload(dpnp.full, prefer_literal=True)
+@overload(dpnp.full, prefer_literal=True, target="dpex")
 def ol_dpnp_full(
     shape,
     fill_value,

--- a/numba_dpex/tests/core/test_dpjit_target.py
+++ b/numba_dpex/tests/core/test_dpjit_target.py
@@ -5,10 +5,13 @@
 """Tests for class DpexTargetContext."""
 
 
+import dpctl
+import dpnp
 import pytest
 from numba.core import typing
 from numba.core.codegen import JITCPUCodegen
 
+from numba_dpex import dpjit
 from numba_dpex.core.targets.dpjit_target import DpexTargetContext
 
 ctx = typing.Context()
@@ -30,3 +33,29 @@ def test_dpjit_target_refresh():
         dpexctx.refresh
     except KeyError:
         pytest.fail("Unexpected KeyError in dpjit_target.")
+
+
+def test_dpjit_target_caching():
+    @dpjit(cache=True)
+    def func(a):
+        b = dpnp.ones(10)
+        return a + b
+
+    q1 = dpctl.SyclQueue()
+    q2 = dpctl.SyclQueue()
+
+    b = dpnp.zeros(10, sycl_queue=q1)
+    c = func(b)
+    print(c)
+
+    b = dpnp.ones(10, sycl_queue=q2)
+    c = func(b)
+    print(c)
+
+    b = dpnp.ones(5)
+    c = func(b)
+    print(c)
+
+    b = dpnp.ones(10, sycl_queue=q2, dtype=dpnp.int32)
+    c = func(b)
+    print(c)

--- a/numba_dpex/tests/core/types/USMNdArray/test_usm_ndarray_creation.py
+++ b/numba_dpex/tests/core/types/USMNdArray/test_usm_ndarray_creation.py
@@ -18,7 +18,9 @@ def test_default_type_construction():
     assert usma.usm_type == "device"
 
     default_device = dpctl.SyclDevice()
-    cached_queue = dpctl.get_device_cached_queue(default_device)
+    cached_queue = dpctl._sycl_queue_manager.get_device_cached_queue(
+        default_device
+    )
 
     assert usma.device == default_device.filter_string
     assert usma.queue == cached_queue
@@ -38,7 +40,9 @@ def test_type_creation_with_device():
 
     assert usma.device == default_device_str
 
-    cached_queue = dpctl.get_device_cached_queue(default_device_str)
+    cached_queue = dpctl._sycl_queue_manager.get_device_cached_queue(
+        default_device_str
+    )
 
     assert usma.queue == cached_queue
 

--- a/numba_dpex/tests/kernel_tests/test_caching.py
+++ b/numba_dpex/tests/kernel_tests/test_caching.py
@@ -20,6 +20,7 @@ def test_LRUcache_operations():
     Performs different permutations of caching operations
     and check if the state of the cache is correct.
     """
+
     alphabet = list(string.ascii_lowercase)
     cache = LRUCache(name="testcache", capacity=4, pyfunc=None)
     assert str(cache) == "{}" and cache.head is None and cache.tail is None
@@ -142,3 +143,127 @@ def test_caching_hit_counts(filter_str):
     actual = dpt.asnumpy(c)
 
     assert np.array_equal(expected, actual) and (d_launcher.cache_hits == N - 1)
+
+
+def load_from_index_file(hashtable, index_file):
+    """Loads values from the index file
+
+    Loads all the values mapped by 'hashtable'
+    from an 'index_file' object.
+    """
+    evicted = {}
+    for k in hashtable.keys():
+        evicted[k] = index_file.load(k)
+    return evicted
+
+
+def test_LRUcache_with_index_file_operations():
+    """Test rigorous caching operations.
+
+    Performs different permutations of caching operations
+    and check if the state of the cache is correct.
+
+    This is similar to test_LRUcache_operations() but the
+    evicted items are stored in a file and we check if the
+    items are stored correctly.
+    """
+
+    def func(a):
+        return a + 1
+
+    alphabet = list(string.ascii_lowercase)
+    cache = LRUCache(name="testcache", capacity=4, pyfunc=func)
+    assert str(cache) == "{}" and cache.head is None and cache.tail is None
+
+    states = []
+    for i in range(4):
+        cache.put(i, alphabet[i])
+        tail_key = cache.get(cache.tail.key)
+        head_key = cache.get(cache.head.key)
+        states.append((cache, tail_key, head_key))
+    assert (
+        str(states)
+        == "["
+        + "({(2: c), (1: b), (3: d), (0: a)}, 'a', 'a'), "
+        + "({(2: c), (1: b), (3: d), (0: a)}, 'b', 'a'), "
+        + "({(2: c), (1: b), (3: d), (0: a)}, 'c', 'b'), "
+        + "({(2: c), (1: b), (3: d), (0: a)}, 'd', 'a')"
+        + "]"
+    )
+
+    states = []
+    picking_order = [3, 1, 0, 2, 2]
+    for index in picking_order:
+        value = cache.get(index)
+        states.append((value, cache, cache.head, cache.tail))
+    assert (
+        str(states)
+        == "["
+        + "('d', {(3: d), (1: b), (0: a), (2: c)}, (2: c), (3: d)), "
+        + "('b', {(3: d), (1: b), (0: a), (2: c)}, (2: c), (1: b)), "
+        + "('a', {(3: d), (1: b), (0: a), (2: c)}, (2: c), (0: a)), "
+        + "('c', {(3: d), (1: b), (0: a), (2: c)}, (3: d), (2: c)), "
+        + "('c', {(3: d), (1: b), (0: a), (2: c)}, (3: d), (2: c))"
+        + "]"
+    )
+
+    states = []
+    for i in range(5, 10):
+        cache.put(i, alphabet[i])
+        tail_key = cache.get(cache.tail.key)
+        head_key = cache.get(cache.head.key)
+        states.append((cache, tail_key, head_key))
+    assert (
+        str(states)
+        == "["
+        + "({(8: i), (2: c), (9: j), (1: b)}, 'f', 'b'), "
+        + "({(8: i), (2: c), (9: j), (1: b)}, 'g', 'c'), "
+        + "({(8: i), (2: c), (9: j), (1: b)}, 'h', 'b'), "
+        + "({(8: i), (2: c), (9: j), (1: b)}, 'i', 'c'), "
+        + "({(8: i), (2: c), (9: j), (1: b)}, 'j', 'b')"
+        + "]"
+    )
+    assert (
+        str(load_from_index_file(cache.evicted, cache._cache_file))
+        == "{3: 'd', 0: 'a', 5: 'f', 6: 'g', 7: 'h'}"
+    )
+
+    picking_order = [2, 1, 3]
+    states = []
+    for index in picking_order:
+        value = cache.get(index)
+        states.append((value, cache, cache.head, cache.tail))
+    assert (
+        str(states)
+        == "["
+        + "('c', {(9: j), (2: c), (1: b), (3: d)}, (8: i), (2: c)), "
+        + "('b', {(9: j), (2: c), (1: b), (3: d)}, (8: i), (1: b)), "
+        + "('d', {(9: j), (2: c), (1: b), (3: d)}, (9: j), (3: d))"
+        + "]"
+    )
+    assert (
+        str(load_from_index_file(cache.evicted, cache._cache_file))
+        == "{0: 'a', 5: 'f', 6: 'g', 7: 'h', 8: 'i'}"
+    )
+
+    cache.put(0, "x")
+    assert (
+        str(cache) == "{(2: c), (1: b), (3: d), (0: x)}"
+        and str(cache.head) == "(2: c)"
+        and str(cache.tail) == "(0: x)"
+    )
+    assert (
+        str(load_from_index_file(cache.evicted, cache._cache_file))
+        == "{5: 'f', 6: 'g', 7: 'h', 8: 'i', 9: 'j'}"
+    )
+
+    cache.put(6, "y")
+    assert (
+        str(cache) == "{(1: b), (3: d), (0: x), (6: y)}"
+        and str(cache.head) == "(1: b)"
+        and str(cache.tail) == "(6: y)"
+    )
+    assert (
+        str(load_from_index_file(cache.evicted, cache._cache_file))
+        == "{5: 'f', 7: 'h', 8: 'i', 9: 'j', 2: 'c'}"
+    )


### PR DESCRIPTION
Enable caching for `@dpjit` 
 * refactor `core.dpjit_dispatcher` to bypass `numba`'s `dispatcher.Dispatcher`'s caching mechanism.
 * refactor `key` for `core.types.usm_ndarray_type` to cache against `sycl_queue`.
 * refactor `decorators.dpjit` to intercept the dispatcher to keep track of `_cache_misses` and `_cache_hits` for unit test.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
