### PR TITLE
Use different data models for DpnpNdArray Type for kernel and dpjit targets

### DIFF
--- a/numba_dpex/core/parfors/kernel_builder.py
+++ b/numba_dpex/core/parfors/kernel_builder.py
@@ -70,30 +70,6 @@ def _compile_kernel_parfor(
         func_ir, kernel_name
     )
 
-    # A cast from DpnpNdArray type to USMNdArray is needed for all arguments of
-    # DpnpNdArray type. Although, DpnpNdArray derives from USMNdArray the two
-    # types use different data models. USMNdArray uses the
-    # numba_dpex.core.datamodel.models.ArrayModel data model that defines all
-    # CPointer type members in the GLOBAL address space. The DpnpNdArray uses
-    # Numba's default ArrayModel that does not define pointers in any specific
-    # address space. For OpenCL HD Graphics devices, defining a kernel function
-    # (spir_kernel calling convention) with pointer arguments that have no
-    # address space qualifier causes a run time crash. By casting the argument
-    # type for parfor arguments from DpnpNdArray type to the USMNdArray type the
-    # generated kernel always has an address space qualifier, avoiding the issue
-    # on OpenCL HD graphics devices.
-
-    for i, argty in enumerate(argtypes):
-        if isinstance(argty, DpnpNdArray):
-            new_argty = USMNdArray(
-                ndim=argty.ndim,
-                layout=argty.layout,
-                dtype=argty.dtype,
-                usm_type=argty.usm_type,
-                queue=argty.queue,
-            )
-            argtypes[i] = new_argty
-
     # compile the kernel
     kernel.compile(
         args=argtypes,

--- a/numba_dpex/core/targets/kernel_target.py
+++ b/numba_dpex/core/targets/kernel_target.py
@@ -72,28 +72,6 @@ class DpexKernelTypingContext(typing.BaseContext):
                     type=str(type(val)), value=val
                 )
 
-            # A cast from DpnpNdArray type to USMNdArray is needed for all
-            # arguments of DpnpNdArray type. Although, DpnpNdArray derives from
-            # USMNdArray the two types use different data models. USMNdArray
-            # uses the numba_dpex.core.datamodel.models.ArrayModel data model
-            # that defines all CPointer type members in the GLOBAL address
-            # space. The DpnpNdArray uses Numba's default ArrayModel that does
-            # not define pointers in any specific address space. For OpenCL HD
-            # Graphics devices, defining a kernel function (spir_kernel calling
-            # convention) with pointer arguments that have no address space
-            # qualifier causes a run time crash. By casting the argument type
-            # for parfor arguments from DpnpNdArray type to the USMNdArray type
-            # the generated kernel always has an address space qualifier,
-            # avoiding the issue on OpenCL HD graphics devices.
-            if isinstance(numba_type, DpnpNdArray):
-                return USMNdArray(
-                    ndim=numba_type.ndim,
-                    layout=numba_type.layout,
-                    dtype=numba_type.dtype,
-                    usm_type=numba_type.usm_type,
-                    queue=numba_type.queue,
-                )
-
         except ValueError:
             # When an array-like kernel argument is not recognized by
             # numba-dpex, this additional check sees if the array-like object

--- a/numba_dpex/dpnp_iface/arrayobj.py
+++ b/numba_dpex/dpnp_iface/arrayobj.py
@@ -1075,12 +1075,13 @@ def getitem_arraynd_intp(context, builder, sig, args):
     """
     ret = np_getitem_arraynd_intp(context, builder, sig, args)
 
-    array_val = args[0]
-    array_ty = sig.args[0]
-    sycl_queue_attr_pos = dpex_dmm.lookup(array_ty).get_field_position(
-        "sycl_queue"
-    )
-    sycl_queue_attr = builder.extract_value(array_val, sycl_queue_attr_pos)
-    ret = builder.insert_value(ret, sycl_queue_attr, sycl_queue_attr_pos)
+    if isinstance(sig.return_type, DpnpNdArray):
+        array_val = args[0]
+        array_ty = sig.args[0]
+        sycl_queue_attr_pos = dpex_dmm.lookup(array_ty).get_field_position(
+            "sycl_queue"
+        )
+        sycl_queue_attr = builder.extract_value(array_val, sycl_queue_attr_pos)
+        ret = builder.insert_value(ret, sycl_queue_attr, sycl_queue_attr_pos)
 
     return ret

--- a/numba_dpex/tests/core/types/DpnpNdArray/test_models.py
+++ b/numba_dpex/tests/core/types/DpnpNdArray/test_models.py
@@ -3,26 +3,25 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from numba import types
-from numba.core.datamodel import models
+from numba.core.datamodel import default_manager, models
 
 from numba_dpex.core.datamodel.models import (
     DpnpNdArrayModel,
+    USMArrayModel,
     dpex_data_model_manager,
 )
 from numba_dpex.core.types.dpnp_ndarray_type import DpnpNdArray
 
 
 def test_model_for_DpnpNdArray():
-    """Test that model is registered for DpnpNdArray instances.
-
-    The model for DpnpNdArray is dpex's ArrayModel.
-
+    """Test the datamodel for DpnpNdArray that is registered with numba's
+    default datamodel manager and numba_dpex's kernel data model manager.
     """
-
-    model = dpex_data_model_manager.lookup(
-        DpnpNdArray(ndim=1, dtype=types.float64, layout="C")
-    )
-    assert isinstance(model, DpnpNdArrayModel)
+    dpnp_ndarray = DpnpNdArray(ndim=1, dtype=types.float64, layout="C")
+    model = dpex_data_model_manager.lookup(dpnp_ndarray)
+    assert isinstance(model, USMArrayModel)
+    default_model = default_manager.lookup(dpnp_ndarray)
+    assert isinstance(default_model, DpnpNdArrayModel)
 
 
 def test_dpnp_ndarray_Model():


### PR DESCRIPTION
- [X] Have you provided a meaningful PR description?

Previously, a `dpnp.ndarray` argument passed to a `kernel` function was passed as an instance of `numba_dpex.core.types.USMNdArray`. The `USMNdArray` type uses the `numba_dpex.core.datamodel.models.USMArrayModel` data model where pointers have an explicit address space qualifier.

The PR now registers the `dpnp.ndarray`-specific `DpnpNdArray` types with a `USMArrayModel` for the `DpexKernelTarget` and with the `numba.core.datamodel.models.ArrayModel` for the `CPUTarget`. By doing so, we now correctly recognize a `dpnp.ndarray` passed to a kernel as such instead of a generic `USMNdArray` object. The change unblocks the creation of a Numba-specific CPython wrapper for kernel functions as we need to use the correct Numba type to properly unbox and box a `dpnp.ndarray`.

Additionally, fixes a bug in `numba_dpex.dpnp_iface.arrayobj.getitem_arraynd_intp` that was found during testing.

- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
