### PR TITLE
Add sycl event

### DIFF
--- a/numba_dpex/core/kernel_interface/dispatcher.py
+++ b/numba_dpex/core/kernel_interface/dispatcher.py
@@ -486,6 +486,9 @@ class JitKernel:
         # Make sure the kernel launch range/nd_range are sane
         self._check_ranges(exec_queue.sycl_device)
 
+        # TODO: return event that calls wait if no reference to the object if
+        # it is possible
+        # event = exec_queue.submit(
         exec_queue.submit(
             sycl_kernel,
             packer.unpacked_args,

--- a/numba_dpex/core/runtime/_eventstruct.h
+++ b/numba_dpex/core/runtime/_eventstruct.h
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Defines the numba-dpex native representation for a dpctl.SyclEvent
+///
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <Python.h>
+
+typedef struct
+{
+    PyObject *parent;
+    void *event_ref;
+} eventstruct_t;

--- a/numba_dpex/core/runtime/context.py
+++ b/numba_dpex/core/runtime/context.py
@@ -203,6 +203,32 @@ class DpexRTContext(object):
 
         return self.error
 
+    def eventstruct_from_python(self, pyapi, obj, ptr):
+        """Calls the c function DPEXRT_sycl_event_from_python"""
+        fnty = llvmir.FunctionType(
+            llvmir.IntType(32), [pyapi.pyobj, pyapi.voidptr]
+        )
+
+        fn = pyapi._get_function(fnty, "DPEXRT_sycl_event_from_python")
+        fn.args[0].add_attribute("nocapture")
+        fn.args[1].add_attribute("nocapture")
+
+        self.error = pyapi.builder.call(fn, (obj, ptr))
+        return self.error
+
+    def eventstruct_to_python(self, pyapi, val):
+        """Calls the c function DPEXRT_sycl_event_to_python"""
+
+        fnty = llvmir.FunctionType(pyapi.pyobj, [pyapi.voidptr])
+
+        fn = pyapi._get_function(fnty, "DPEXRT_sycl_event_to_python")
+        fn.args[0].add_attribute("nocapture")
+        qptr = cgutils.alloca_once_value(pyapi.builder, val)
+        ptr = pyapi.builder.bitcast(qptr, pyapi.voidptr)
+        self.error = pyapi.builder.call(fn, [ptr])
+
+        return self.error
+
     def usm_ndarray_to_python_acqref(self, pyapi, aryty, ary, dtypeptr):
         """Boxes a DpnpNdArray native object into a Python dpnp.ndarray.
 

--- a/numba_dpex/core/types/__init__.py
+++ b/numba_dpex/core/types/__init__.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from .array_type import Array
-from .dpctl_types import DpctlSyclQueue
+from .dpctl_types import DpctlSyclEvent, DpctlSyclQueue
 from .dpnp_ndarray_type import DpnpNdArray
 from .numba_types_short_names import (
     b1,
@@ -33,6 +33,7 @@ usm_ndarray = USMNdArray
 __all__ = [
     "Array",
     "DpctlSyclQueue",
+    "DpctlSyclEvent",
     "DpnpNdArray",
     "USMNdArray",
     "none",

--- a/numba_dpex/core/typing/typeof.py
+++ b/numba_dpex/core/typing/typeof.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from dpctl import SyclQueue
+from dpctl import SyclEvent, SyclQueue
 from dpctl.tensor import usm_ndarray
 from dpnp import ndarray
 from numba.extending import typeof_impl
@@ -10,7 +10,7 @@ from numba.np import numpy_support
 
 from numba_dpex.utils import address_space
 
-from ..types.dpctl_types import DpctlSyclQueue
+from ..types.dpctl_types import DpctlSyclEvent, DpctlSyclQueue
 from ..types.dpnp_ndarray_type import DpnpNdArray
 from ..types.usm_ndarray_type import USMNdArray
 
@@ -106,3 +106,17 @@ def typeof_dpctl_sycl_queue(val, c):
     Returns: A numba_dpex.core.types.dpctl_types.DpctlSyclQueue instance.
     """
     return DpctlSyclQueue(val)
+
+
+@typeof_impl.register(SyclEvent)
+def typeof_dpctl_sycl_event(val, c):
+    """Registers the type inference implementation function for a
+    dpctl.SyclEvent PyObject.
+
+    Args:
+        val : An instance of dpctl.SyclEvent.
+        c : Unused argument used to be consistent with Numba API.
+
+    Returns: A numba_dpex.core.types.dpctl_types.DpctlSyclEvent instance.
+    """
+    return DpctlSyclEvent(val)

--- a/numba_dpex/tests/core/types/DpctlSyclEvent/__init__.py
+++ b/numba_dpex/tests/core/types/DpctlSyclEvent/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from . import *

--- a/numba_dpex/tests/core/types/DpctlSyclEvent/test_box_unbox.py
+++ b/numba_dpex/tests/core/types/DpctlSyclEvent/test_box_unbox.py
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests for boxing and unboxing of types supported inside dpjit
+"""
+
+import sys
+
+import dpctl
+
+from numba_dpex import dpjit
+
+
+@dpjit
+def unbox_box(a):
+    return a
+
+
+@dpjit
+def unbox(a):
+    return None
+
+
+def test_unboxing_boxing_with_return():
+    """Tests basic boxing and unboxing of a dpctl.SyclEvent object.
+
+    Checks if we can pass in and return a dpctl.SyclEvent object to and
+    from a dpjit decorated function. Checks if we have expected count of
+    references.
+    """
+
+    e = dpctl.SyclEvent()
+
+    ref_before = sys.getrefcount(e)
+    o = unbox_box(e)
+    ref_after = sys.getrefcount(e)
+
+    assert ref_before + 1 == ref_after  # we have 'o' referencing same object
+    assert id(o) == id(e)
+
+
+def test_unboxing_boxing_with_same_assign():
+    """Tests basic boxing and unboxing of a dpctl.SyclEvent object.
+
+    Checks if we can pass in and return a dpctl.SyclEvent object to and
+    from a dpjit decorated function. Checks if we have expected count of
+    references.
+    """
+
+    e = dpctl.SyclEvent()
+
+    ref_before = sys.getrefcount(e)
+    e = unbox_box(e)
+    ref_after = sys.getrefcount(e)
+
+    assert ref_before == ref_after
+
+
+def test_unboxing_boxing_without_return():
+    """Tests basic boxing and unboxing of a dpctl.SyclEvent object.
+
+    Checks if we can pass in and return a dpctl.SyclEvent object to and
+    from a dpjit decorated function without assigning it to new variable.
+    Checks if it does not affect reference count.
+    """
+
+    e = dpctl.SyclEvent()
+
+    ref_before = sys.getrefcount(e)
+    unbox_box(e)
+    ref_after = sys.getrefcount(e)
+
+    assert ref_before == ref_after
+
+
+def test_unboxing():
+    """Tests basic unboxing of a dpctl.SyclEvent object.
+
+    Checks if we have expected amount of reference if we pass dpctl.SyclEvent
+    object to a dpjit decorated function.
+    """
+
+    e = dpctl.SyclEvent()
+
+    ref_before = sys.getrefcount(e)
+    unbox(e)
+    ref_after = sys.getrefcount(e)
+
+    assert ref_before == ref_after

--- a/numba_dpex/tests/core/types/DpctlSyclEvent/test_models.py
+++ b/numba_dpex/tests/core/types/DpctlSyclEvent/test_models.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import dpctl
+from numba import types
+from numba.core.datamodel import default_manager, models
+
+from numba_dpex.core.datamodel.models import (
+    SyclEventModel,
+    dpex_data_model_manager,
+)
+from numba_dpex.core.types.dpctl_types import DpctlSyclEvent
+
+
+def test_model_for_DpctlSyclEvent():
+    """Test the datamodel for DpctlSyclEvent that is registered with numba's
+    default datamodel manager and numba_dpex's kernel data model manager.
+    """
+    sycl_event = DpctlSyclEvent(dpctl.SyclEvent())
+    model = dpex_data_model_manager.lookup(sycl_event)
+    assert isinstance(model, SyclEventModel)
+    default_model = default_manager.lookup(sycl_event)
+    assert isinstance(default_model, SyclEventModel)
+
+
+def test_sycl_event_Model():
+    """Test for sycl_event_Model.
+
+    It is a subclass of models.StructModel and models.ArrayModel.
+    """
+
+    assert issubclass(SyclEventModel, models.StructModel)


### PR DESCRIPTION
Add dpctl.SyclEvent to numba friendly types, so that we can convert kernel dispatcher into @dpjit function.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?

Closes: #1137 