### PR TITLE
fix lowerer function to be used for parfors.

### DIFF
--- a/numba_dpex/core/passes/parfor_lowering_pass.py
+++ b/numba_dpex/core/passes/parfor_lowering_pass.py
@@ -287,7 +287,6 @@ class WrapperDefaultLower(Lower):
 
 
 def lower_parfor_dpex(lowerer, parfor):
-    parfor.lowerer = ParforLowerImpl()._lower_parfor_as_kernel
     if parfor.lowerer is None:
         _lower_parfor_parallel_std(lowerer, parfor)
     else:


### PR DESCRIPTION
- [X] Have you provided a meaningful PR description?

Fixes a bug in the lowering function where we ere selecting the dpex parfor lower to kernel for all types of parfor kernels including NumPy parfors.

- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
To be added.
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [X] If this PR is a work in progress, are you filing the PR as a draft?
