### PR TITLE
fix: update sourceware resources

### DIFF
--- a/docs/user_guides/debugging/backtrace.rst
+++ b/docs/user_guides/debugging/backtrace.rst
@@ -32,4 +32,4 @@ Example 2:
 See also:
 
     - `Backtraces in GDB*
-      <https://sourceware.org/gdb/current/onlinedocs/gdb/Backtrace.html#Backtrace>`_
+      <https://sourceware.org/gdb/onlinedocs/gdb/Backtrace.html#Backtrace>`_

--- a/docs/user_guides/debugging/breakpoints.rst
+++ b/docs/user_guides/debugging/breakpoints.rst
@@ -17,7 +17,7 @@ You have several ways to set breakpoints:
 See also:
   - `Breakpoints in GDB*`_.
 
-.. _Breakpoints in GDB*: https://sourceware.org/gdb/current/onlinedocs/gdb/Set-Breaks.html#Set-Breaks
+.. _Breakpoints in GDB*: https://sourceware.org/gdb/onlinedocs/gdb/Set-Breaks.html#Set-Breaks
 
 Consider the following numba-dpex kernel code (refer
 ``numba_dpex/examples/debug/simple_sum.py`` for full example):

--- a/docs/user_guides/debugging/stepping.rst
+++ b/docs/user_guides/debugging/stepping.rst
@@ -72,4 +72,4 @@ a single line without interference, set the scheduler-locking setting to `on` or
 
 See also:
 
-- `Continuing and Stepping in GDB* <https://sourceware.org/gdb/current/onlinedocs/gdb/Continuing-and-Stepping.html#Continuing-and-Stepping>`_
+- `Continuing and Stepping in GDB* <https://sourceware.org/gdb/onlinedocs/gdb/Continuing-and-Stepping.html#Continuing-and-Stepping>`_


### PR DESCRIPTION
- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?

This PR resolves Sourceware resources in different files. Instead of `https://sourceware.org/gdb/current/onlinedocs/*` it should be `https://sourceware.org/gdb/onlinedocs/*`.