### PR TITLE
Upgraded spirv-max-version from 1.1 to 1.4.

### DIFF
--- a/numba_dpex/spirv_generator.py
+++ b/numba_dpex/spirv_generator.py
@@ -76,7 +76,7 @@ class CmdLine:
             llvm_spirv_flags.append("--spirv-debug-info-version=ocl-100")
 
         if not config.NATIVE_FP_ATOMICS:
-            llvm_spirv_args = ["--spirv-max-version", "1.1"] + llvm_spirv_args
+            llvm_spirv_args = ["--spirv-max-version", "1.4"] + llvm_spirv_args
         llvm_spirv_tool = self._llvm_spirv()
 
         if config.DEBUG:

--- a/numba_dpex/tests/kernel_tests/test_print.py
+++ b/numba_dpex/tests/kernel_tests/test_print.py
@@ -16,6 +16,11 @@ list_of_dtypes = [
     dpnp.float64,
 ]
 
+skip_on_gpu = pytest.mark.skipif(
+    dpctl.SyclDevice().device_type == dpctl.device_type.gpu,
+    reason="skip print on gpu",
+)
+
 
 @pytest.fixture(params=list_of_dtypes)
 def input_arrays(request):
@@ -24,6 +29,7 @@ def input_arrays(request):
     return a
 
 
+@skip_on_gpu
 def test_print_scalar_with_string(input_arrays, capfd):
     """Tests if we can print a scalar value with a string."""
 
@@ -41,6 +47,7 @@ def test_print_scalar_with_string(input_arrays, capfd):
     assert "printing ... 10" in captured.out
 
 
+@skip_on_gpu
 def test_print_scalar(input_arrays, capfd):
     """Tests if we can print a scalar value."""
 
@@ -59,6 +66,7 @@ def test_print_scalar(input_arrays, capfd):
     assert "10" in captured.out
 
 
+@skip_on_gpu
 def test_print_only_str(input_arrays):
     """Negative test to capture LoweringError as printing strings is
     unsupported.
@@ -80,6 +88,7 @@ def test_print_only_str(input_arrays):
         print_string[dpex.Range(1)](a)
 
 
+@skip_on_gpu
 def test_print_array(input_arrays):
     """Negative test to capture LoweringError as printing arrays
     is unsupported.


### PR DESCRIPTION
- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?


As #885 , spirv-max-version is limited to 1.1 to avoid with oneAPI dpcpp 2023.0. While infra team is updating spirv headers to 1.4, as part of Numba 0.57 upgrade, numba-dpex needs to lift the limit and support spirv 1.4. 