### PR TITLE
Bind cmake to 3.26

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -18,7 +18,7 @@ requirements:
         - python
         - setuptools >=63.*
         - scikit-build >=0.15*
-        - cmake >=3.26*
+        - cmake==3.26
         - numba >=0.57*
         - dpctl >=0.14*
         - dpnp >=0.11*


### PR DESCRIPTION
Fixes build issues realted to the conda-forge release of cmake 3.27

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
