### PR TITLE
Improve error message for unsupported parfor args

### DIFF
--- a/numba_dpex/core/exceptions.py
+++ b/numba_dpex/core/exceptions.py
@@ -293,7 +293,9 @@ class UnsupportedKernelArgumentError(Exception):
     def __init__(self, type, value, kernel_name="") -> None:
         self.message = (
             f"Argument {value} passed to kernel {kernel_name} is of an "
-            f"unsupported type ({type})."
+            f"unsupported type ({type}). Allowed kernel arguments must be "
+            "sub-types of numba.types.Number or sub-types of "
+            "numba_dpex.USMNdArray"
         )
         super().__init__(self.message)
 

--- a/numba_dpex/core/parfors/parfor_lowerer.py
+++ b/numba_dpex/core/parfors/parfor_lowerer.py
@@ -135,6 +135,8 @@ class ParforLowerImpl:
             llvm_val = _getvar(lowerer, arg)
             if isinstance(argtype, DpnpNdArray):
                 self.kernel_builder.build_array_arg(
+                    kernel_name=kernel_fn.name,
+                    numba_val=arg,
                     array_val=llvm_val,
                     array_rank=argtype.ndim,
                     arg_list=self.args_list,
@@ -146,29 +148,35 @@ class ParforLowerImpl:
             else:
                 if argtype == types.complex64:
                     self.kernel_builder.build_complex_arg(
-                        llvm_val,
-                        types.float32,
-                        self.args_list,
-                        self.args_ty_list,
-                        self.kernel_arg_num,
+                        kernel_name=kernel_fn.name,
+                        numba_val=arg,
+                        llvm_val=llvm_val,
+                        ty=types.float32,
+                        arg_list=self.args_list,
+                        args_ty_list=self.args_ty_list,
+                        arg_num=self.kernel_arg_num,
                     )
                     self.kernel_arg_num += 2
                 elif argtype == types.complex128:
                     self.kernel_builder.build_complex_arg(
-                        llvm_val,
-                        types.float64,
-                        self.args_list,
-                        self.args_ty_list,
-                        self.kernel_arg_num,
+                        kernel_name=kernel_fn.name,
+                        numba_val=arg,
+                        llvm_val=llvm_val,
+                        ty=types.float64,
+                        arg_list=self.args_list,
+                        args_ty_list=self.args_ty_list,
+                        arg_num=self.kernel_arg_num,
                     )
                     self.kernel_arg_num += 2
                 else:
                     self.kernel_builder.build_arg(
-                        llvm_val,
-                        argtype,
-                        self.args_list,
-                        self.args_ty_list,
-                        self.kernel_arg_num,
+                        kernel_name=kernel_fn.name,
+                        numba_val=arg,
+                        llvm_val=llvm_val,
+                        ty=argtype,
+                        arg_list=self.args_list,
+                        args_ty_list=self.args_ty_list,
+                        arg_num=self.kernel_arg_num,
                     )
                     self.kernel_arg_num += 1
 

--- a/numba_dpex/dpctl_iface/_helpers.py
+++ b/numba_dpex/dpctl_iface/_helpers.py
@@ -4,39 +4,46 @@
 
 from numba.core import types
 
+from numba_dpex.core.exceptions import UnsupportedKernelArgumentError
 
-def numba_type_to_dpctl_typenum(context, type):
+
+def numba_type_to_dpctl_typenum(context, kernel_name, numba_value, numba_type):
     """
     This function looks up the dpctl defined enum values from
     ``DPCTLKernelArgType``.
     """
 
     val = None
-    if type == types.int32 or isinstance(type, types.scalars.IntegerLiteral):
+
+    if numba_type == types.int32 or isinstance(
+        numba_type, types.scalars.IntegerLiteral
+    ):
         # DPCTL_LONG_LONG
         val = context.get_constant(types.int32, 9)
-    elif type == types.uint32:
+    elif numba_type == types.uint32:
         # DPCTL_UNSIGNED_LONG_LONG
         val = context.get_constant(types.int32, 10)
-    elif type == types.boolean:
+    elif numba_type == types.boolean:
         # DPCTL_UNSIGNED_INT
         val = context.get_constant(types.int32, 5)
-    elif type == types.int64:
+    elif numba_type == types.int64:
         # DPCTL_LONG_LONG
         val = context.get_constant(types.int32, 9)
-    elif type == types.uint64:
+    elif numba_type == types.uint64:
         # DPCTL_SIZE_T
         val = context.get_constant(types.int32, 11)
-    elif type == types.float32:
+    elif numba_type == types.float32:
         # DPCTL_FLOAT
         val = context.get_constant(types.int32, 12)
-    elif type == types.float64:
+    elif numba_type == types.float64:
         # DPCTL_DOUBLE
         val = context.get_constant(types.int32, 13)
-    elif type == types.voidptr:
+    elif numba_type == types.voidptr:
         # DPCTL_VOID_PTR
         val = context.get_constant(types.int32, 15)
     else:
-        raise NotImplementedError
+        raise UnsupportedKernelArgumentError(
+            kernel_name=kernel_name, type=type(numba_type), value=numba_value
+        )
 
     return val

--- a/numba_dpex/dpctl_iface/legacy_kernel_launch_ops.py
+++ b/numba_dpex/dpctl_iface/legacy_kernel_launch_ops.py
@@ -143,7 +143,7 @@ class KernelLaunchOps:
                 self.context.get_constant(types.int64, 0), storage
             )
             ty = numba_type_to_dpctl_typenum(
-                context=self.context, type=types.int64
+                context=self.context, numba_type=types.int64
             )
             self._form_kernel_arg_and_arg_ty(
                 self.builder.bitcast(
@@ -160,7 +160,7 @@ class KernelLaunchOps:
                 self.context.get_constant(types.int64, 0), storage
             )
             ty = numba_type_to_dpctl_typenum(
-                context=self.context, type=types.int64
+                context=self.context, numba_type=types.int64
             )
             self._form_kernel_arg_and_arg_ty(
                 self.builder.bitcast(
@@ -182,7 +182,7 @@ class KernelLaunchOps:
             )
 
             ty = numba_type_to_dpctl_typenum(
-                context=self.context, type=types.int64
+                context=self.context, numba_type=types.int64
             )
             self._form_kernel_arg_and_arg_ty(
                 self.builder.bitcast(
@@ -204,7 +204,7 @@ class KernelLaunchOps:
             )
 
             ty = numba_type_to_dpctl_typenum(
-                context=self.context, type=types.int64
+                context=self.context, numba_type=types.int64
             )
             self._form_kernel_arg_and_arg_ty(
                 self.builder.bitcast(
@@ -247,7 +247,7 @@ class KernelLaunchOps:
             # here for them to match.
             legal_names = legalize_names([var])
             ty = numba_type_to_dpctl_typenum(
-                context=self.context, type=types.voidptr
+                context=self.context, numba_type=types.voidptr
             )
 
             malloc_fn = DpctlCAPIFnBuilder.get_dpctl_malloc_shared(
@@ -323,7 +323,7 @@ class KernelLaunchOps:
                     ],
                 )
                 ty = numba_type_to_dpctl_typenum(
-                    context=self.context, type=types.int64
+                    context=self.context, numba_type=types.int64
                 )
                 self._form_kernel_arg_and_arg_ty(
                     self.builder.bitcast(
@@ -354,7 +354,7 @@ class KernelLaunchOps:
                 )
 
                 ty = numba_type_to_dpctl_typenum(
-                    context=self.context, type=types.int64
+                    context=self.context, numba_type=types.int64
                 )
                 self._form_kernel_arg_and_arg_ty(
                     self.builder.bitcast(
@@ -368,7 +368,7 @@ class KernelLaunchOps:
 
         else:
             ty = numba_type_to_dpctl_typenum(
-                context=self.context, type=arg_type
+                context=self.context, numba_type=arg_type
             )
             self._form_kernel_arg_and_arg_ty(
                 self.builder.bitcast(

--- a/numba_dpex/tests/dpjit_tests/parfors/test_unsupported_parfor_kernel_arg_error.py
+++ b/numba_dpex/tests/dpjit_tests/parfors/test_unsupported_parfor_kernel_arg_error.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+
+import dpnp
+import numpy
+import pytest
+from numba.tests.support import captured_stdout
+
+from numba_dpex import dpjit, prange
+from numba_dpex.core.exceptions import UnsupportedKernelArgumentError
+
+
+@dpjit
+def scale_prange(a, b, scalar):
+    dtype = a.dtype
+
+    for i in prange(a.shape[0]):
+        c = dtype.type(0.25) * scalar
+        b[i] = c * a[i]
+
+
+def test_unsupported_prange_arg():
+    dtype: numpy.dtype = numpy.dtype("float")
+    SCALAR = dtype.type(0.5)
+
+    a = dpnp.ones(1024)
+    b = dpnp.zeros(1024)
+
+    os.environ["NUMBA_CAPTURED_ERRORS"] = "new_style"
+    with pytest.raises(UnsupportedKernelArgumentError):
+        scale_prange(a, b, SCALAR)
+    os.unsetenv("NUMBA_CAPTURED_ERRORS")


### PR DESCRIPTION
- [X] Have you provided a meaningful PR description?

Improve error message for unsupported parfor args
  - Instead of raising a `NotImplementedError`, we now raise a more informative `numba_dpex.core.exceptions.UnsupportedKernelArgumentError` if a unsupported argument type is encountered.

Reproducer:
```python
import numpy as np
import dpnp
from numba_dpex import prange, dpjit

@dpjit
def test(a, b, scalar):
    dtype = a.dtype

    for i in prange(a.shape[0]):
        c = dtype.type(0.25) * scalar
        b[i] = c * a[i]


dtype: np.dtype = np.dtype("float")
SCALAR = dtype.type(0.5)

a = dpnp.ones(1024)
b = dpnp.zeros(1024)

test(a, b, SCALAR)
```

Before

```bash
Traceback (most recent call last):
  File "/home/diptorupd/Desktop/devel/numba-dpex/driver.py", line 25, in <module>
    test(a, b, SCALAR)
...
  File "/home/diptorupd/miniconda3/envs/dpex-devel/lib/python3.10/site-packages/numba/core/lowering.py", line 285, in lower_block
    self.lower_inst(inst)
  File "/home/diptorupd/miniconda3/envs/dpex-devel/lib/python3.10/site-packages/numba/parfors/parfor_lowering.py", line 51, in lower_inst
    _lower_parfor_parallel(self, inst)
  File "/home/diptorupd/miniconda3/envs/dpex-devel/lib/python3.10/site-packages/numba/parfors/parfor_lowering.py", line 60, in _lower_parfor_parallel
    return parfor.lowerer(lowerer, parfor)
  File "/home/diptorupd/Desktop/devel/numba-dpex/numba_dpex/core/parfors/parfor_lowerer.py", line 500, in _lower_parfor_as_kernel
    self._submit_parfor_kernel(
  File "/home/diptorupd/Desktop/devel/numba-dpex/numba_dpex/core/parfors/parfor_lowerer.py", line 198, in _submit_parfor_kernel
    self._build_kernel_arglist(kernel_fn, lowerer)
  File "/home/diptorupd/Desktop/devel/numba-dpex/numba_dpex/core/parfors/parfor_lowerer.py", line 172, in _build_kernel_arglist
    self.kernel_builder.build_arg(
  File "/home/diptorupd/Desktop/devel/numba-dpex/numba_dpex/core/utils/kernel_launcher.py", line 154, in build_arg
    numba_type_to_dpctl_typenum(
  File "/home/diptorupd/Desktop/devel/numba-dpex/numba_dpex/dpctl_iface/_helpers.py", line 48, in numba_type_to_dpctl_typenum
    raise NotImplementedError
NotImplementedError
```
After:

```bash
Traceback (most recent call last):
  File "/home/diptorupd/Desktop/devel/numba-dpex/driver.py", line 25, in <module>
    test(a, b, SCALAR)
 ...
  File "/home/diptorupd/miniconda3/envs/dpex-devel/lib/python3.10/site-packages/numba/core/lowering.py", line 187, in lower
    self.lower_normal_function(self.fndesc)
  File "/home/diptorupd/miniconda3/envs/dpex-devel/lib/python3.10/site-packages/numba/core/lowering.py", line 241, in lower_normal_function
    entry_block_tail = self.lower_function_body()
  File "/home/diptorupd/miniconda3/envs/dpex-devel/lib/python3.10/site-packages/numba/core/lowering.py", line 271, in lower_function_body
    self.lower_block(block)
  File "/home/diptorupd/miniconda3/envs/dpex-devel/lib/python3.10/site-packages/numba/core/lowering.py", line 285, in lower_block
    self.lower_inst(inst)
  File "/home/diptorupd/miniconda3/envs/dpex-devel/lib/python3.10/site-packages/numba/parfors/parfor_lowering.py", line 51, in lower_inst
    _lower_parfor_parallel(self, inst)
  File "/home/diptorupd/miniconda3/envs/dpex-devel/lib/python3.10/site-packages/numba/parfors/parfor_lowering.py", line 60, in _lower_parfor_parallel
    return parfor.lowerer(lowerer, parfor)
  File "/home/diptorupd/Desktop/devel/numba-dpex/numba_dpex/core/parfors/parfor_lowerer.py", line 500, in _lower_parfor_as_kernel
    self._submit_parfor_kernel(
  File "/home/diptorupd/Desktop/devel/numba-dpex/numba_dpex/core/parfors/parfor_lowerer.py", line 198, in _submit_parfor_kernel
    self._build_kernel_arglist(kernel_fn, lowerer)
  File "/home/diptorupd/Desktop/devel/numba-dpex/numba_dpex/core/parfors/parfor_lowerer.py", line 172, in _build_kernel_arglist
    self.kernel_builder.build_arg(
  File "/home/diptorupd/Desktop/devel/numba-dpex/numba_dpex/core/utils/kernel_launcher.py", line 154, in build_arg
    numba_type_to_dpctl_typenum(
  File "/home/diptorupd/Desktop/devel/numba-dpex/numba_dpex/dpctl_iface/_helpers.py", line 45, in numba_type_to_dpctl_typenum
    raise UnsupportedKernelArgumentError(
numba_dpex.core.exceptions.UnsupportedKernelArgumentError: Argument $dtype.12 passed to kernel __dpex_parfor_kernel_0 is of an unsupported type (<class 'numba.core.types.npytypes.DType'>). Allowed kernel arguments must be sub-types of numba.types.Number or sub-types of numba_dpex.USMNdArray
```
- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
