### PR TITLE
Removes spirv-tools as a runtime conda dependency.

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -26,7 +26,6 @@ requirements:
         - python
         - numba >=0.57*
         - dpctl >=0.14*
-        - spirv-tools
         - dpcpp-llvm-spirv
         - dpnp >=0.11*
         - packaging

--- a/environment.yml
+++ b/environment.yml
@@ -14,7 +14,6 @@ dependencies:
   - dpctl >=0.14*
   - dpnp >=0.11*
   - mkl >=2021.3.0  # for dpnp
-  - spirv-tools
   - dpcpp-llvm-spirv
   - packaging
   - pytest


### PR DESCRIPTION
#1103 removed `spirv-tools` as a requirement for numba-dpex. The PR removes `spirv-tools` as a run-time dependency from our `meta.yaml`.