### PR TITLE
Passing tests are incorrectly marked xfail.

### DIFF
--- a/numba_dpex/tests/dpjit_tests/parfors/test_dpnp_logic_ops.py
+++ b/numba_dpex/tests/dpjit_tests/parfors/test_dpnp_logic_ops.py
@@ -59,7 +59,6 @@ def input_arrays(request):
     return a, b
 
 
-@pytest.mark.xfail
 def test_binary_ops(binary_op, input_arrays):
     a, b = input_arrays
     binop = getattr(dpnp, binary_op)


### PR DESCRIPTION
Removes xfail for unit tests that actually pass