### PR TITLE
Generate proper mangled name for kernel functions

### DIFF
--- a/numba_dpex/core/codegen.py
+++ b/numba_dpex/core/codegen.py
@@ -35,6 +35,7 @@ class SPIRVCodeLibrary(CPUCodeLibrary):
         pmb.opt_level = config.OPT
 
         pmb.disable_unit_at_a_time = False
+        pmb.inlining_threshold = 2
         pmb.disable_unroll_loops = True
         pmb.loop_vectorize = False
         pmb.slp_vectorize = False

--- a/numba_dpex/core/kernel_interface/spirv_kernel.py
+++ b/numba_dpex/core/kernel_interface/spirv_kernel.py
@@ -136,6 +136,7 @@ class SpirvKernel(KernelInterface):
         kernel = cres.target_context.prepare_ocl_kernel(
             func, cres.signature.args
         )
+        cres.library._optimize_final_module()
         self._llvm_module = kernel.module.__str__()
         self._module_name = kernel.name
 

--- a/numba_dpex/core/types/usm_ndarray_type.py
+++ b/numba_dpex/core/types/usm_ndarray_type.py
@@ -222,3 +222,17 @@ class USMNdArray(Array):
     @property
     def box_type(self):
         return dpctl.tensor.usm_ndarray
+
+    @property
+    def mangling_args(self):
+        """Returns a list of parameters used to create a mangled name for a
+        USMNdArray type.
+        """
+        filter_str_splits = self.device.split(":")
+        args = [
+            self.dtype,
+            self.ndim,
+            self.layout,
+            filter_str_splits[0] + "_" + filter_str_splits[1],
+        ]
+        return self.__class__.__name__, args


### PR DESCRIPTION
- [X] Have you provided a meaningful PR description?

Fixes how function names are generated at the LLVM IR level for `numba_dpex.kernel` decorated functions and auto-generated kernels for parfor nodes.

Previously an unreadable gobbledegook was generated
> dpex_py_devfn__5F__5F_main_5F__5F__2E_kernel_5F_vector_5F_sum_24_1_2E_USMNdArray_28_dtype_3D_float64_2C__20_ndim_3D_1_2C__20_layout_3D_C_2C__20_address_5F_space_3D_1_2C__20_usm_5F_type_3D_device_2C__20_device_3D_level_5F_zero_3A_gpu_3A_0_2C__20_sycl_5F_queue_3D_DpctlSyclQueue_29__2E_USMNdArray_28_dtype_3D_float64_2C__20_ndim_3D_1_2C__20_layout_3D_C_2C__20_address_5F_space_3D_1_2C__20_usm_5F_type_3D_device_2C__20_device_3D_level_5F_zero_3A_gpu_3A_0_2C__20_sycl_5F_queue_3D_DpctlSyclQueue_29__2E_USMNdArray_28_dtype_3D_float64_2C__20_ndim_3D_1_2C__20_layout_3D_C_2C__20_address_5F_space_3D_1_2C__20_usm_5F_type_3D_device_2C__20_device_3D_level_5F_zero_3A_gpu_3A_0_2C__20_sycl_5F_queue_3D_DpctlSyclQueue_29_

After the fix:
> _ZN8__main__28kernel_vector_sum_241dpex_fnB2v1B40c8tJTC_2fWQI8IW1CiAAYKPM6RBFDjESyhCQA_3dE10USMNdArrayIdLi1E1C14level_zero_gpuE10USMNdArrayIdLi1E1C14level_zero_gpuE10USMNdArrayIdLi1E1C14level_zero_gpuE

The new function names can also be demangled (*e.g.,* using `c++filt`) into human readable format:

> __main__::kernel_vector_sum_241dpex_fn[abi:v1][abi:c8tJTC_2fWQI8IW1CiAAYKPM6RBFDjESyhCQA_3d](USMNdArray<double, 1, C, level_zero_gpu>, USMNdArray<double, 1, C, level_zero_gpu>, USMNdArray<double, 1, C, level_zero_gpu>)

For parfor auto generated kernels:

>_ZN08NumbaEnv13_3cdynamic_3e33__dpex_parfor_kernel_0_245dpex_fnB2v5B40c8tJTC_2fWQI8IW1CiAAYKPM6RBFDjESyhCQA_3dE10USMNdArrayIfLi1E1C10opencl_gpuE10USMNdArrayIfLi1E1C10opencl_gpuE10USMNdArrayIfLi1E1C10opencl_gpuE

that demangles into:

>NumbaEnv::_3cdynamic_3e::__dpex_parfor_kernel_0_245dpex_fn[abi:v5][abi:c8tJTC_2fWQI8IW1CiAAYKPM6RBFDjESyhCQA_3d](USMNdArray<float, 1, C, opencl_gpu>, USMNdArray<float, 1, C, opencl_gpu>, USMNdArray<float, 1, C, opencl_gpu>)


Additionally, the LLVM module is now lightly optimized prior to spirv generation to ensure that the `spir_func` gets fully inlined into the `spir_kernel` wrapper function.

- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?

Fixes #260 