### PR TITLE
Various fixes to get numba-dpex build on the internal TeamCity CI/CD

### DIFF
--- a/numba_dpex/tests/core/types/DpctlSyclQueue/test_queue_ref_attr.py
+++ b/numba_dpex/tests/core/types/DpctlSyclQueue/test_queue_ref_attr.py
@@ -72,7 +72,7 @@ def test_queue_ref_access_in_dpjit():
     cq1 = dpctl._sycl_queue_manager.get_device_cached_queue(d)
     cq2 = dpctl._sycl_queue_manager.get_device_cached_queue(d)
 
-    expected = cq1 == cq2
     actual = test_queue_equality(cq1, cq2)
+    expected = cq1 == cq2
 
     assert expected == actual

--- a/numba_dpex/tests/core/types/USMNdArray/test_array_creation_errors.py
+++ b/numba_dpex/tests/core/types/USMNdArray/test_array_creation_errors.py
@@ -1,5 +1,4 @@
 import dpctl
-from numba.core.types.scalars import Float
 
 from numba_dpex.core.types import USMNdArray
 

--- a/numba_dpex/tests/dpjit_tests/parfors/test_dpnp_bitwise_ops.py
+++ b/numba_dpex/tests/dpjit_tests/parfors/test_dpnp_bitwise_ops.py
@@ -9,7 +9,6 @@ import numpy as np
 import pytest
 
 from numba_dpex import dpjit
-from numba_dpex.tests._helper import filter_strings
 
 list_of_binary_ops = [
     "bitwise_and",
@@ -51,8 +50,7 @@ def input_arrays(request):
     return a, b
 
 
-@pytest.mark.parametrize("filter_str", filter_strings)
-def test_binary_ops(filter_str, binary_op, input_arrays):
+def test_binary_ops(binary_op, input_arrays):
     a, b = input_arrays
     binop = getattr(dpnp, binary_op)
     actual = dpnp.empty(shape=a.shape, dtype=a.dtype)
@@ -73,8 +71,7 @@ def test_binary_ops(filter_str, binary_op, input_arrays):
     )
 
 
-@pytest.mark.parametrize("filter_str", filter_strings)
-def test_unary_ops(filter_str, unary_op, input_arrays):
+def test_unary_ops(unary_op, input_arrays):
     a = input_arrays[0]
     uop = getattr(dpnp, unary_op)
     actual = np.empty(shape=a.shape, dtype=a.dtype)

--- a/numba_dpex/tests/dpjit_tests/parfors/test_dpnp_logic_ops.py
+++ b/numba_dpex/tests/dpjit_tests/parfors/test_dpnp_logic_ops.py
@@ -9,7 +9,6 @@ import numpy as np
 import pytest
 
 from numba_dpex import dpjit
-from numba_dpex.tests._helper import filter_strings
 
 """ Following cases, dpnp raises NotImplementedError"""
 
@@ -61,8 +60,7 @@ def input_arrays(request):
 
 
 @pytest.mark.xfail
-@pytest.mark.parametrize("filter_str", filter_strings)
-def test_binary_ops(filter_str, binary_op, input_arrays):
+def test_binary_ops(binary_op, input_arrays):
     a, b = input_arrays
     binop = getattr(dpnp, binary_op)
     actual = dpnp.empty(shape=a.shape, dtype=a.dtype)
@@ -84,8 +82,7 @@ def test_binary_ops(filter_str, binary_op, input_arrays):
 
 
 @pytest.mark.xfail
-@pytest.mark.parametrize("filter_str", filter_strings)
-def test_unary_ops(filter_str, unary_op, input_arrays):
+def test_unary_ops(unary_op, input_arrays):
     a = input_arrays[0]
     uop = getattr(dpnp, unary_op)
     actual = dpnp.empty(shape=a.shape, dtype=a.dtype)

--- a/numba_dpex/tests/dpjit_tests/parfors/test_dpnp_transcedental_functions.py
+++ b/numba_dpex/tests/dpjit_tests/parfors/test_dpnp_transcedental_functions.py
@@ -9,7 +9,7 @@ import numpy as np
 import pytest
 
 from numba_dpex import dpjit
-from numba_dpex.tests._helper import filter_strings, is_gen12
+from numba_dpex.tests._helper import is_gen12
 
 """dpnp raise error on : mod, abs and remainder(float32)"""
 list_of_binary_ops = [
@@ -78,8 +78,7 @@ def input_arrays(request):
     return a, b
 
 
-@pytest.mark.parametrize("filter_str", filter_strings)
-def test_binary_ops(filter_str, binary_op, input_arrays):
+def test_binary_ops(binary_op, input_arrays):
     a, b = input_arrays
     binop = getattr(dpnp, binary_op)
     actual = dpnp.empty(shape=a.shape, dtype=a.dtype)
@@ -101,10 +100,10 @@ def test_binary_ops(filter_str, binary_op, input_arrays):
     )
 
 
-@pytest.mark.parametrize("filter_str", filter_strings)
-def test_unary_ops(filter_str, unary_op, input_arrays):
+def test_unary_ops(unary_op, input_arrays):
     skip_ops = ["abs", "sign", "log", "log2", "log10", "expm1"]
-    if unary_op in skip_ops and is_gen12(filter_str):
+    device = dpctl.SyclDevice()
+    if unary_op in skip_ops and is_gen12(device.filter_string):
         pytest.skip()
 
     a = input_arrays[0]

--- a/numba_dpex/tests/dpjit_tests/parfors/test_dpnp_trigonometric_functions.py
+++ b/numba_dpex/tests/dpjit_tests/parfors/test_dpnp_trigonometric_functions.py
@@ -9,19 +9,7 @@ import numpy as np
 import pytest
 
 from numba_dpex import dpjit
-from numba_dpex.tests._helper import filter_strings, is_gen12
-
-list_of_filter_strs = [
-    "opencl:gpu:0",
-    "level_zero:gpu:0",
-    "opencl:cpu:0",
-]
-
-
-@pytest.fixture(params=list_of_filter_strs)
-def filter_str(request):
-    return request.param
-
+from numba_dpex.tests._helper import is_gen12
 
 list_of_trig_ops = [
     "sin",
@@ -70,8 +58,8 @@ def input_arrays(request):
     return a, b
 
 
-@pytest.mark.parametrize("filter_str", filter_strings)
-def test_trigonometric_fn(filter_str, trig_op, input_arrays):
+def test_trigonometric_fn(trig_op, input_arrays):
+    filter_str = dpctl.SyclDevice().filter_string
     # FIXME: Why does archcosh fail on Gen12 discrete graphics card?
     if trig_op == "arccosh" and is_gen12(filter_str):
         pytest.skip()

--- a/numba_dpex/tests/kernel_tests/test_atomic_op.py
+++ b/numba_dpex/tests/kernel_tests/test_atomic_op.py
@@ -9,7 +9,7 @@ import pytest
 import numba_dpex as dpex
 from numba_dpex import config
 from numba_dpex.core.descriptor import dpex_kernel_target
-from numba_dpex.tests._helper import filter_strings, override_config
+from numba_dpex.tests._helper import override_config
 
 global_size = 100
 N = global_size
@@ -38,8 +38,8 @@ def fdtype(request):
 
 @pytest.fixture(params=list_of_i_dtypes + list_of_f_dtypes)
 def input_arrays(request):
-    def _inpute_arrays(filter_str):
-        a = np.array([0], request.param, device=filter_str)
+    def _inpute_arrays():
+        a = np.array([0], request.param)
         return a, request.param
 
     return _inpute_arrays
@@ -72,10 +72,9 @@ skip_no_atomic_support = pytest.mark.skipif(
 )
 
 
-@pytest.mark.parametrize("filter_str", filter_strings)
 @skip_no_atomic_support
-def test_kernel_atomic_simple(filter_str, input_arrays, kernel_result_pair):
-    a, dtype = input_arrays(filter_str)
+def test_kernel_atomic_simple(input_arrays, kernel_result_pair):
+    a, dtype = input_arrays()
     kernel, expected = kernel_result_pair
     kernel[dpex.Range(global_size)](a)
     assert a[0] == expected
@@ -112,10 +111,9 @@ def get_func_local(op_type, dtype):
     return f
 
 
-@pytest.mark.parametrize("filter_str", filter_strings)
 @skip_no_atomic_support
-def test_kernel_atomic_local(filter_str, input_arrays, return_list_of_op):
-    a, dtype = input_arrays(filter_str)
+def test_kernel_atomic_local(input_arrays, return_list_of_op):
+    a, dtype = input_arrays()
     op_type, expected = return_list_of_op
     f = get_func_local(op_type, dtype)
     kernel = dpex.kernel(f)
@@ -150,15 +148,14 @@ def get_kernel_multi_dim(op_type, size):
     return dpex.kernel(f)
 
 
-@pytest.mark.parametrize("filter_str", filter_strings)
 @skip_no_atomic_support
 def test_kernel_atomic_multi_dim(
-    filter_str, return_list_of_op, return_list_of_dim, return_dtype
+    return_list_of_op, return_list_of_dim, return_dtype
 ):
     op_type, expected = return_list_of_op
     dim = return_list_of_dim
     kernel = get_kernel_multi_dim(op_type, len(dim))
-    a = np.zeros(dim, dtype=return_dtype, device=filter_str)
+    a = np.zeros(dim, dtype=return_dtype)
     kernel[dpex.Range(global_size)](a)
     assert a[0] == expected
 

--- a/numba_dpex/tests/kernel_tests/test_barrier.py
+++ b/numba_dpex/tests/kernel_tests/test_barrier.py
@@ -9,13 +9,11 @@ import pytest
 
 import numba_dpex as dpex
 from numba_dpex import float32, usm_ndarray, void
-from numba_dpex.tests._helper import filter_strings
 
 f32arrty = usm_ndarray(ndim=1, dtype=float32, layout="C")
 
 
-@pytest.mark.parametrize("filter_str", filter_strings)
-def test_proper_lowering(filter_str):
+def test_proper_lowering():
     # This will trigger eager compilation
     @dpex.kernel(void(f32arrty))
     def twice(A):
@@ -35,8 +33,7 @@ def test_proper_lowering(filter_str):
     np.testing.assert_allclose(orig * 2, after)
 
 
-@pytest.mark.parametrize("filter_str", filter_strings)
-def test_no_arg_barrier_support(filter_str):
+def test_no_arg_barrier_support():
     @dpex.kernel(void(f32arrty))
     def twice(A):
         i = dpex.get_global_id(0)
@@ -54,8 +51,7 @@ def test_no_arg_barrier_support(filter_str):
     np.testing.assert_allclose(orig * 2, after)
 
 
-@pytest.mark.parametrize("filter_str", filter_strings)
-def test_local_memory(filter_str):
+def test_local_memory():
     blocksize = 10
 
     @dpex.kernel(void(f32arrty))

--- a/numba_dpex/tests/kernel_tests/test_caching.py
+++ b/numba_dpex/tests/kernel_tests/test_caching.py
@@ -11,7 +11,6 @@ import pytest
 import numba_dpex as dpex
 from numba_dpex.core.caching import LRUCache
 from numba_dpex.core.kernel_interface.dispatcher import JitKernel
-from numba_dpex.tests._helper import filter_strings
 
 
 def test_LRUcache_operations():
@@ -106,17 +105,14 @@ def test_LRUcache_operations():
     assert str(cache.evicted) == "{5: 'f', 7: 'h', 8: 'i', 9: 'j', 2: 'c'}"
 
 
-@pytest.mark.parametrize("filter_str", filter_strings)
-def test_caching_hit_counts(filter_str):
+def test_caching_hit_counts():
     """Tests the correct number of cache hits.
+
     If a Dispatcher is invoked 10 times and if the caching is enabled,
     then the total number of cache hits will be 9. Given the fact that
     the first time the kernel will be compiled and it will be loaded
     off the cache for the next time on.
 
-    Args:
-        filter_str (str): The device name coming from filter_strings in
-        ._helper.py
     """
 
     def data_parallel_sum(x, y, z):
@@ -126,9 +122,9 @@ def test_caching_hit_counts(filter_str):
         i = dpex.get_global_id(0)
         z[i] = x[i] + y[i]
 
-    a = dpt.arange(0, 100, device=filter_str)
-    b = dpt.arange(0, 100, device=filter_str)
-    c = dpt.zeros_like(a, device=filter_str)
+    a = dpt.arange(0, 100)
+    b = dpt.arange(0, 100)
+    c = dpt.zeros_like(a)
 
     expected = dpt.asnumpy(a) + dpt.asnumpy(b)
 

--- a/numba_dpex/tests/test_array_utils.py
+++ b/numba_dpex/tests/test_array_utils.py
@@ -8,9 +8,7 @@ import dpctl
 import dpctl.memory as dpctl_mem
 import dpctl.tensor as dpt
 import numpy as np
-import pytest
 
-from numba_dpex.tests._helper import filter_strings
 from numba_dpex.utils import (
     as_usm_obj,
     copy_to_numpy_from_usm_obj,
@@ -20,38 +18,34 @@ from numba_dpex.utils import (
 from . import _helper
 
 
-@pytest.mark.parametrize("filter_str", filter_strings)
-def test_has_usm_memory(filter_str):
+def test_has_usm_memory():
     a = np.ones(1023, dtype=np.float32)
+    q = dpctl.SyclQueue()
+    # test usm_ndarray
+    da = dpt.usm_ndarray(a.shape, dtype=a.dtype, buffer="shared")
+    usm_mem = has_usm_memory(da)
+    assert da.usm_data._pointer == usm_mem._pointer
 
-    with dpctl.device_context(filter_str) as q:
-        # test usm_ndarray
-        da = dpt.usm_ndarray(a.shape, dtype=a.dtype, buffer="shared")
-        usm_mem = has_usm_memory(da)
-        assert da.usm_data._pointer == usm_mem._pointer
+    # test usm allocated numpy.ndarray
+    buf = dpctl_mem.MemoryUSMShared(a.size * a.dtype.itemsize, queue=q)
+    ary_buf = np.ndarray(a.shape, buffer=buf, dtype=a.dtype)
+    usm_mem = has_usm_memory(ary_buf)
+    assert buf._pointer == usm_mem._pointer
 
-        # test usm allocated numpy.ndarray
-        buf = dpctl_mem.MemoryUSMShared(a.size * a.dtype.itemsize, queue=q)
-        ary_buf = np.ndarray(a.shape, buffer=buf, dtype=a.dtype)
-        usm_mem = has_usm_memory(ary_buf)
-        assert buf._pointer == usm_mem._pointer
-
-        usm_mem = has_usm_memory(a)
-        assert usm_mem is None
+    usm_mem = has_usm_memory(a)
+    assert usm_mem is None
 
 
-@pytest.mark.parametrize("filter_str", filter_strings)
-def test_as_usm_obj(filter_str):
+def test_as_usm_obj():
     a = np.ones(1023, dtype=np.float32)
     b = a * 3
+    queue = dpctl.SyclQueue()
+    a_copy = np.empty_like(a)
+    usm_mem = as_usm_obj(a, queue=queue)
+    copy_to_numpy_from_usm_obj(usm_mem, a_copy)
+    assert np.all(a == a_copy)
 
-    with dpctl.device_context(filter_str) as queue:
-        a_copy = np.empty_like(a)
-        usm_mem = as_usm_obj(a, queue=queue)
-        copy_to_numpy_from_usm_obj(usm_mem, a_copy)
-        assert np.all(a == a_copy)
-
-        b_copy = np.empty_like(b)
-        usm_mem = as_usm_obj(b, queue=queue, copy=False)
-        copy_to_numpy_from_usm_obj(usm_mem, b_copy)
-        assert np.any(np.not_equal(b, b_copy))
+    b_copy = np.empty_like(b)
+    usm_mem = as_usm_obj(b, queue=queue, copy=False)
+    copy_to_numpy_from_usm_obj(usm_mem, b_copy)
+    assert np.any(np.not_equal(b, b_copy))

--- a/numba_dpex/tests/test_vectorize.py
+++ b/numba_dpex/tests/test_vectorize.py
@@ -4,12 +4,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import dpctl
 import numpy as np
 import pytest
-from numba import float32, float64, int32, int64, njit, vectorize
-
-from numba_dpex.tests._helper import filter_strings
+from numba import float32, float64, int32, int64, vectorize
 
 list_of_shape = [
     (100, 100),
@@ -45,8 +42,7 @@ def input_type(request):
 
 
 @pytest.mark.xfail
-@pytest.mark.parametrize("filter_str", filter_strings)
-def test_vectorize(filter_str, shape, dtypes, input_type):
+def test_vectorize(shape, dtypes, input_type):
     def vector_add(a, b):
         return a + b
 
@@ -61,10 +57,9 @@ def test_vectorize(filter_str, shape, dtypes, input_type):
         A = dtype(1.2)
         B = dtype(2.3)
 
-    with dpctl.device_context(filter_str):
-        f = vectorize(sig, target="dpex")(vector_add)
-        expected = f(A, B)
-        actual = vector_add(A, B)
+    f = vectorize(sig, target="dpex")(vector_add)
+    expected = f(A, B)
+    actual = vector_add(A, B)
 
-        max_abs_err = np.sum(expected) - np.sum(actual)
-        assert max_abs_err < 1e-5
+    max_abs_err = np.sum(expected) - np.sum(actual)
+    assert max_abs_err < 1e-5

--- a/setup.py
+++ b/setup.py
@@ -99,6 +99,7 @@ def spirv_compile():
     clang_args = [
         compiler,
         "-flto",
+        "-fveclib=none",
         "-target",
         "spir64-unknown-unknown",
         "-c",


### PR DESCRIPTION
- [X] Have you provided a meaningful PR description?
- Add fveclib=none to the compile flags in setup.py. The flag ensures that icx does not try to link with SVML.

- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
