### PR TITLE
Fix typo causing improper datamodel lookup.

### DIFF
--- a/numba_dpex/core/parfors/parfor_lowerer.py
+++ b/numba_dpex/core/parfors/parfor_lowerer.py
@@ -136,7 +136,7 @@ class ParforLowerImpl:
             argtype = kernel_fn.kernel_arg_types[arg_num]
             llvm_val = _getvar(lowerer, arg)
             if isinstance(argtype, DpnpNdArray):
-                datamodel = dpex_dmm.lookup(arg_type)
+                datamodel = dpex_dmm.lookup(argtype)
                 self.kernel_builder.build_array_arg(
                     array_val=llvm_val,
                     array_data_model=datamodel,

--- a/numba_dpex/tests/dpjit_tests/parfors/prange/test_pairwise_distance.py
+++ b/numba_dpex/tests/dpjit_tests/parfors/prange/test_pairwise_distance.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import dpctl
+import dpnp
+import numba as nb
+import pytest
+
+from numba_dpex import dpjit
+
+
+def test_pairwise_distance():
+    @dpjit
+    def pairwise_distance(X1, X2, D):
+        """Naïve pairwise distance impl - take an array representing M points in N
+        dimensions, and return the M x M matrix of Euclidean distances
+
+        Args:
+            X1 : Set of points
+            X2 : Set of points
+            D  : Outputted distance matrix
+        """
+        # Size of inputs
+        X1_rows = X1.shape[0]
+        X2_rows = X2.shape[0]
+        X1_cols = X1.shape[1]
+
+        # TODO: get rid of it once prange supports dtype
+        # https://github.com/IntelPython/numba-dpex/issues/1063
+        float0 = X1.dtype.type(0.0)
+
+        # Outermost parallel loop over the matrix X1
+        for i in nb.prange(X1_rows):
+            # Loop over the matrix X2
+            for j in range(X2_rows):
+                d = float0
+                # Compute exclidean distance
+                for k in range(X1_cols):
+                    tmp = X1[i, k] - X2[j, k]
+                    d += tmp * tmp
+                # Write computed distance to distance matrix
+                D[i, j] = dpnp.sqrt(d)
+
+    q = dpctl.SyclQueue()
+    X1 = dpnp.ones((100, 2), sycl_queue=q)
+    X2 = dpnp.ones((100, 2), sycl_queue=q)
+    D = dpnp.empty((100, 100), sycl_queue=q)
+
+    try:
+        pairwise_distance(X1, X2, D)
+    except:
+        pytest.fail("Failed to compile prange loop for pairwise distance calc")


### PR DESCRIPTION
- [x] Have you provided a meaningful PR description?
A typo in the parfor_lower module was resulting in improper data model lookup for prange arguments. The PR fixes the issue.

- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
Yes
- [X] Have you made sure that new changes do not introduce compiler warnings?
Yes
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
