### PR TITLE
Fix/opencl gpu exec

### DIFF
--- a/numba_dpex/core/parfors/kernel_builder.py
+++ b/numba_dpex/core/parfors/kernel_builder.py
@@ -28,7 +28,7 @@ import numba_dpex as dpex
 from numba_dpex import config
 
 from ..descriptor import dpex_kernel_target
-from ..types.dpnp_ndarray_type import DpnpNdArray
+from ..types import DpnpNdArray, USMNdArray
 from ..utils.kernel_templates import RangeKernelTemplate
 
 
@@ -69,6 +69,30 @@ def _compile_kernel_parfor(
     kernel = dpex.core.kernel_interface.spirv_kernel.SpirvKernel(
         func_ir, kernel_name
     )
+
+    # A cast from DpnpNdArray type to USMNdArray is needed for all arguments of
+    # DpnpNdArray type. Although, DpnpNdArray derives from USMNdArray the two
+    # types use different data models. USMNdArray uses the
+    # numba_dpex.core.datamodel.models.ArrayModel data model that defines all
+    # CPointer type members in the GLOBAL address space. The DpnpNdArray uses
+    # Numba's default ArrayModel that does not define pointers in any specific
+    # address space. For OpenCL HD Graphics devices, defining a kernel function
+    # (spir_kernel calling convention) with pointer arguments that have no
+    # address space qualifier causes a run time crash. By casting the argument
+    # type for parfor arguments from DpnpNdArray type to the USMNdArray type the
+    # generated kernel always has an address space qualifier, avoiding the issue
+    # on OpenCL HD graphics devices.
+
+    for i, argty in enumerate(argtypes):
+        if isinstance(argty, DpnpNdArray):
+            new_argty = USMNdArray(
+                ndim=argty.ndim,
+                layout=argty.layout,
+                dtype=argty.dtype,
+                usm_type=argty.usm_type,
+                queue=argty.queue,
+            )
+            argtypes[i] = new_argty
 
     # compile the kernel
     kernel.compile(

--- a/numba_dpex/core/types/dpnp_ndarray_type.py
+++ b/numba_dpex/core/types/dpnp_ndarray_type.py
@@ -58,6 +58,12 @@ class DpnpNdArray(USMNdArray):
         else:
             return
 
+    def __str__(self):
+        return self.name.replace("USMNdArray", "DpnpNdarray")
+
+    def __repr__(self):
+        return self.__str__()
+
     def __allocate__(
         self,
         typingctx,

--- a/numba_dpex/core/types/usm_ndarray_type.py
+++ b/numba_dpex/core/types/usm_ndarray_type.py
@@ -87,7 +87,7 @@ class USMNdArray(Array):
             self.dtype = dtype
 
         if name is None:
-            type_name = "usm_ndarray"
+            type_name = "USMNdArray"
             if readonly:
                 type_name = "readonly " + type_name
             if not aligned:
@@ -115,6 +115,9 @@ class USMNdArray(Array):
             name=name,
             aligned=aligned,
         )
+
+    def __repr__(self):
+        return self.name
 
     def copy(
         self,


### PR DESCRIPTION
- [X] Have you provided a meaningful PR description?

All parfor array arguments are now inferred as `USMNdArray` instead of `DpnpNdArray`. The change ensures that any kernel functions (LLVM IR function with a `spir_kernel` calling convention) that is generated from a parfor always has an address space qualifier for every pointer argument. Defining a kernel function that has pointer arguments with no address space qualifier results in a crash for OpenCL UHD Graphics driver-based devices.

- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
No existing tests were tested with `ONEAPI_DEVICE_SELECTOR=opencl:gpu`
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
