### PR TITLE
Do not build for python 3.8 in Github CI

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.8', '3.9', '3.10']
+        python: ['3.9', '3.10']
         os: [ubuntu-latest, windows-latest]
 
     runs-on: ${{ matrix.os }}
@@ -93,7 +93,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.8', '3.9', '3.10']
+        python: ['3.9', '3.10']
         os: [ubuntu-20.04, ubuntu-latest, windows-latest]
         experimental: [false]
 
@@ -199,7 +199,7 @@ jobs:
 
     strategy:
       matrix:
-        python: ['3.8', '3.9', '3.10']
+        python: ['3.9', '3.10']
         os: [ubuntu-latest, windows-latest]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,7 +22,7 @@ on:
       oneapi_version:
         default: '2023.1.0.46401'
       python_versions:
-        default: '["3.8", "3.9", "3.10", "3.11"]'
+        default: '["3.9", "3.10", "3.11"]'
       buildkit_version:
         default: '0.11.6'
 

--- a/build-environment.yml
+++ b/build-environment.yml
@@ -1,9 +1,0 @@
-name: build
-channels:
-  - defaults
-dependencies:
-  - conda-build
-  - python=3.8
-variables:
-  CHANNELS: -c defaults -c numba -c intel -c numba/label/dev -c dppy/label/dev --override-channels
-  CHANNELS_DEV: -c dppy/label/dev -c defaults -c numba -c intel -c numba/label/dev --override-channels

--- a/numba_dpex/core/runtime/_nrt_python_helper.c
+++ b/numba_dpex/core/runtime/_nrt_python_helper.c
@@ -170,20 +170,12 @@ PyTypeObject MemInfoType = {
      * https://github.com/python/cpython/blob/d917cfe4051d45b2b755c726c096ecfcc4869ceb/Include/cpython/object.h#L257
      */
     0, /* tp_vectorcall */
-#if (PY_MAJOR_VERSION == 3) && (PY_MINOR_VERSION == 8)
-    /* This is Python 3.8 only.
-     * See: https://github.com/python/cpython/blob/3.8/Include/cpython/object.h
-     * there's a tp_print preserved for backwards compatibility. xref:
-     * https://github.com/python/cpython/blob/d917cfe4051d45b2b755c726c096ecfcc4869ceb/Include/cpython/object.h#L260
-     */
-    0, /* tp_print */
-#endif
 
 /* WARNING: Do not remove this, only modify it! It is a version guard to
  * act as a reminder to update this struct on Python version update! */
 #if (PY_MAJOR_VERSION == 3)
-#if !((PY_MINOR_VERSION == 8) || (PY_MINOR_VERSION == 9) ||                    \
-      (PY_MINOR_VERSION == 10) || (PY_MINOR_VERSION == 11))
+#if !((PY_MINOR_VERSION == 9) || (PY_MINOR_VERSION == 10) ||                   \
+      (PY_MINOR_VERSION == 11))
 #error "Python minor version is not supported."
 #endif
 #else


### PR DESCRIPTION
Python 3.8 is no longer officially supported.

Fixes #1114 