### PR TITLE
Update the SPIR-V version for the atomic emulation kernel.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -115,7 +115,7 @@ def spirv_compile():
     spirv_args = [
         _llvm_spirv(),
         "--spirv-max-version",
-        "1.1",
+        "1.4",
         "numba_dpex/ocl/atomics/atomic_ops.bc",
         "-o",
         "numba_dpex/ocl/atomics/atomic_ops.spir",


### PR DESCRIPTION
Updates the spirv version used to compile the atomic emulation kernel to bring it in line with the changes introduced in #1056
