### PR TITLE
Added REDUCTION_WORK_GROUP_SIZE to allow configuring reduction work_g…

### DIFF
--- a/numba_dpex/config.py
+++ b/numba_dpex/config.py
@@ -90,3 +90,7 @@ TESTING_LOG_DEBUGGING = _readenv("NUMBA_DPEX_TESTING_LOG_DEBUGGING", int, DEBUG)
 # Flag to turn on the ConstantSizeStaticLocalMemoryPass in the kernel pipeline.
 # The pass is turned off by default.
 STATIC_LOCAL_MEM_PASS = _readenv("NUMBA_DPEX_STATIC_LOCAL_MEM_PASS", int, 0)
+# This is to set reduction kernel work_group_size.
+REDUCTION_WORK_GROUP_SIZE = _readenv(
+    "NUMBA_DPEX_REDUCTION_WORK_GROUP_SIZE", int, 0
+)

--- a/numba_dpex/core/parfors/reduction_helper.py
+++ b/numba_dpex/core/parfors/reduction_helper.py
@@ -16,7 +16,7 @@ from numba.core.ir_utils import (
 from numba.parfors import parfor
 from numba.parfors.parfor_lowering_utils import ParforLoweringBuilder
 
-from numba_dpex import utils
+from numba_dpex import config, utils
 from numba_dpex.core.utils.kernel_launcher import KernelLaunchIRBuilder
 from numba_dpex.dpctl_iface import DpctlCAPIFnBuilder
 
@@ -48,6 +48,8 @@ class ReductionHelper:
 
         # allocate partial sum
         work_group_size = 8
+        if config.REDUCTION_WORK_GROUP_SIZE:
+            work_group_size = config.REDUCTION_WORK_GROUP_SIZE
         # writing work_group_size inot IR
         work_group_size_var = pfbdr.assign(
             rhs=ir.Const(work_group_size, loc),

--- a/numba_dpex/tests/dpjit_tests/test_dpjit_reduction.py
+++ b/numba_dpex/tests/dpjit_tests/test_dpjit_reduction.py
@@ -8,6 +8,7 @@ import numpy
 import pytest
 
 import numba_dpex as dpex
+from numba_dpex import config
 
 N = 10
 
@@ -121,5 +122,25 @@ def test_dpjit_array_arg_float32_types(input_arrays):
     b = dpnp.arange(100, dtype=dpnp.float32)
 
     c = vecadd_prange_float(a, b)
+
+    assert s == c
+
+
+def test_dpjit_reduction_work_group_size(input_arrays):
+    """Tests passing work_group_size to a dpjit
+    prange reduciton kernel.
+
+    Args:
+        input_arrays (dpnp.ndarray): Array arguments to be passed to a kernel.
+    """
+    a, b = input_arrays
+
+    config.REDUCTION_WORK_GROUP_SIZE = 2
+
+    c = vecadd_prange1(a, b)
+
+    config.REDUCTION_WORK_GROUP_SIZE = 4
+
+    s = vecadd_prange1(a, b)
 
     assert s == c


### PR DESCRIPTION
…roup_size.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
