### PR TITLE
Add Coverity scan CI

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -1,0 +1,49 @@
+name: Coverity
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  Coverity:
+
+    runs-on: ubuntu-latest
+
+    env:
+      CHECKERS: --concurrency --security --rule --enable-constraint-fpp --enable-fnptr --enable-virtual --webapp-security --enable-audit-checkers --enable-default
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-java@v1
+      with:
+        java-version: 11
+
+    - name: URL encode project name
+      run: echo "COV_PROJECT=${{ github.repository }}" | sed -e 's:/:%2F:g' -e 's/ /%20/g' >> $GITHUB_ENV
+
+    - name: Coverity Download
+      run: |
+        mkdir -p /tmp/cov-analysis
+        wget https://scan.coverity.com/download/linux64 --post-data "token=${{secrets.COV_TOKEN}}&project=${{env.COV_PROJECT}}" -O cov-analysis.tgz
+        tar -xzf cov-analysis.tgz --strip 1 -C /tmp/cov-analysis
+        rm cov-analysis.tgz
+
+    - name: Coverity Full Scan
+      if: ${{ github.event_name != 'pull_request' }}
+      run: |
+        export PATH=$PATH:/tmp/cov-analysis/bin
+        set -x
+        cov-build --dir cov-int --fs-capture-search $GITHUB_WORKSPACE --no-command
+        # Not available in package, maybe will be once approved?
+        # cov-analyze --dir cov-int --ticker-mode none --strip-path $GITHUB_WORKSPACE $CHECKERS
+
+        tar czvf numba-dpex.tgz cov-int
+        rm -rf cov-int
+
+        curl --form token=${{ secrets.COV_TOKEN }} \
+            --form email=${{ secrets.COV_EMAIL }} \
+            --form file=@numba-dpex.tgz \
+            --form version="${{ github.sha }}" \
+            --form description="Coverity Scan ${{ github.repository }} / ${{ github.ref }}" \
+            https://scan.coverity.com/builds?project=${{env.COV_PROJECT}}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/IntelPython/numba-dpex/badge.svg?branch=main)](https://coveralls.io/github/IntelPython/numba-dpex?branch=main)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
 [![Join the chat at https://matrix.to/#/#Data-Parallel-Python_community:gitter.im](https://badges.gitter.im/Join%20Chat.svg)](https://app.gitter.im/#/room/#Data-Parallel-Python_community:gitter.im)
+[![Coverity Scan Build Status](https://scan.coverity.com/projects/29068/badge.svg)](https://scan.coverity.com/projects/intelpython-numba-dpex)
 <img align="left" src="https://spec.oneapi.io/oneapi-logo-white-scaled.jpg" alt="oneAPI logo" width="75"/>
 <br/>
 <br/>


### PR DESCRIPTION
Initial PR to support Open Source Coverity Reports. I was able to run this workflow on a fork and it successfully uploaded basic build. Now the project needs to be reviewed by the Coverity:

```
While we review your project application you cannot view defects.
It takes about 1-2 business day to review your association with the project and to make sure project meets open source guidelines.
```

`cov-analyze` not available in the toolset right now. I'm not sure if we suppose to run it for open source here or just set up it in project settings.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
