### PR TITLE
Remove deprecated FindPythonLibs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,10 +18,6 @@ This ``CMakeLists.txt`` file will be used by ``setup.py``.
 
 cmake_minimum_required(VERSION 3.21...3.27 FATAL_ERROR)
 
-if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.24")
-    cmake_policy(SET CMP0135 NEW)
-endif()
-
 message(STATUS "NUMBA_DPEX_VERSION=" "${NUMBA_DPEX_VERSION}")
 
 project(numba-dpex

--- a/numba_dpex/core/runtime/CMakeLists.txt
+++ b/numba_dpex/core/runtime/CMakeLists.txt
@@ -78,10 +78,10 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${SKBUILD_MODULE_PATH})
 message(STATUS "CMAKE_MODULE_PATH=" "${CMAKE_MODULE_PATH}")
 
 # Add packages
-find_package(PythonLibs REQUIRED)
-find_package(PythonExtensions REQUIRED)
-find_package(NumPy REQUIRED)
+find_package(Python 3.9 REQUIRED
+  COMPONENTS Interpreter Development.Module NumPy)
 find_package(Dpctl REQUIRED)
+find_package(NumPy REQUIRED)
 
 # Includes
 include(GNUInstallDirs)
@@ -98,14 +98,10 @@ file(GLOB SOURCES "*.c")
 link_directories(${DPCTL_LIBRARY_PATH})
 
 # Output static library, *.so or *.dll
-add_library(${PROJECT_NAME} MODULE ${SOURCES})
+python_add_library(${PROJECT_NAME} MODULE ${SOURCES})
 
-# Link the static library to python libraries and DPCTLSyclInterface
-target_link_libraries(${PROJECT_NAME} ${Python_LIBRARIES})
-target_link_libraries(${PROJECT_NAME} DPCTLSyclInterface)
-
-# Build python extension module
-python_extension_module(${PROJECT_NAME})
+# Link the DPCTLSyclInterface library to target
+target_link_libraries(${PROJECT_NAME} PRIVATE DPCTLSyclInterface)
 
 # If IS_DEVELOP, copy back the target into numba_dpex/core/runtime
 if(IS_DEVELOP)


### PR DESCRIPTION
Remove deprecated FindPythonLibs dependencies since they are no longer supported by CMake 3.27.

~~Blocked by https://github.com/IntelPython/dpctl/pull/1389~~

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?

Close #1125 
