### PR TITLE
Numba-mlir integration

### DIFF
--- a/numba_dpex/core/descriptor.py
+++ b/numba_dpex/core/descriptor.py
@@ -27,8 +27,11 @@ def _inherit_if_not_set(flags, options, name, default=targetconfig._NotSet):
     if cstk:
         # inherit
         top = cstk.top()
-        setattr(flags, name, getattr(top, name))
-    elif default is not targetconfig._NotSet:
+        if hasattr(top, name):
+            setattr(flags, name, getattr(top, name))
+            return
+
+    if default is not targetconfig._NotSet:
         setattr(flags, name, default)
 
 

--- a/numba_dpex/core/pipelines/dpjit_compiler.py
+++ b/numba_dpex/core/pipelines/dpjit_compiler.py
@@ -68,6 +68,15 @@ class _DpjitPassBuilder(object):
         """Returns an nopython mode pipeline based PassManager"""
         pm = PassManager(name)
 
+        flags = state.flags
+        if hasattr(flags, "use_mlir") and flags.use_mlir:
+            from numba_mlir.mlir.passes import MlirReplaceParfors
+
+            pm.add_pass(
+                MlirReplaceParfors,
+                "Lower parfor using MLIR pipeline",
+            )
+
         # legalize
         pm.add_pass(
             NoPythonSupportedFeatureValidation,

--- a/numba_dpex/decorators.py
+++ b/numba_dpex/decorators.py
@@ -155,6 +155,7 @@ def dpjit(*args, **kws):
     kws.update({"nopython": True})
     kws.update({"parallel": True})
     kws.update({"pipeline_class": DpjitCompiler})
+    kws.update({"_target": "dpex"})
 
     # FIXME: When trying to use dpex's target context, overloads do not work
     # properly. We will turn on dpex target once the issue is fixed.

--- a/numba_dpex/tests/_helper.py
+++ b/numba_dpex/tests/_helper.py
@@ -6,11 +6,22 @@
 
 import contextlib
 import shutil
+from functools import cache
 
 import dpctl
 import pytest
 
-from numba_dpex import config, numba_sem_version
+from numba_dpex import config, dpjit, numba_sem_version
+
+
+@cache
+def has_numba_mlir():
+    try:
+        import numba_mlir
+    except ImportError:
+        return False
+
+    return True
 
 
 def has_opencl_gpu():
@@ -88,6 +99,10 @@ skip_no_level_zero_gpu = pytest.mark.skipif(
     not has_level_zero(),
     reason="No level-zero GPU platforms available",
 )
+skip_no_numba_mlir = pytest.mark.skipif(
+    not has_numba_mlir(),
+    reason="numba-mlir package is not availabe",
+)
 
 filter_strings = [
     pytest.param("level_zero:gpu:0", marks=skip_no_level_zero_gpu),
@@ -120,6 +135,14 @@ skip_no_gdb = pytest.mark.skipif(
     config.TESTING_SKIP_NO_DEBUGGING and not shutil.which("gdb-oneapi"),
     reason="Intel® Distribution for GDB* is not available",
 )
+
+
+decorators = [
+    pytest.param(dpjit, id="dpjit"),
+    pytest.param(
+        dpjit(use_mlir=True), id="dpjit_mlir", marks=skip_no_numba_mlir
+    ),
+]
 
 
 @contextlib.contextmanager

--- a/numba_dpex/tests/test_prange.py
+++ b/numba_dpex/tests/test_prange.py
@@ -12,12 +12,10 @@ from numba import njit
 
 from numba_dpex import dpjit, prange
 
-dpjit_mlir = dpjit(use_mlir=True)
+from ._helper import decorators
 
 
-@pytest.mark.parametrize(
-    "jit", [dpjit, dpjit_mlir], ids=["dpjit", "dpjit_mlir"]
-)
+@pytest.mark.parametrize("jit", decorators)
 def test_one_prange_mul(jit):
     @jit
     def f(a, b):
@@ -40,9 +38,7 @@ def test_one_prange_mul(jit):
         assert nb[i, 0] == na[i, 0] * 10
 
 
-@pytest.mark.parametrize(
-    "jit", [dpjit, dpjit_mlir], ids=["dpjit", "dpjit_mlir"]
-)
+@pytest.mark.parametrize("jit", decorators)
 def test_one_prange_mul_nested(jit):
     @jit
     def f_inner(a, b):
@@ -189,8 +185,9 @@ def test_three_prange():
     assert np.all(b.asnumpy() == 12)
 
 
-def test_two_consecutive_prange():
-    @dpjit
+@pytest.mark.parametrize("jit", decorators)
+def test_two_consecutive_prange(jit):
+    @jit
     def prange_example(a, b, c, d):
         for i in prange(n):
             c[i] = a[i] + b[i]

--- a/numba_dpex/tests/test_prange.py
+++ b/numba_dpex/tests/test_prange.py
@@ -12,9 +12,14 @@ from numba import njit
 
 from numba_dpex import dpjit, prange
 
+dpjit_mlir = dpjit(use_mlir=True)
 
-def test_one_prange_mul():
-    @dpjit
+
+@pytest.mark.parametrize(
+    "jit", [dpjit, dpjit_mlir], ids=["dpjit", "dpjit_mlir"]
+)
+def test_one_prange_mul(jit):
+    @jit
     def f(a, b):
         for i in prange(4):
             b[i, 0] = a[i, 0] * 10


### PR DESCRIPTION
* Add `use_mlir` option to decorator with proper target options support
* Insert mlir parfor lowering passe if flag is set
* Update some prange tests
* One can use `NUMBA_MLIR_LOG_GPU_RUNTIME_CALLS=1` to check if numba-mlir gpu runtime was actually invoked