### PR TITLE
Changes to the DpctlSyclQueue and USMNdArray types.

### DIFF
--- a/numba_dpex/core/kernel_interface/dispatcher.py
+++ b/numba_dpex/core/kernel_interface/dispatcher.py
@@ -409,9 +409,14 @@ class JitKernel:
         # FIXME: For specialized and ahead of time compiled and cached kernels,
         # the CFD check was already done statically. The run-time check is
         # redundant. We should avoid these checks for the specialized case.
-        exec_queue = determine_kernel_launch_queue(
+        ty_queue = determine_kernel_launch_queue(
             args, argtypes, self.kernel_name
         )
+
+        # FIXME: We need a better way than having to create a queue every time.
+        device = ty_queue.sycl_device
+        exec_queue = dpctl.get_device_cached_queue(device)
+
         backend = exec_queue.backend
 
         if exec_queue.backend not in [

--- a/numba_dpex/core/parfors/kernel_builder.py
+++ b/numba_dpex/core/parfors/kernel_builder.py
@@ -6,6 +6,7 @@ import copy
 import sys
 import warnings
 
+import dpctl
 import dpctl.program as dpctl_prog
 from numba.core import ir, types
 from numba.core.errors import NumbaParallelSafetyWarning
@@ -426,7 +427,10 @@ def create_kernel_for_parfor(
     for arg in parfor_args:
         obj = typemap[arg]
         if isinstance(obj, DpnpNdArray):
-            exec_queue = obj.queue
+            filter_string = obj.queue.sycl_device
+            # FIXME: A better design is required so that we do not have to
+            # create a queue every time.
+            exec_queue = dpctl.get_device_cached_queue(filter_string)
 
     if not exec_queue:
         raise AssertionError(

--- a/numba_dpex/core/runtime/_dpexrt_python.c
+++ b/numba_dpex/core/runtime/_dpexrt_python.c
@@ -1180,7 +1180,7 @@ static int DPEXRT_sycl_queue_from_python(PyObject *obj,
     PyGILState_STATE gstate;
 
     // Increment the ref count on obj to prevent CPython from garbage
-    // collecting the array.
+    // collecting the dpctl.SyclQueue object
     Py_IncRef(obj);
 
     // We are unconditionally casting obj to a struct PySyclQueueObject*. If

--- a/numba_dpex/core/typeconv/array_conversion.py
+++ b/numba_dpex/core/typeconv/array_conversion.py
@@ -4,8 +4,7 @@
 
 from numba.np import numpy_support
 
-from numba_dpex.core.types import USMNdArray
-from numba_dpex.core.utils import get_info_from_suai
+from numba_dpex.core.types import DpctlSyclQueue, USMNdArray
 from numba_dpex.utils.constants import address_space
 
 
@@ -37,7 +36,7 @@ def to_usm_ndarray(suai_attrs, addrspace=address_space.GLOBAL):
         ndim=suai_attrs.dimensions,
         layout=layout,
         usm_type=suai_attrs.usm_type,
-        queue=suai_attrs.queue,
+        queue=DpctlSyclQueue(suai_attrs.queue),
         readonly=not suai_attrs.is_writable,
         name=None,
         aligned=True,

--- a/numba_dpex/core/typing/typeof.py
+++ b/numba_dpex/core/typing/typeof.py
@@ -42,7 +42,10 @@ def _typeof_helper(val, array_class_type):
             "The usm_type for the usm_ndarray could not be inferred"
         )
 
-    assert val.sycl_queue is not None
+    if not val.sycl_queue:
+        raise AssertionError
+
+    ty_queue = DpctlSyclQueue(sycl_queue=val.sycl_queue)
 
     return array_class_type(
         dtype=dtype,
@@ -50,7 +53,7 @@ def _typeof_helper(val, array_class_type):
         layout=layout,
         readonly=readonly,
         usm_type=usm_type,
-        queue=val.sycl_queue,
+        queue=ty_queue,
         addrspace=address_space.GLOBAL,
     )
 

--- a/numba_dpex/tests/core/types/DpctlSyclQueue/test_queue_ref_attr.py
+++ b/numba_dpex/tests/core/types/DpctlSyclQueue/test_queue_ref_attr.py
@@ -72,7 +72,7 @@ def test_queue_ref_access_in_dpjit():
     cq1 = dpctl._sycl_queue_manager.get_device_cached_queue(d)
     cq2 = dpctl._sycl_queue_manager.get_device_cached_queue(d)
 
-    expected = cq1 == cq2
     actual = test_queue_equality(cq1, cq2)
+    expected = cq1 == cq2
 
     assert expected == actual

--- a/numba_dpex/tests/core/types/USMNdArray/test_array_creation_errors.py
+++ b/numba_dpex/tests/core/types/USMNdArray/test_array_creation_errors.py
@@ -1,5 +1,4 @@
 import dpctl
-from numba.core.types.scalars import Float
 
 from numba_dpex.core.types import USMNdArray
 

--- a/numba_dpex/tests/core/types/USMNdArray/test_array_creation_errors.py
+++ b/numba_dpex/tests/core/types/USMNdArray/test_array_creation_errors.py
@@ -1,61 +1,43 @@
 import dpctl
+import pytest
 
-from numba_dpex.core.types import USMNdArray
+from numba_dpex.core.types import USMNdArray, dpctl_types
 
 
-def test_init():
-    usma = USMNdArray(1, device=None, queue=None)
-    assert usma.dtype.name == "float64"
-    assert usma.ndim == 1
-    assert usma.layout == "C"
-    assert usma.addrspace == 1
-    assert usma.usm_type == "device"
-    assert (
-        str(usma.queue.sycl_device.device_type) == "device_type.cpu"
-        or str(usma.queue.sycl_device.device_type) == "device_type.gpu"
-    )
+def test_usmndarray_negative_tests():
+    default_device = dpctl.SyclDevice().filter_string
 
-    device = dpctl.SyclDevice().filter_string
+    usmarr1 = USMNdArray(1, device=None, queue=None)
+    assert usmarr1.dtype.name == "float64"
+    assert usmarr1.ndim == 1
+    assert usmarr1.layout == "C"
+    assert usmarr1.addrspace == 1
+    assert usmarr1.usm_type == "device"
 
-    usma = USMNdArray(1, device=device, queue=None)
-    assert usma.dtype.name == "float64"
-    assert usma.ndim == 1
-    assert usma.layout == "C"
-    assert usma.addrspace == 1
-    assert usma.usm_type == "device"
-    assert (
-        str(usma.queue.sycl_device.device_type) == "device_type.cpu"
-        or str(usma.queue.sycl_device.device_type) == "device_type.gpu"
-    )
+    assert usmarr1.queue.sycl_device == default_device
 
-    # usma = USMNdArray(1, device="gpu", queue=None)
-    # assert usma.dtype.name == "int64"
-    # assert usma.ndim == 1
-    # assert usma.layout == "C"
-    # assert usma.addrspace == 1
-    # assert usma.usm_type == "device"
-    # assert str(usma.queue.sycl_device.device_type) == "device_type.gpu"
+    usmarr2 = USMNdArray(1, device=default_device, queue=None)
+    assert usmarr2.dtype.name == "float64"
+    assert usmarr2.ndim == 1
+    assert usmarr2.layout == "C"
+    assert usmarr2.addrspace == 1
+    assert usmarr2.usm_type == "device"
+    assert usmarr2.queue.sycl_device == default_device
 
-    queue = dpctl.SyclQueue()
-    usma = USMNdArray(1, device=None, queue=queue)
-    assert usma.dtype.name == "float64"
-    assert usma.ndim == 1
-    assert usma.layout == "C"
-    assert usma.addrspace == 1
-    assert usma.usm_type == "device"
-    assert usma.queue.addressof_ref() > 0
+    queue = dpctl_types.DpctlSyclQueue(dpctl.SyclQueue())
 
-    try:
-        usma = USMNdArray(1, device=device, queue=queue)
-    except Exception as e:
-        assert "exclusive keywords" in str(e)
+    usmarr3 = USMNdArray(1, device=None, queue=queue)
+    assert usmarr3.dtype.name == "float64"
+    assert usmarr3.ndim == 1
+    assert usmarr3.layout == "C"
+    assert usmarr3.addrspace == 1
+    assert usmarr3.usm_type == "device"
 
-    try:
-        usma = USMNdArray(1, queue=0)
-    except Exception as e:
-        assert "queue keyword arg" in str(e)
+    with pytest.raises(TypeError):
+        USMNdArray(1, device=default_device, queue=queue)
 
-    try:
-        usma = USMNdArray(1, device=0)
-    except Exception as e:
-        assert "SYCL filter selector" in str(e)
+    with pytest.raises(TypeError):
+        USMNdArray(1, queue=0)
+
+    with pytest.raises(TypeError):
+        USMNdArray(1, device=0)

--- a/numba_dpex/tests/core/types/USMNdArray/test_usm_ndarray_creation.py
+++ b/numba_dpex/tests/core/types/USMNdArray/test_usm_ndarray_creation.py
@@ -1,7 +1,7 @@
 import dpctl
 import pytest
 
-from numba_dpex.core.types import USMNdArray
+from numba_dpex.core.types import DpctlSyclQueue, USMNdArray
 
 """Negative tests for expected exceptions raised during USMNdArray creation.
 
@@ -49,24 +49,26 @@ def test_type_creation_with_device():
 
     if usma.queue != cached_queue:
         pytest.xfail(
-            "Returned queue does not have the same queue as cached against the device."
+            "Returned queue does not have the same queue as cached "
+            "against the device."
         )
 
 
 def test_type_creation_with_queue():
     """Tests creating a USMNdArray with a queue arg and no device"""
-    queue = dpctl.SyclQueue()
-    usma = USMNdArray(1, queue=queue)
+    ty_queue = DpctlSyclQueue(dpctl.SyclQueue())
+    usma = USMNdArray(1, queue=ty_queue)
 
     assert usma.ndim == 1
     assert usma.layout == "C"
     assert usma.addrspace == 1
     assert usma.usm_type == "device"
 
-    assert usma.device == queue.sycl_device.filter_string
-    if usma.queue != queue:
+    assert usma.device == ty_queue.sycl_device
+    if usma.queue != ty_queue:
         pytest.xfail(
-            "Returned queue does not have the same queue as the one passed to the dpnp function."
+            "Returned queue does not have the same queue as the one passed "
+            "to the dpnp function."
         )
 
 

--- a/numba_dpex/tests/dpjit_tests/dpnp/test_dpnp_empty.py
+++ b/numba_dpex/tests/dpjit_tests/dpnp/test_dpnp_empty.py
@@ -124,9 +124,6 @@ def test_dpnp_empty_exceptions():
         c = dpnp.empty(shape, sycl_queue=queue, device=device)
         return c
 
-    try:
+    with pytest.raises(errors.TypingError):
         queue = dpctl.SyclQueue()
         func(10, queue)
-    except Exception as e:
-        assert isinstance(e, errors.TypingError)
-        assert "`device` and `sycl_queue` are exclusive keywords" in str(e)

--- a/numba_dpex/tests/dpjit_tests/dpnp/test_dpnp_empty_like.py
+++ b/numba_dpex/tests/dpjit_tests/dpnp/test_dpnp_empty_like.py
@@ -176,11 +176,5 @@ def test_dpnp_empty_like_from_scalar(shape):
         x = dpnp.empty_like(shape)
         return x
 
-    try:
+    with pytest.raises(errors.TypingError):
         func(shape)
-    except Exception as e:
-        assert isinstance(e, errors.TypingError)
-        assert (
-            "No implementation of function Function(<function empty_like"
-            in str(e)
-        )

--- a/numba_dpex/tests/dpjit_tests/parfors/test_dpnp_bitwise_ops.py
+++ b/numba_dpex/tests/dpjit_tests/parfors/test_dpnp_bitwise_ops.py
@@ -9,7 +9,6 @@ import numpy as np
 import pytest
 
 from numba_dpex import dpjit
-from numba_dpex.tests._helper import filter_strings
 
 list_of_binary_ops = [
     "bitwise_and",
@@ -51,8 +50,7 @@ def input_arrays(request):
     return a, b
 
 
-@pytest.mark.parametrize("filter_str", filter_strings)
-def test_binary_ops(filter_str, binary_op, input_arrays):
+def test_binary_ops(binary_op, input_arrays):
     a, b = input_arrays
     binop = getattr(dpnp, binary_op)
     actual = dpnp.empty(shape=a.shape, dtype=a.dtype)
@@ -73,8 +71,7 @@ def test_binary_ops(filter_str, binary_op, input_arrays):
     )
 
 
-@pytest.mark.parametrize("filter_str", filter_strings)
-def test_unary_ops(filter_str, unary_op, input_arrays):
+def test_unary_ops(unary_op, input_arrays):
     a = input_arrays[0]
     uop = getattr(dpnp, unary_op)
     actual = np.empty(shape=a.shape, dtype=a.dtype)

--- a/numba_dpex/tests/dpjit_tests/parfors/test_dpnp_logic_ops.py
+++ b/numba_dpex/tests/dpjit_tests/parfors/test_dpnp_logic_ops.py
@@ -9,7 +9,6 @@ import numpy as np
 import pytest
 
 from numba_dpex import dpjit
-from numba_dpex.tests._helper import filter_strings
 
 """ Following cases, dpnp raises NotImplementedError"""
 
@@ -61,8 +60,7 @@ def input_arrays(request):
 
 
 @pytest.mark.xfail
-@pytest.mark.parametrize("filter_str", filter_strings)
-def test_binary_ops(filter_str, binary_op, input_arrays):
+def test_binary_ops(binary_op, input_arrays):
     a, b = input_arrays
     binop = getattr(dpnp, binary_op)
     actual = dpnp.empty(shape=a.shape, dtype=a.dtype)
@@ -84,8 +82,7 @@ def test_binary_ops(filter_str, binary_op, input_arrays):
 
 
 @pytest.mark.xfail
-@pytest.mark.parametrize("filter_str", filter_strings)
-def test_unary_ops(filter_str, unary_op, input_arrays):
+def test_unary_ops(unary_op, input_arrays):
     a = input_arrays[0]
     uop = getattr(dpnp, unary_op)
     actual = dpnp.empty(shape=a.shape, dtype=a.dtype)

--- a/numba_dpex/tests/dpjit_tests/parfors/test_dpnp_transcedental_functions.py
+++ b/numba_dpex/tests/dpjit_tests/parfors/test_dpnp_transcedental_functions.py
@@ -9,7 +9,7 @@ import numpy as np
 import pytest
 
 from numba_dpex import dpjit
-from numba_dpex.tests._helper import filter_strings, is_gen12
+from numba_dpex.tests._helper import is_gen12
 
 """dpnp raise error on : mod, abs and remainder(float32)"""
 list_of_binary_ops = [
@@ -78,8 +78,7 @@ def input_arrays(request):
     return a, b
 
 
-@pytest.mark.parametrize("filter_str", filter_strings)
-def test_binary_ops(filter_str, binary_op, input_arrays):
+def test_binary_ops(binary_op, input_arrays):
     a, b = input_arrays
     binop = getattr(dpnp, binary_op)
     actual = dpnp.empty(shape=a.shape, dtype=a.dtype)
@@ -101,10 +100,10 @@ def test_binary_ops(filter_str, binary_op, input_arrays):
     )
 
 
-@pytest.mark.parametrize("filter_str", filter_strings)
-def test_unary_ops(filter_str, unary_op, input_arrays):
+def test_unary_ops(unary_op, input_arrays):
     skip_ops = ["abs", "sign", "log", "log2", "log10", "expm1"]
-    if unary_op in skip_ops and is_gen12(filter_str):
+    device = dpctl.SyclDevice()
+    if unary_op in skip_ops and is_gen12(device.filter_string):
         pytest.skip()
 
     a = input_arrays[0]

--- a/numba_dpex/tests/dpjit_tests/parfors/test_dpnp_trigonometric_functions.py
+++ b/numba_dpex/tests/dpjit_tests/parfors/test_dpnp_trigonometric_functions.py
@@ -9,19 +9,7 @@ import numpy as np
 import pytest
 
 from numba_dpex import dpjit
-from numba_dpex.tests._helper import filter_strings, is_gen12
-
-list_of_filter_strs = [
-    "opencl:gpu:0",
-    "level_zero:gpu:0",
-    "opencl:cpu:0",
-]
-
-
-@pytest.fixture(params=list_of_filter_strs)
-def filter_str(request):
-    return request.param
-
+from numba_dpex.tests._helper import is_gen12
 
 list_of_trig_ops = [
     "sin",
@@ -70,8 +58,8 @@ def input_arrays(request):
     return a, b
 
 
-@pytest.mark.parametrize("filter_str", filter_strings)
-def test_trigonometric_fn(filter_str, trig_op, input_arrays):
+def test_trigonometric_fn(trig_op, input_arrays):
+    filter_str = dpctl.SyclDevice().filter_string
     # FIXME: Why does archcosh fail on Gen12 discrete graphics card?
     if trig_op == "arccosh" and is_gen12(filter_str):
         pytest.skip()

--- a/numba_dpex/tests/dpjit_tests/test_dpjit_reduction.py
+++ b/numba_dpex/tests/dpjit_tests/test_dpjit_reduction.py
@@ -65,7 +65,6 @@ def input_arrays(request):
     return a, b
 
 
-@pytest.mark.skip(reason="Gives segfault, need to fix.")
 def test_dpjit_array_arg_types_add1(input_arrays):
     """Tests passing float and int type dpnp arrays to a dpjit
     prange function.

--- a/numba_dpex/tests/kernel_tests/test_atomic_op.py
+++ b/numba_dpex/tests/kernel_tests/test_atomic_op.py
@@ -9,7 +9,7 @@ import pytest
 import numba_dpex as dpex
 from numba_dpex import config
 from numba_dpex.core.descriptor import dpex_kernel_target
-from numba_dpex.tests._helper import filter_strings, override_config
+from numba_dpex.tests._helper import override_config
 
 global_size = 100
 N = global_size
@@ -38,8 +38,8 @@ def fdtype(request):
 
 @pytest.fixture(params=list_of_i_dtypes + list_of_f_dtypes)
 def input_arrays(request):
-    def _inpute_arrays(filter_str):
-        a = np.array([0], request.param, device=filter_str)
+    def _inpute_arrays():
+        a = np.array([0], request.param)
         return a, request.param
 
     return _inpute_arrays
@@ -72,10 +72,9 @@ skip_no_atomic_support = pytest.mark.skipif(
 )
 
 
-@pytest.mark.parametrize("filter_str", filter_strings)
 @skip_no_atomic_support
-def test_kernel_atomic_simple(filter_str, input_arrays, kernel_result_pair):
-    a, dtype = input_arrays(filter_str)
+def test_kernel_atomic_simple(input_arrays, kernel_result_pair):
+    a, dtype = input_arrays()
     kernel, expected = kernel_result_pair
     kernel[dpex.Range(global_size)](a)
     assert a[0] == expected
@@ -112,10 +111,9 @@ def get_func_local(op_type, dtype):
     return f
 
 
-@pytest.mark.parametrize("filter_str", filter_strings)
 @skip_no_atomic_support
-def test_kernel_atomic_local(filter_str, input_arrays, return_list_of_op):
-    a, dtype = input_arrays(filter_str)
+def test_kernel_atomic_local(input_arrays, return_list_of_op):
+    a, dtype = input_arrays()
     op_type, expected = return_list_of_op
     f = get_func_local(op_type, dtype)
     kernel = dpex.kernel(f)
@@ -150,15 +148,14 @@ def get_kernel_multi_dim(op_type, size):
     return dpex.kernel(f)
 
 
-@pytest.mark.parametrize("filter_str", filter_strings)
 @skip_no_atomic_support
 def test_kernel_atomic_multi_dim(
-    filter_str, return_list_of_op, return_list_of_dim, return_dtype
+    return_list_of_op, return_list_of_dim, return_dtype
 ):
     op_type, expected = return_list_of_op
     dim = return_list_of_dim
     kernel = get_kernel_multi_dim(op_type, len(dim))
-    a = np.zeros(dim, dtype=return_dtype, device=filter_str)
+    a = np.zeros(dim, dtype=return_dtype)
     kernel[dpex.Range(global_size)](a)
     assert a[0] == expected
 

--- a/numba_dpex/tests/kernel_tests/test_barrier.py
+++ b/numba_dpex/tests/kernel_tests/test_barrier.py
@@ -9,13 +9,11 @@ import pytest
 
 import numba_dpex as dpex
 from numba_dpex import float32, usm_ndarray, void
-from numba_dpex.tests._helper import filter_strings
 
 f32arrty = usm_ndarray(ndim=1, dtype=float32, layout="C")
 
 
-@pytest.mark.parametrize("filter_str", filter_strings)
-def test_proper_lowering(filter_str):
+def test_proper_lowering():
     # This will trigger eager compilation
     @dpex.kernel(void(f32arrty))
     def twice(A):
@@ -35,8 +33,7 @@ def test_proper_lowering(filter_str):
     np.testing.assert_allclose(orig * 2, after)
 
 
-@pytest.mark.parametrize("filter_str", filter_strings)
-def test_no_arg_barrier_support(filter_str):
+def test_no_arg_barrier_support():
     @dpex.kernel(void(f32arrty))
     def twice(A):
         i = dpex.get_global_id(0)
@@ -54,8 +51,7 @@ def test_no_arg_barrier_support(filter_str):
     np.testing.assert_allclose(orig * 2, after)
 
 
-@pytest.mark.parametrize("filter_str", filter_strings)
-def test_local_memory(filter_str):
+def test_local_memory():
     blocksize = 10
 
     @dpex.kernel(void(f32arrty))

--- a/numba_dpex/tests/kernel_tests/test_caching.py
+++ b/numba_dpex/tests/kernel_tests/test_caching.py
@@ -11,7 +11,6 @@ import pytest
 import numba_dpex as dpex
 from numba_dpex.core.caching import LRUCache
 from numba_dpex.core.kernel_interface.dispatcher import JitKernel
-from numba_dpex.tests._helper import filter_strings
 
 
 def test_LRUcache_operations():
@@ -106,17 +105,14 @@ def test_LRUcache_operations():
     assert str(cache.evicted) == "{5: 'f', 7: 'h', 8: 'i', 9: 'j', 2: 'c'}"
 
 
-@pytest.mark.parametrize("filter_str", filter_strings)
-def test_caching_hit_counts(filter_str):
+def test_caching_hit_counts():
     """Tests the correct number of cache hits.
+
     If a Dispatcher is invoked 10 times and if the caching is enabled,
     then the total number of cache hits will be 9. Given the fact that
     the first time the kernel will be compiled and it will be loaded
     off the cache for the next time on.
 
-    Args:
-        filter_str (str): The device name coming from filter_strings in
-        ._helper.py
     """
 
     def data_parallel_sum(x, y, z):
@@ -126,9 +122,9 @@ def test_caching_hit_counts(filter_str):
         i = dpex.get_global_id(0)
         z[i] = x[i] + y[i]
 
-    a = dpt.arange(0, 100, device=filter_str)
-    b = dpt.arange(0, 100, device=filter_str)
-    c = dpt.zeros_like(a, device=filter_str)
+    a = dpt.arange(0, 100)
+    b = dpt.arange(0, 100)
+    c = dpt.zeros_like(a)
 
     expected = dpt.asnumpy(a) + dpt.asnumpy(b)
 

--- a/numba_dpex/tests/kernel_tests/test_scalar_arg_types.py
+++ b/numba_dpex/tests/kernel_tests/test_scalar_arg_types.py
@@ -46,7 +46,8 @@ def input_arrays(request):
 
 
 def test_numeric_kernel_arg_types1(input_arrays):
-    """Tests passing float, int and complex type dpnp arrays to a kernel function.
+    """Tests passing float, int and complex type dpnp arrays to a kernel
+    function.
 
     Args:
         input_arrays (dpnp.ndarray): Array arguments to be passed to a kernel.

--- a/numba_dpex/tests/test_array_utils.py
+++ b/numba_dpex/tests/test_array_utils.py
@@ -8,9 +8,7 @@ import dpctl
 import dpctl.memory as dpctl_mem
 import dpctl.tensor as dpt
 import numpy as np
-import pytest
 
-from numba_dpex.tests._helper import filter_strings
 from numba_dpex.utils import (
     as_usm_obj,
     copy_to_numpy_from_usm_obj,
@@ -20,38 +18,34 @@ from numba_dpex.utils import (
 from . import _helper
 
 
-@pytest.mark.parametrize("filter_str", filter_strings)
-def test_has_usm_memory(filter_str):
+def test_has_usm_memory():
     a = np.ones(1023, dtype=np.float32)
+    q = dpctl.SyclQueue()
+    # test usm_ndarray
+    da = dpt.usm_ndarray(a.shape, dtype=a.dtype, buffer="shared")
+    usm_mem = has_usm_memory(da)
+    assert da.usm_data._pointer == usm_mem._pointer
 
-    with dpctl.device_context(filter_str) as q:
-        # test usm_ndarray
-        da = dpt.usm_ndarray(a.shape, dtype=a.dtype, buffer="shared")
-        usm_mem = has_usm_memory(da)
-        assert da.usm_data._pointer == usm_mem._pointer
+    # test usm allocated numpy.ndarray
+    buf = dpctl_mem.MemoryUSMShared(a.size * a.dtype.itemsize, queue=q)
+    ary_buf = np.ndarray(a.shape, buffer=buf, dtype=a.dtype)
+    usm_mem = has_usm_memory(ary_buf)
+    assert buf._pointer == usm_mem._pointer
 
-        # test usm allocated numpy.ndarray
-        buf = dpctl_mem.MemoryUSMShared(a.size * a.dtype.itemsize, queue=q)
-        ary_buf = np.ndarray(a.shape, buffer=buf, dtype=a.dtype)
-        usm_mem = has_usm_memory(ary_buf)
-        assert buf._pointer == usm_mem._pointer
-
-        usm_mem = has_usm_memory(a)
-        assert usm_mem is None
+    usm_mem = has_usm_memory(a)
+    assert usm_mem is None
 
 
-@pytest.mark.parametrize("filter_str", filter_strings)
-def test_as_usm_obj(filter_str):
+def test_as_usm_obj():
     a = np.ones(1023, dtype=np.float32)
     b = a * 3
+    queue = dpctl.SyclQueue()
+    a_copy = np.empty_like(a)
+    usm_mem = as_usm_obj(a, queue=queue)
+    copy_to_numpy_from_usm_obj(usm_mem, a_copy)
+    assert np.all(a == a_copy)
 
-    with dpctl.device_context(filter_str) as queue:
-        a_copy = np.empty_like(a)
-        usm_mem = as_usm_obj(a, queue=queue)
-        copy_to_numpy_from_usm_obj(usm_mem, a_copy)
-        assert np.all(a == a_copy)
-
-        b_copy = np.empty_like(b)
-        usm_mem = as_usm_obj(b, queue=queue, copy=False)
-        copy_to_numpy_from_usm_obj(usm_mem, b_copy)
-        assert np.any(np.not_equal(b, b_copy))
+    b_copy = np.empty_like(b)
+    usm_mem = as_usm_obj(b, queue=queue, copy=False)
+    copy_to_numpy_from_usm_obj(usm_mem, b_copy)
+    assert np.any(np.not_equal(b, b_copy))

--- a/numba_dpex/tests/test_vectorize.py
+++ b/numba_dpex/tests/test_vectorize.py
@@ -4,12 +4,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import dpctl
 import numpy as np
 import pytest
-from numba import float32, float64, int32, int64, njit, vectorize
-
-from numba_dpex.tests._helper import filter_strings
+from numba import float32, float64, int32, int64, vectorize
 
 list_of_shape = [
     (100, 100),
@@ -45,8 +42,7 @@ def input_type(request):
 
 
 @pytest.mark.xfail
-@pytest.mark.parametrize("filter_str", filter_strings)
-def test_vectorize(filter_str, shape, dtypes, input_type):
+def test_vectorize(shape, dtypes, input_type):
     def vector_add(a, b):
         return a + b
 
@@ -61,10 +57,9 @@ def test_vectorize(filter_str, shape, dtypes, input_type):
         A = dtype(1.2)
         B = dtype(2.3)
 
-    with dpctl.device_context(filter_str):
-        f = vectorize(sig, target="dpex")(vector_add)
-        expected = f(A, B)
-        actual = vector_add(A, B)
+    f = vectorize(sig, target="dpex")(vector_add)
+    expected = f(A, B)
+    actual = vector_add(A, B)
 
-        max_abs_err = np.sum(expected) - np.sum(actual)
-        assert max_abs_err < 1e-5
+    max_abs_err = np.sum(expected) - np.sum(actual)
+    assert max_abs_err < 1e-5

--- a/setup.py
+++ b/setup.py
@@ -99,6 +99,7 @@ def spirv_compile():
     clang_args = [
         compiler,
         "-flto",
+        "-fveclib=none",
         "-target",
         "spir64-unknown-unknown",
         "-c",


### PR DESCRIPTION
- [X] Have you provided a meaningful PR description?
   
Storing the Python dpctl.SyclQueue inside any instance of the DpctlSyclQueue type was causing segfaults due to the Python object getting garbage collected prematurely.

The changes in the PR update the DpctlSyclQueue type to only store the filter string associated with the dpctl.SyclQueue and not the actual Python object. In addition, the USMNdArray type now stores an instance of a DpctlSyclQueue in its queue parameter instead of a Python dpctl.SyclQueue object.

Due to these changes, all places where the Python dpctl.SyclQueue was getting extracted and used from a UsmNdArray instance or DpctlSyclQueue instance have been updated.

All test cases were also updated.

- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
