### PR TITLE
Update docker to support recent changes

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,21 +4,27 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        default: '0.20.0'
+        default: '0.21.0'
       dpctl_version:
-        default: '0.14.2'
+        default: '0.14.4'
       dpnp_version:
-        default: '0.11.1'
+        default: '0.12.0'
       numpy_version:
-        default: '1.22.3'
+        default: '1.24.3'
       numba_version:
-        default: '0.56.4'
+        default: '0.57.0'
+      # dpcpp_llvm_spirv_version:
+      #   default: 'main'
       cython_version:
-        default: "0.29.33"
+        default: "0.29.35"
       scikit_build_version:
-        default: "0.16.7"
+        default: "0.17.6"
       oneapi_version:
-        default: '2023.0.0'
+        default: '2023.1.0.46401'
+      python_versions:
+        default: '["3.8", "3.9", "3.10", "3.11"]'
+      buildkit_version:
+        default: '0.11.6'
 
 
 jobs:
@@ -27,9 +33,9 @@ jobs:
     outputs:
       repository: ${{ steps.write.outputs.repository }}
       BUILD_ARGS: ${{ steps.write.outputs.BUILD_ARGS }}
-      DOCKER_TAG: ${{ steps.write.outputs.DOCKER_TAG }}
       DOCKER_STAGES_IMAGE: ${{ steps.write.outputs.DOCKER_STAGES_IMAGE }}
       DOCKER_REPO_IMAGE: ${{ steps.write.outputs.DOCKER_REPO_IMAGE }}
+      VERSION: ${{ steps.write.outputs.VERSION }}
     steps:
       - name: Write output env
         id: write
@@ -41,30 +47,28 @@ jobs:
           echo "ONEAPI_VERSION=${{ inputs.oneapi_version }}" >> $GITHUB_OUTPUT
           echo "DPCTL_GIT_BRANCH=${{ inputs.dpctl_version }}" >> $GITHUB_OUTPUT
           echo "DPNP_GIT_BRANCH=${{ inputs.dpnp_version }}" >> $GITHUB_OUTPUT
+          # echo "DPCPP_LLVM_SPIRV_GIT_BRANCH=${{ inputs.dpcpp_llvm_spirv_version }}" >> $GITHUB_OUTPUT
           echo "NUMBA_DPEX_GIT_BRANCH=${{ inputs.version }}" >> $GITHUB_OUTPUT
           echo "INTEL_NUMPY_VERSION===${{ inputs.numpy_version }}" >> $GITHUB_OUTPUT
           echo "INTEL_NUMBA_VERSION===${{ inputs.numba_version }}" >> $GITHUB_OUTPUT
           echo "CYTHON_VERSION===${{ inputs.cython_version }}" >> $GITHUB_OUTPUT
           echo "SCIKIT_BUILD_VERSION===${{ inputs.scikit_build_version }}" >> $GITHUB_OUTPUT
-          echo "GITHUB_USER=${{ github.actor }}" >> $GITHUB_OUTPUT
-          echo "GITHUB_PASSWORD=${{ secrets.GITHUB_TOKEN }}" >> $GITHUB_OUTPUT
 
           echo "EOF" >> $GITHUB_OUTPUT
 
           echo "DOCKER_STAGES_IMAGE=ghcr.io/$REPOSITORY/stages" >> $GITHUB_OUTPUT
           echo "DOCKER_REPO_IMAGE=ghcr.io/$REPOSITORY" >> $GITHUB_OUTPUT
+          echo "VERSION=$(echo ${{ inputs.version }} | tr '/' '-')" >> $GITHUB_OUTPUT
 
   build-toolkit:
     needs: env
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # Numba does not support 3.11
-        # https://github.com/numba/numba/issues/8304
-        python_version: ['3.8', '3.9', '3.10']
+        python_version: ${{ fromJSON(inputs.python_versions) }}
     env:
       BUILD_TARGET: toolkit
-      DOCKER_TAG: ${{ inputs.version }}-py${{ matrix.python_version }}
+      DOCKER_TAG: ${{ needs.env.outputs.VERSION }}-py${{ matrix.python_version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -72,7 +76,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
         with:
           driver-opts: |
-            image=moby/buildkit:v0.11.4
+            image=moby/buildkit:v${{ inputs.buildkit_version }}
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
@@ -94,6 +98,8 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             ${{ needs.env.outputs.BUILD_ARGS }}
+            GITHUB_USER=${{ github.actor }}
+            GITHUB_PASSWORD=${{ secrets.GITHUB_TOKEN }}
             PYTHON_VERSION=${{ matrix.python_version }}
 
   build-runtime-base:
@@ -101,12 +107,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # Numba does not support 3.11
-        # https://github.com/numba/numba/issues/8304
-        python_version: ['3.8', '3.9', '3.10']
+        python_version: ${{ fromJSON(inputs.python_versions) }}
     env:
       BUILD_TARGET: runtime-base
-      DOCKER_TAG: ${{ inputs.version }}-py${{ matrix.python_version }}
+      DOCKER_TAG: ${{ needs.env.outputs.VERSION }}-py${{ matrix.python_version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -114,7 +118,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
         with:
           driver-opts: |
-            image=moby/buildkit:v0.11.4
+            image=moby/buildkit:v${{ inputs.buildkit_version }}
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
@@ -136,21 +140,20 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             ${{ needs.env.outputs.BUILD_ARGS }}
+            GITHUB_USER=${{ github.actor }}
+            GITHUB_PASSWORD=${{ secrets.GITHUB_TOKEN }}
             TOOLKIT_IMAGE=${{ needs.env.outputs.DOCKER_STAGES_IMAGE }}:${{ env.DOCKER_TAG }}-toolkit
             PYTHON_VERSION=${{ matrix.python_version }}
-
 
   build-builder:
     needs: [env, build-runtime-base]
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # Numba does not support 3.11
-        # https://github.com/numba/numba/issues/8304
-        python_version: ['3.8', '3.9', '3.10']
+        python_version: ${{ fromJSON(inputs.python_versions) }}
     env:
       BUILD_TARGET: builder
-      DOCKER_TAG: ${{ inputs.version }}-py${{ matrix.python_version }}
+      DOCKER_TAG: ${{ needs.env.outputs.VERSION }}-py${{ matrix.python_version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -158,7 +161,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
         with:
           driver-opts: |
-            image=moby/buildkit:v0.11.4
+            image=moby/buildkit:v${{ inputs.buildkit_version }}
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
@@ -180,6 +183,8 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             ${{ needs.env.outputs.BUILD_ARGS }}
+            GITHUB_USER=${{ github.actor }}
+            GITHUB_PASSWORD=${{ secrets.GITHUB_TOKEN }}
             TOOLKIT_IMAGE=${{ needs.env.outputs.DOCKER_STAGES_IMAGE }}:${{ env.DOCKER_TAG }}-toolkit
             RUNTIME_BASE_IMAGE=${{ needs.env.outputs.DOCKER_STAGES_IMAGE }}:${{ env.DOCKER_TAG }}-runtime-base
             PYTHON_VERSION=${{ matrix.python_version }}
@@ -189,12 +194,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # Numba does not support 3.11
-        # https://github.com/numba/numba/issues/8304
-        python_version: ['3.8', '3.9', '3.10']
+        python_version: ${{ fromJSON(inputs.python_versions) }}
     env:
       BUILD_TARGET: dpctl-builder
-      DOCKER_TAG: ${{ inputs.version }}-py${{ matrix.python_version }}
+      DOCKER_TAG: ${{ needs.env.outputs.VERSION }}-py${{ matrix.python_version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -202,7 +205,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
         with:
           driver-opts: |
-            image=moby/buildkit:v0.11.4
+            image=moby/buildkit:v${{ inputs.buildkit_version }}
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
@@ -224,6 +227,8 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             ${{ needs.env.outputs.BUILD_ARGS }}
+            GITHUB_USER=${{ github.actor }}
+            GITHUB_PASSWORD=${{ secrets.GITHUB_TOKEN }}
             BUILDER_IMAGE=${{ needs.env.outputs.DOCKER_STAGES_IMAGE }}:${{ env.DOCKER_TAG }}-builder
             PYTHON_VERSION=${{ matrix.python_version }}
 
@@ -232,12 +237,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # Numba does not support 3.11
-        # https://github.com/numba/numba/issues/8304
-        python_version: ['3.8', '3.9', '3.10']
+        python_version: ${{ fromJSON(inputs.python_versions) }}
     env:
       BUILD_TARGET: dpnp-builder
-      DOCKER_TAG: ${{ inputs.version }}-py${{ matrix.python_version }}
+      DOCKER_TAG: ${{ needs.env.outputs.VERSION }}-py${{ matrix.python_version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -245,7 +248,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
         with:
           driver-opts: |
-            image=moby/buildkit:v0.11.4
+            image=moby/buildkit:v${{ inputs.buildkit_version }}
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
@@ -267,22 +270,22 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             ${{ needs.env.outputs.BUILD_ARGS }}
+            GITHUB_USER=${{ github.actor }}
+            GITHUB_PASSWORD=${{ secrets.GITHUB_TOKEN }}
             BUILDER_IMAGE=${{ needs.env.outputs.DOCKER_STAGES_IMAGE }}:${{ env.DOCKER_TAG }}-builder
             DPCTL_BUILDER_IMAGE=${{ needs.env.outputs.DOCKER_STAGES_IMAGE }}:${{ env.DOCKER_TAG }}-dpctl-builder
             PYTHON_VERSION=${{ matrix.python_version }}
 
-  build-numba-dpex-builder-runtime:
-    needs: [env, build-dpctl-builder, build-dpnp-builder]
+  build-dpcpp-llvm-spirv:
+    needs: [env, build-builder]
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # Numba does not support 3.11
-        # https://github.com/numba/numba/issues/8304
-        python_version: ['3.8', '3.9', '3.10']
+        python_version: ${{ fromJSON(inputs.python_versions) }}
     env:
-      BUILD_TARGET: numba-dpex-builder-runtime
-      DOCKER_TAG: ${{ inputs.version }}-py${{ matrix.python_version }}
-      DEST_TAG: ${{ needs.env.outputs.DOCKER_REPO_IMAGE }}/builder:${{ inputs.version }}-py${{ matrix.python_version }}
+      BUILD_TARGET: dpcpp-llvm-spirv-builder
+      DOCKER_TAG: ${{ needs.env.outputs.VERSION }}-py${{ matrix.python_version }}
+      DEST_TAG: ${{ needs.env.outputs.DOCKER_REPO_IMAGE }}/builder:${{ needs.env.outputs.VERSION }}-py${{ matrix.python_version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -290,7 +293,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
         with:
           driver-opts: |
-            image=moby/buildkit:v0.11.4
+            image=moby/buildkit:v${{ inputs.buildkit_version }}
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
@@ -312,23 +315,67 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             ${{ needs.env.outputs.BUILD_ARGS }}
+            GITHUB_USER=${{ github.actor }}
+            GITHUB_PASSWORD=${{ secrets.GITHUB_TOKEN }}
+            BUILDER_IMAGE=${{ needs.env.outputs.DOCKER_STAGES_IMAGE }}:${{ env.DOCKER_TAG }}-builder
+
+  build-numba-dpex-builder-runtime:
+    needs: [env, build-dpctl-builder, build-dpnp-builder, build-dpcpp-llvm-spirv]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python_version: ${{ fromJSON(inputs.python_versions) }}
+    env:
+      BUILD_TARGET: numba-dpex-builder-runtime
+      DOCKER_TAG: ${{ needs.env.outputs.VERSION }}-py${{ matrix.python_version }}
+      DEST_TAG: ${{ needs.env.outputs.DOCKER_REPO_IMAGE }}/builder:${{ needs.env.outputs.VERSION }}-py${{ matrix.python_version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          driver-opts: |
+            image=moby/buildkit:v${{ inputs.buildkit_version }}
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Docker meta
+        uses: docker/metadata-action@v4
+        id: meta
+        with:
+          images: ${{ needs.env.outputs.DOCKER_STAGES_IMAGE }}
+          tags: ${{ env.DOCKER_TAG }}-${{ env.BUILD_TARGET }}
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          push: true
+          target: ${{ env.BUILD_TARGET }}
+          tags: ${{ steps.meta.outputs.tags }},${{ env.DEST_TAG }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            ${{ needs.env.outputs.BUILD_ARGS }}
+            GITHUB_USER=${{ github.actor }}
+            GITHUB_PASSWORD=${{ secrets.GITHUB_TOKEN }}
             BUILDER_IMAGE=${{ needs.env.outputs.DOCKER_STAGES_IMAGE }}:${{ env.DOCKER_TAG }}-builder
             DPCTL_BUILDER_IMAGE=${{ needs.env.outputs.DOCKER_STAGES_IMAGE }}:${{ env.DOCKER_TAG }}-dpctl-builder
             DPNP_BUILDER_IMAGE=${{ needs.env.outputs.DOCKER_STAGES_IMAGE }}:${{ env.DOCKER_TAG }}-dpnp-builder
+            DPCPP_LLVM_SPIRV_BUILDER_IMAGE=${{ needs.env.outputs.DOCKER_STAGES_IMAGE }}:${{ env.DOCKER_TAG }}-dpcpp-llvm-spirv-builder
             PYTHON_VERSION=${{ matrix.python_version }}
 
   build-runtime:
-    needs: [env, build-runtime-base, build-dpctl-builder, build-dpnp-builder, build-numba-dpex-builder-runtime]
+    needs: [env, build-runtime-base, build-dpctl-builder, build-dpnp-builder, build-numba-dpex-builder-runtime, build-dpcpp-llvm-spirv]
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # Numba does not support 3.11
-        # https://github.com/numba/numba/issues/8304
-        python_version: ['3.8', '3.9', '3.10']
+        python_version: ${{ fromJSON(inputs.python_versions) }}
     env:
       BUILD_TARGET: runtime
-      DOCKER_TAG: ${{ inputs.version }}-py${{ matrix.python_version }}
-      DEST_TAG: ${{ needs.env.outputs.DOCKER_REPO_IMAGE }}/runtime:${{ inputs.version }}-py${{ matrix.python_version }}
+      DOCKER_TAG: ${{ needs.env.outputs.VERSION }}-py${{ matrix.python_version }}
+      DEST_TAG: ${{ needs.env.outputs.DOCKER_REPO_IMAGE }}/runtime:${{ needs.env.outputs.VERSION }}-py${{ matrix.python_version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -336,7 +383,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
         with:
           driver-opts: |
-            image=moby/buildkit:v0.11.4
+            image=moby/buildkit:v${{ inputs.buildkit_version }}
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
@@ -358,9 +405,12 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             ${{ needs.env.outputs.BUILD_ARGS }}
+            GITHUB_USER=${{ github.actor }}
+            GITHUB_PASSWORD=${{ secrets.GITHUB_TOKEN }}
             BUILDER_IMAGE=${{ needs.env.outputs.DOCKER_STAGES_IMAGE }}:${{ env.DOCKER_TAG }}-builder
             DPCTL_BUILDER_IMAGE=${{ needs.env.outputs.DOCKER_STAGES_IMAGE }}:${{ env.DOCKER_TAG }}-dpctl-builder
             DPNP_BUILDER_IMAGE=${{ needs.env.outputs.DOCKER_STAGES_IMAGE }}:${{ env.DOCKER_TAG }}-dpnp-builder
+            DPCPP_LLVM_SPIRV_BUILDER_IMAGE=${{ needs.env.outputs.DOCKER_STAGES_IMAGE }}:${{ env.DOCKER_TAG }}-dpcpp-llvm-spirv-builder
             NUMBA_DPEX_BUILDER_RUNTIME_IMAGE=${{ needs.env.outputs.DOCKER_STAGES_IMAGE }}:${{ env.DOCKER_TAG }}-numba-dpex-builder-runtime
             RUNTIME_BASE_IMAGE=${{ needs.env.outputs.DOCKER_STAGES_IMAGE }}:${{ env.DOCKER_TAG }}-runtime-base
             PYTHON_VERSION=${{ matrix.python_version }}
@@ -370,12 +420,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # Numba does not support 3.11
-        # https://github.com/numba/numba/issues/8304
-        python_version: ['3.8', '3.9', '3.10']
+        python_version: ${{ fromJSON(inputs.python_versions) }}
     env:
       BUILD_TARGET: drivers
-      DOCKER_TAG: ${{ inputs.version }}-py${{ matrix.python_version }}
+      DOCKER_TAG: ${{ needs.env.outputs.VERSION }}-py${{ matrix.python_version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -383,7 +431,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
         with:
           driver-opts: |
-            image=moby/buildkit:v0.11.4
+            image=moby/buildkit:v${{ inputs.buildkit_version }}
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
@@ -405,6 +453,8 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             ${{ needs.env.outputs.BUILD_ARGS }}
+            GITHUB_USER=${{ github.actor }}
+            GITHUB_PASSWORD=${{ secrets.GITHUB_TOKEN }}
             PYTHON_VERSION=${{ matrix.python_version }}
 
   build-runtime-gpu:
@@ -412,13 +462,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # Numba does not support 3.11
-        # https://github.com/numba/numba/issues/8304
-        python_version: ['3.8', '3.9', '3.10']
+        python_version: ${{ fromJSON(inputs.python_versions) }}
     env:
       BUILD_TARGET: runtime-gpu
-      DOCKER_TAG: ${{ inputs.version }}-py${{ matrix.python_version }}
-      DEST_TAG: ${{ needs.env.outputs.DOCKER_REPO_IMAGE }}/runtime:${{ inputs.version }}-py${{ matrix.python_version }}-gpu
+      DOCKER_TAG: ${{ needs.env.outputs.VERSION }}-py${{ matrix.python_version }}
+      DEST_TAG: ${{ needs.env.outputs.DOCKER_REPO_IMAGE }}/runtime:${{ needs.env.outputs.VERSION }}-py${{ matrix.python_version }}-gpu
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -426,7 +474,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
         with:
           driver-opts: |
-            image=moby/buildkit:v0.11.4
+            image=moby/buildkit:v${{ inputs.buildkit_version }}
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
@@ -448,6 +496,8 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             ${{ needs.env.outputs.BUILD_ARGS }}
+            GITHUB_USER=${{ github.actor }}
+            GITHUB_PASSWORD=${{ secrets.GITHUB_TOKEN }}
             RUNTIME_IMAGE=${{ needs.env.outputs.DOCKER_STAGES_IMAGE }}:${{ env.DOCKER_TAG }}-runtime
             PYTHON_VERSION=${{ matrix.python_version }}
 
@@ -456,13 +506,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # Numba does not support 3.11
-        # https://github.com/numba/numba/issues/8304
-        python_version: ['3.8', '3.9', '3.10']
+        python_version: ${{ fromJSON(inputs.python_versions) }}
     env:
       BUILD_TARGET: numba-dpex-builder-runtime-gpu
-      DOCKER_TAG: ${{ inputs.version }}-py${{ matrix.python_version }}
-      DEST_TAG: ${{ needs.env.outputs.DOCKER_REPO_IMAGE }}/builder:${{ inputs.version }}-py${{ matrix.python_version }}-gpu
+      DOCKER_TAG: ${{ needs.env.outputs.VERSION }}-py${{ matrix.python_version }}
+      DEST_TAG: ${{ needs.env.outputs.DOCKER_REPO_IMAGE }}/builder:${{ needs.env.outputs.VERSION }}-py${{ matrix.python_version }}-gpu
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -470,7 +518,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
         with:
           driver-opts: |
-            image=moby/buildkit:v0.11.4
+            image=moby/buildkit:v${{ inputs.buildkit_version }}
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
@@ -492,6 +540,8 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             ${{ needs.env.outputs.BUILD_ARGS }}
+            GITHUB_USER=${{ github.actor }}
+            GITHUB_PASSWORD=${{ secrets.GITHUB_TOKEN }}
             RUNTIME_IMAGE=${{ needs.env.outputs.DOCKER_STAGES_IMAGE }}:${{ env.DOCKER_TAG }}-runtime
             NUMBA_DPEX_BUILDER_RUNTIME_IMAGE=${{ needs.env.outputs.DOCKER_STAGES_IMAGE }}:${{ env.DOCKER_TAG }}-numba-dpex-builder-runtime
             PYTHON_VERSION=${{ matrix.python_version }}
@@ -502,14 +552,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Numba does not support 3.11
-        # https://github.com/numba/numba/issues/8304
-        python_version: ['3.8', '3.9', '3.10']
+        python_version: ${{ fromJSON(inputs.python_versions) }}
         pyargs: ['dpctl', 'numba_dpex.tests', '/opt/dpnp/tests', '/opt/dpnp/tests/third_party']
     env:
-      DOCKER_TAG: ${{ inputs.version }}-py${{ matrix.python_version }}
+      DOCKER_TAG: ${{ needs.env.outputs.VERSION }}-py${{ matrix.python_version }}
     container:
-      image: ${{ needs.env.outputs.DOCKER_STAGES_IMAGE }}:${{ inputs.version }}-py${{ matrix.python_version }}-runtime
+      image: ${{ needs.env.outputs.DOCKER_STAGES_IMAGE }}:${{ needs.env.outputs.VERSION }}-py${{ matrix.python_version }}-runtime
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Add `dpcpp-llvm-spirv` support. Update some build instructions to work with newer versions. Upgrade dep versions.

Update base image to use debian bookworm. It unblocks from using latest gpu drivers and it seems like the problem with print inside gpu kernel is gone.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
