### PR TITLE
scikit-build setup.py for numba-dpex

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,38 @@
+#[=======================================================================[.rst:
+numba_dpex
+-----------
+
+A cmake file to compile the ``_dpexrt_python`` Python C extension for
+``numba_dpex``. You can build this component locally in-place by invoking these
+commands:
+
+.. code-block:: cmake
+    ~$ cmake .
+    ~$ cmake --build . --verbose
+
+Once compiled, the _dpexrt_python library will be in ``numba_dpex/core/runtime``
+folder.
+
+This ``CMakeLists.txt`` file will be used by ``setup.py``.
+#]=======================================================================]
+
+cmake_minimum_required(VERSION 3.21...3.27 FATAL_ERROR)
+
+if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.24")
+    cmake_policy(SET CMP0135 NEW)
+endif()
+
+message(STATUS "NUMBA_DPEX_VERSION=" "${NUMBA_DPEX_VERSION}")
+
+project(numba-dpex
+    DESCRIPTION "An extension for Numba to add data-parallel offload capability"
+    VERSION ${NUMBA_DPEX_VERSION}
+)
+
+if(IS_INSTALL)
+    install(DIRECTORY numba_dpex
+        DESTINATION ${CMAKE_INSTALL_PREFIX}
+        FILES_MATCHING PATTERN "*.py")
+endif()
+
+add_subdirectory(numba_dpex)

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,9 +1,6 @@
 include MANIFEST.in
 include README.md setup.py LICENSE
 
-recursive-include numba_dpex *.cl
-recursive-include numba_dpex *.spir
-
 include versioneer.py
 include numba_dpex/_version.py
 

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -17,7 +17,9 @@ requirements:
     host:
         - python
         - setuptools >=63.*
-        - numba 0.57*
+        - scikit-build
+        - cmake
+        - numba >=0.57*
         - dpctl >=0.14*
         - dpnp >=0.11*
         - dpcpp-llvm-spirv

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -17,8 +17,8 @@ requirements:
     host:
         - python
         - setuptools >=63.*
-        - scikit-build
-        - cmake
+        - scikit-build >=0.15*
+        - cmake >=3.26*
         - numba >=0.57*
         - dpctl >=0.14*
         - dpnp >=0.11*

--- a/environment.yml
+++ b/environment.yml
@@ -16,6 +16,8 @@ dependencies:
   - mkl >=2021.3.0  # for dpnp
   - dpcpp-llvm-spirv
   - packaging
+  - scikit-build
+  - cmake
   - pytest
   - pip
   - pip:

--- a/environment.yml
+++ b/environment.yml
@@ -16,8 +16,8 @@ dependencies:
   - mkl >=2021.3.0  # for dpnp
   - dpcpp-llvm-spirv
   - packaging
-  - scikit-build
-  - cmake
+  - scikit-build >=0.15*
+  - cmake >=3.26*
   - pytest
   - pip
   - pip:

--- a/environment/coverage.yml
+++ b/environment/coverage.yml
@@ -20,3 +20,5 @@ dependencies:
   - pytest-cov
   - pytest-xdist
   - pexpect
+  - scikit-build
+  - cmake

--- a/environment/coverage.yml
+++ b/environment/coverage.yml
@@ -20,5 +20,5 @@ dependencies:
   - pytest-cov
   - pytest-xdist
   - pexpect
-  - scikit-build
-  - cmake
+  - scikit-build>=0.15*
+  - cmake>=3.26*

--- a/numba_dpex/CMakeLists.txt
+++ b/numba_dpex/CMakeLists.txt
@@ -1,0 +1,48 @@
+if(IS_INSTALL)
+    install(DIRECTORY core
+        DESTINATION numba_dpex
+        FILES_MATCHING PATTERN "*.py")
+endif()
+
+add_subdirectory(core/runtime)
+
+if(IS_INSTALL)
+    install(DIRECTORY dpctl_iface
+        DESTINATION numba_dpex
+        FILES_MATCHING PATTERN "*.py")
+endif()
+
+if(IS_INSTALL)
+    install(DIRECTORY dpnp_iface
+        DESTINATION numba_dpex
+        FILES_MATCHING PATTERN "*.py")
+endif()
+
+if(IS_INSTALL)
+    install(DIRECTORY examples
+        DESTINATION numba_dpex)
+endif()
+
+if(IS_INSTALL)
+    install(DIRECTORY numba_patches
+        DESTINATION numba_dpex
+        FILES_MATCHING PATTERN "*.py")
+endif()
+
+if(IS_INSTALL)
+    install(DIRECTORY ocl
+        DESTINATION numba_dpex
+        FILES_MATCHING PATTERN "*.py")
+endif()
+
+if(IS_INSTALL)
+    install(DIRECTORY tests
+        DESTINATION numba_dpex
+        FILES_MATCHING PATTERN "*.py")
+endif()
+
+if(IS_INSTALL)
+    install(DIRECTORY utils
+        DESTINATION numba_dpex
+        FILES_MATCHING PATTERN "*.py")
+endif()

--- a/numba_dpex/core/runtime/CMakeLists.txt
+++ b/numba_dpex/core/runtime/CMakeLists.txt
@@ -1,0 +1,124 @@
+#[=======================================================================[.rst:
+_dpexrt_python
+---------------
+
+A cmake file to compile the ``_dpexrt_python`` Python C extension for
+``numba_dpex``. You can build this component locally in-place by invoking these
+commands:
+
+.. code-block:: cmake
+    ~$ cmake .
+    ~$ cmake --build . --verbose
+
+Once compiled, the _dpexrt_python library will be in ``numba_dpex/core/runtime``
+folder.
+#]=======================================================================]
+
+cmake_minimum_required(VERSION 3.21...3.27 FATAL_ERROR)
+
+if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.24")
+    cmake_policy(SET CMP0135 NEW)
+endif()
+
+project(_dpexrt_python
+    DESCRIPTION "A Python C extension for numba-dpex runtime."
+)
+
+# Get numba include path
+if(NOT DEFINED Numba_INCLUDE_DIRS)
+    execute_process(
+        COMMAND python -c "import numba; print(numba.extending.include_path());"
+        OUTPUT_VARIABLE Numba_INCLUDE_DIRS
+        RESULT_VARIABLE RET
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+
+    if(RET EQUAL "1")
+        message(FATAL_ERROR "Module \'numba\' not found.")
+    endif()
+endif()
+
+# Get dpctl library path
+if(NOT DEFINED DPCTL_LIBRARY_PATH)
+    execute_process(
+        COMMAND python -c "import dpctl; import os; print(os.path.dirname(dpctl.__file__));"
+        OUTPUT_VARIABLE DPCTL_LIBRARY_PATH
+        RESULT_VARIABLE RET
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+
+    if(RET EQUAL "1")
+        message(FATAL_ERROR "Module \'dpctl\' not found.")
+    endif()
+endif()
+
+# Update CMAKE_MODULE_PATH
+set(DPCTL_MODULE_PATH ${DPCTL_LIBRARY_PATH}/resources/cmake)
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${DPCTL_MODULE_PATH})
+
+# Get scikit-build path
+if(NOT DEFINED SKBUILD_PATH)
+    execute_process(
+        COMMAND python -c "import skbuild; print(skbuild.__path__[0]);"
+        OUTPUT_VARIABLE SKBUILD_PATH
+        RESULT_VARIABLE RET
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+
+    if(RET EQUAL "1")
+        message(FATAL_ERROR "Module \'skbuild\' not found.")
+    endif()
+endif()
+
+# Update CMAKE_MODULE_PATH
+set(SKBUILD_MODULE_PATH ${SKBUILD_PATH}/resources/cmake)
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${SKBUILD_MODULE_PATH})
+
+# Check CMAKE_MODULE_PATH
+message(STATUS "CMAKE_MODULE_PATH=" "${CMAKE_MODULE_PATH}")
+
+# Add packages
+find_package(PythonLibs REQUIRED)
+find_package(PythonExtensions REQUIRED)
+find_package(NumPy REQUIRED)
+find_package(Dpctl REQUIRED)
+
+# Includes
+include(GNUInstallDirs)
+include_directories(${Python_INCLUDE_DIRS})
+include_directories(${NumPy_INCLUDE_DIRS})
+include_directories(${Numba_INCLUDE_DIRS})
+include_directories(${Dpctl_INCLUDE_DIRS})
+include_directories(.)
+
+# Source files, *.c
+file(GLOB SOURCES "*.c")
+
+# Link dpctl library path with -L
+link_directories(${DPCTL_LIBRARY_PATH})
+
+# Output static library, *.so or *.dll
+add_library(${PROJECT_NAME} MODULE ${SOURCES})
+
+# Link the static library to python libraries and DPCTLSyclInterface
+target_link_libraries(${PROJECT_NAME} ${Python_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} DPCTLSyclInterface)
+
+# Build python extension module
+python_extension_module(${PROJECT_NAME})
+
+# If IS_DEVELOP, copy back the target into numba_dpex/core/runtime
+if(IS_DEVELOP)
+    add_custom_command(
+        TARGET ${PROJECT_NAME}
+        POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy
+        ${CMAKE_BINARY_DIR}/numba_dpex/core/runtime/*.so
+        ${CMAKE_SOURCE_DIR}/numba_dpex/core/runtime/
+    )
+endif()
+
+# Install
+install(
+    TARGETS ${PROJECT_NAME} LIBRARY DESTINATION numba_dpex/core/runtime
+)

--- a/numba_dpex/tests/core/types/__init__.py
+++ b/numba_dpex/tests/core/types/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from . import *

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,3 +44,14 @@ VCS = "git"
 style = "pep440"
 versionfile_source = "numba_dpex/_version.py"
 parentdir_prefix = ""
+
+[build-system]
+requires = [
+    "setuptools>=42",
+    "scikit-build>=0.13",
+    "cmake>=3.18",
+    "ninja",
+    "numba>=0.57",
+    "versioneer-518"
+]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
We need to switch to scikit-build based setup. 

This will make easy to integrate/compile different extensions and libraries with orthogonal requirements.

JIRA Reference: [SAT-6040](https://jira.devtools.intel.com/browse/SAT-6040)

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
