### PR TITLE
Support tests on single point precision GPUs

### DIFF
--- a/numba_dpex/tests/core/passes/test_parfor_legalize_cfd_pass.py
+++ b/numba_dpex/tests/core/passes/test_parfor_legalize_cfd_pass.py
@@ -14,10 +14,13 @@ import pytest
 
 from numba_dpex import dpjit
 from numba_dpex.core.exceptions import ExecutionQueueInferenceError
-from numba_dpex.tests._helper import skip_no_opencl_cpu, skip_no_opencl_gpu
+from numba_dpex.tests._helper import (
+    get_all_dtypes,
+    skip_no_opencl_cpu,
+    skip_no_opencl_gpu,
+)
 
 shapes = [10, (2, 5)]
-dtypes = [dpnp.int32, dpnp.int64, dpnp.float32, dpnp.float64]
 usm_types = ["device"]
 devices = ["gpu"]
 
@@ -30,7 +33,12 @@ def func1(a, b):
 
 @skip_no_opencl_gpu
 @pytest.mark.parametrize("shape", shapes)
-@pytest.mark.parametrize("dtype", dtypes)
+@pytest.mark.parametrize(
+    "dtype",
+    get_all_dtypes(
+        no_bool=True, no_float16=True, no_none=True, no_complex=True
+    ),
+)
 @pytest.mark.parametrize("usm_type", usm_types)
 @pytest.mark.parametrize("device", devices)
 def test_parfor_legalize_cfd_pass(shape, dtype, usm_type, device):

--- a/numba_dpex/tests/core/types/DpnpNdArray/test_boxing_unboxing.py
+++ b/numba_dpex/tests/core/types/DpnpNdArray/test_boxing_unboxing.py
@@ -22,7 +22,7 @@ def test_boxing_unboxing():
     def func(a):
         return a
 
-    a = dpnp.empty(10)
+    a = dpnp.empty(10, dtype=dpnp.float32)
     try:
         b = func(a)
     except:
@@ -40,8 +40,8 @@ def test_stride_calc_at_unboxing():
     def _tester(a):
         return a.strides
 
-    b = dpnp.empty((4, 16, 4))
+    b = dpnp.empty((4, 16, 4), dtype=dpnp.float32)
     strides = dpjit(_tester)(b)
 
     # Numba computes strides as bytes
-    assert list(strides) == [512, 32, 8]
+    assert list(strides) == [256, 16, 4]

--- a/numba_dpex/tests/core/types/USMNdArray/test_array_creation_errors.py
+++ b/numba_dpex/tests/core/types/USMNdArray/test_array_creation_errors.py
@@ -1,14 +1,14 @@
 import dpctl
 import pytest
 
-from numba_dpex.core.types import USMNdArray, dpctl_types
+from numba_dpex.core.types import USMNdArray, dpctl_types, float32
 
 
 def test_usmndarray_negative_tests():
     default_device = dpctl.SyclDevice().filter_string
 
-    usmarr1 = USMNdArray(1, device=None, queue=None)
-    assert usmarr1.dtype.name == "float64"
+    usmarr1 = USMNdArray(1, device=None, queue=None, dtype=float32)
+    assert usmarr1.dtype.name == "float32"
     assert usmarr1.ndim == 1
     assert usmarr1.layout == "C"
     assert usmarr1.addrspace == 1
@@ -16,8 +16,8 @@ def test_usmndarray_negative_tests():
 
     assert usmarr1.queue.sycl_device == default_device
 
-    usmarr2 = USMNdArray(1, device=default_device, queue=None)
-    assert usmarr2.dtype.name == "float64"
+    usmarr2 = USMNdArray(1, device=default_device, queue=None, dtype=float32)
+    assert usmarr2.dtype.name == "float32"
     assert usmarr2.ndim == 1
     assert usmarr2.layout == "C"
     assert usmarr2.addrspace == 1
@@ -26,18 +26,18 @@ def test_usmndarray_negative_tests():
 
     queue = dpctl_types.DpctlSyclQueue(dpctl.SyclQueue())
 
-    usmarr3 = USMNdArray(1, device=None, queue=queue)
-    assert usmarr3.dtype.name == "float64"
+    usmarr3 = USMNdArray(1, device=None, queue=queue, dtype=float32)
+    assert usmarr3.dtype.name == "float32"
     assert usmarr3.ndim == 1
     assert usmarr3.layout == "C"
     assert usmarr3.addrspace == 1
     assert usmarr3.usm_type == "device"
 
     with pytest.raises(TypeError):
-        USMNdArray(1, device=default_device, queue=queue)
+        USMNdArray(1, device=default_device, queue=queue, dtype=float32)
 
     with pytest.raises(TypeError):
-        USMNdArray(1, queue=0)
+        USMNdArray(1, queue=0, dtype=float32)
 
     with pytest.raises(TypeError):
-        USMNdArray(1, device=0)
+        USMNdArray(1, device=0, dtype=float32)

--- a/numba_dpex/tests/core/types/USMNdArray/test_usm_ndarray_type.py
+++ b/numba_dpex/tests/core/types/USMNdArray/test_usm_ndarray_type.py
@@ -2,12 +2,17 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import dpctl
 import dpctl.tensor as dpt
 import numpy as np
 import pytest
 from numba.misc.special import typeof
 
 from numba_dpex.core.types import USMNdArray
+from numba_dpex.tests._helper import (
+    get_queue_or_skip,
+    skip_if_dtype_not_supported,
+)
 
 list_of_dtypes = [
     np.int32,
@@ -35,6 +40,9 @@ def usm_type(request):
 
 
 def test_usm_ndarray_type(dtype, usm_type):
+    q = get_queue_or_skip()
+    skip_if_dtype_not_supported(dtype, q)
+
     a = np.array(np.random.random(10), dtype)
     da = dpt.usm_ndarray(a.shape, dtype=a.dtype, buffer=usm_type)
 

--- a/numba_dpex/tests/dpjit_tests/dpnp/test_dpnp_empty.py
+++ b/numba_dpex/tests/dpjit_tests/dpnp/test_dpnp_empty.py
@@ -10,9 +10,9 @@ import pytest
 from numba import errors
 
 from numba_dpex import dpjit
+from numba_dpex.tests._helper import get_all_dtypes
 
 shapes = [11, (2, 5)]
-dtypes = [dpnp.int32, dpnp.int64, dpnp.float32, dpnp.float64]
 usm_types = ["device", "shared", "host"]
 
 
@@ -51,7 +51,12 @@ def test_dpnp_empty_default(shape):
 
 
 @pytest.mark.parametrize("shape", shapes)
-@pytest.mark.parametrize("dtype", dtypes)
+@pytest.mark.parametrize(
+    "dtype",
+    get_all_dtypes(
+        no_bool=True, no_float16=True, no_none=True, no_complex=True
+    ),
+)
 @pytest.mark.parametrize("usm_type", usm_types)
 def test_dpnp_empty_from_device(shape, dtype, usm_type):
     """ "Use device only in dpnp.emtpy() inside dpjit."""
@@ -84,7 +89,12 @@ def test_dpnp_empty_from_device(shape, dtype, usm_type):
 
 
 @pytest.mark.parametrize("shape", shapes)
-@pytest.mark.parametrize("dtype", dtypes)
+@pytest.mark.parametrize(
+    "dtype",
+    get_all_dtypes(
+        no_bool=True, no_float16=True, no_none=True, no_complex=True
+    ),
+)
 @pytest.mark.parametrize("usm_type", usm_types)
 def test_dpnp_empty_from_queue(shape, dtype, usm_type):
     """ "Use queue only in dpnp.emtpy() inside dpjit."""
@@ -121,7 +131,9 @@ def test_dpnp_empty_exceptions():
 
     @dpjit
     def func(shape, queue):
-        c = dpnp.empty(shape, sycl_queue=queue, device=device)
+        c = dpnp.empty(
+            shape, sycl_queue=queue, device=device, dtype=dpnp.float32
+        )
         return c
 
     with pytest.raises(errors.TypingError):

--- a/numba_dpex/tests/dpjit_tests/dpnp/test_dpnp_empty_like.py
+++ b/numba_dpex/tests/dpjit_tests/dpnp/test_dpnp_empty_like.py
@@ -12,9 +12,9 @@ import pytest
 from numba import errors
 
 from numba_dpex import dpjit
+from numba_dpex.tests._helper import get_all_dtypes
 
 shapes = [10, (2, 5)]
-dtypes = [dpnp.int32, dpnp.int64, dpnp.float32, dpnp.float64]
 usm_types = ["device", "shared", "host"]
 
 
@@ -53,7 +53,12 @@ def test_dpnp_empty_like_default(shape):
 
 
 @pytest.mark.parametrize("shape", shapes)
-@pytest.mark.parametrize("dtype", dtypes)
+@pytest.mark.parametrize(
+    "dtype",
+    get_all_dtypes(
+        no_bool=True, no_float16=True, no_none=True, no_complex=True
+    ),
+)
 @pytest.mark.parametrize("usm_type", usm_types)
 def test_dpnp_empty_like_from_device(shape, dtype, usm_type):
     """ "Use device only in dpnp.emtpy)like() inside dpjit."""
@@ -87,7 +92,12 @@ def test_dpnp_empty_like_from_device(shape, dtype, usm_type):
 
 
 @pytest.mark.parametrize("shape", shapes)
-@pytest.mark.parametrize("dtype", dtypes)
+@pytest.mark.parametrize(
+    "dtype",
+    get_all_dtypes(
+        no_bool=True, no_float16=True, no_none=True, no_complex=True
+    ),
+)
 @pytest.mark.parametrize("usm_type", usm_types)
 def test_dpnp_empty_like_from_queue(shape, dtype, usm_type):
     """ "Use queue only in dpnp.emtpy_like() inside dpjit."""
@@ -146,7 +156,7 @@ def test_dpnp_empty_like_exceptions():
 
     try:
         queue = dpctl.SyclQueue()
-        a = dpnp.ones(10)
+        a = dpnp.ones(10, dtype=dpnp.float32)
         func1(a, queue)
     except Exception as e:
         assert isinstance(e, errors.TypingError)
@@ -175,7 +185,7 @@ def test_dpnp_empty_like_from_numpy():
         y = dpnp.empty_like(x)
         return y
 
-    a = numpy.empty(10)
+    a = numpy.empty(10, dtype=numpy.float32)
 
     with pytest.raises(Exception):
         func(a)

--- a/numba_dpex/tests/dpjit_tests/dpnp/test_dpnp_full.py
+++ b/numba_dpex/tests/dpjit_tests/dpnp/test_dpnp_full.py
@@ -14,9 +14,9 @@ import pytest
 from numba import errors
 
 from numba_dpex import dpjit
+from numba_dpex.tests._helper import get_all_dtypes
 
 shapes = [11, (3, 7)]
-dtypes = [dpnp.int32, dpnp.int64, dpnp.float32, dpnp.float64]
 usm_types = ["device", "shared", "host"]
 fill_values = [
     7,
@@ -41,7 +41,7 @@ def test_dpnp_full_default(shape, fill_value):
 
     @dpjit
     def func(shape, fill_value):
-        c = dpnp.full(shape, fill_value)
+        c = dpnp.full(shape, fill_value, dtype=numpy.float32)
         return c
 
     try:
@@ -54,7 +54,7 @@ def test_dpnp_full_default(shape, fill_value):
     else:
         assert c.shape == shape
 
-    dummy = dpnp.full(shape, fill_value)
+    dummy = dpnp.full(shape, fill_value, dtype=dpnp.float32)
 
     if c.dtype != dummy.dtype:
         if sys.platform != "linux":
@@ -80,7 +80,12 @@ def test_dpnp_full_default(shape, fill_value):
 
 @pytest.mark.parametrize("shape", shapes)
 @pytest.mark.parametrize("fill_value", fill_values)
-@pytest.mark.parametrize("dtype", dtypes)
+@pytest.mark.parametrize(
+    "dtype",
+    get_all_dtypes(
+        no_bool=True, no_float16=True, no_none=True, no_complex=True
+    ),
+)
 @pytest.mark.parametrize("usm_type", usm_types)
 def test_dpnp_full_from_device(shape, fill_value, dtype, usm_type):
     """ "Use device only in dpnp.full() inside dpjit."""
@@ -122,7 +127,12 @@ def test_dpnp_full_from_device(shape, fill_value, dtype, usm_type):
 
 @pytest.mark.parametrize("shape", shapes)
 @pytest.mark.parametrize("fill_value", fill_values)
-@pytest.mark.parametrize("dtype", dtypes)
+@pytest.mark.parametrize(
+    "dtype",
+    get_all_dtypes(
+        no_bool=True, no_float16=True, no_none=True, no_complex=True
+    ),
+)
 @pytest.mark.parametrize("usm_type", usm_types)
 def test_dpnp_full_from_queue(shape, fill_value, dtype, usm_type):
     """ "Use queue only in dpnp.full() inside dpjit."""

--- a/numba_dpex/tests/dpjit_tests/dpnp/test_dpnp_full_like.py
+++ b/numba_dpex/tests/dpjit_tests/dpnp/test_dpnp_full_like.py
@@ -15,9 +15,9 @@ import pytest
 from numba import errors
 
 from numba_dpex import dpjit
+from numba_dpex.tests._helper import get_all_dtypes
 
 shapes = [11, (3, 7)]
-dtypes = [dpnp.int32, dpnp.int64, dpnp.float32, dpnp.float64]
 usm_types = ["device", "shared", "host"]
 fill_values = [
     7,
@@ -43,7 +43,7 @@ def test_dpnp_full_like_default(shape, fill_value):
         return y
 
     try:
-        a = dpnp.zeros(shape)
+        a = dpnp.zeros(shape, dtype=dpnp.float32)
         c = func(a, fill_value)
     except Exception:
         pytest.fail("Calling dpnp.full_like() inside dpjit failed.")
@@ -78,7 +78,12 @@ def test_dpnp_full_like_default(shape, fill_value):
 
 @pytest.mark.parametrize("shape", shapes)
 @pytest.mark.parametrize("fill_value", fill_values)
-@pytest.mark.parametrize("dtype", dtypes)
+@pytest.mark.parametrize(
+    "dtype",
+    get_all_dtypes(
+        no_bool=True, no_float16=True, no_none=True, no_complex=True
+    ),
+)
 @pytest.mark.parametrize("usm_type", usm_types)
 def test_dpnp_full_like_from_device(shape, fill_value, dtype, usm_type):
     """ "Use device only in dpnp.full_like() inside dpjit."""
@@ -121,7 +126,12 @@ def test_dpnp_full_like_from_device(shape, fill_value, dtype, usm_type):
 
 @pytest.mark.parametrize("shape", shapes)
 @pytest.mark.parametrize("fill_value", fill_values)
-@pytest.mark.parametrize("dtype", dtypes)
+@pytest.mark.parametrize(
+    "dtype",
+    get_all_dtypes(
+        no_bool=True, no_float16=True, no_none=True, no_complex=True
+    ),
+)
 @pytest.mark.parametrize("usm_type", usm_types)
 def test_dpnp_full_like_from_queue(shape, fill_value, dtype, usm_type):
     """ "Use queue only in dpnp.full_like() inside dpjit."""

--- a/numba_dpex/tests/dpjit_tests/dpnp/test_dpnp_ones.py
+++ b/numba_dpex/tests/dpjit_tests/dpnp/test_dpnp_ones.py
@@ -10,9 +10,12 @@ import pytest
 from numba import errors
 
 from numba_dpex import dpjit
+from numba_dpex.tests._helper import get_all_dtypes
 
 shapes = [11, (3, 7)]
-dtypes = [dpnp.int32, dpnp.int64, dpnp.float32, dpnp.float64]
+dtypes = get_all_dtypes(
+    no_bool=True, no_float16=True, no_none=True, no_complex=True
+)
 usm_types = ["device", "shared", "host"]
 
 
@@ -22,7 +25,7 @@ def test_dpnp_ones_default(shape):
 
     @dpjit
     def func(shape):
-        c = dpnp.ones(shape)
+        c = dpnp.ones(shape, dtype=dpnp.float32)
         return c
 
     try:
@@ -37,7 +40,7 @@ def test_dpnp_ones_default(shape):
 
     assert (c.asnumpy() == 1).all()
 
-    dummy = dpnp.ones(shape)
+    dummy = dpnp.ones(shape, dtype=dpnp.float32)
 
     assert c.dtype == dummy.dtype
     assert c.usm_type == dummy.usm_type

--- a/numba_dpex/tests/dpjit_tests/dpnp/test_dpnp_ones_like.py
+++ b/numba_dpex/tests/dpjit_tests/dpnp/test_dpnp_ones_like.py
@@ -12,9 +12,12 @@ import pytest
 from numba import errors
 
 from numba_dpex import dpjit
+from numba_dpex.tests._helper import get_all_dtypes
 
 shapes = [11, (3, 7)]
-dtypes = [dpnp.int32, dpnp.int64, dpnp.float32, dpnp.float64]
+dtypes = get_all_dtypes(
+    no_bool=True, no_float16=True, no_none=True, no_complex=True
+)
 usm_types = ["device", "shared", "host"]
 
 
@@ -28,7 +31,7 @@ def test_dpnp_ones_like_default(shape):
         return y
 
     try:
-        a = dpnp.zeros(shape)
+        a = dpnp.zeros(shape, dtype=dpnp.float32)
         c = func(a)
     except Exception:
         pytest.fail("Calling dpnp.ones_like() inside dpjit failed.")
@@ -151,7 +154,7 @@ def test_dpnp_ones_like_exceptions():
 
     try:
         queue = dpctl.SyclQueue()
-        a = dpnp.zeros(10)
+        a = dpnp.zeros(10, dtype=dpnp.float32)
         func1(a, queue)
     except Exception as e:
         assert isinstance(e, errors.TypingError)
@@ -180,7 +183,7 @@ def test_dpnp_ones_like_from_numpy():
         y = dpnp.ones_like(x)
         return y
 
-    a = numpy.ones(10)
+    a = numpy.ones(10, dtype=dpnp.float32)
 
     with pytest.raises(Exception):
         func(a)

--- a/numba_dpex/tests/dpjit_tests/dpnp/test_dpnp_zeros.py
+++ b/numba_dpex/tests/dpjit_tests/dpnp/test_dpnp_zeros.py
@@ -10,9 +10,12 @@ import pytest
 from numba import errors
 
 from numba_dpex import dpjit
+from numba_dpex.tests._helper import get_all_dtypes
 
 shapes = [11, (3, 7)]
-dtypes = [dpnp.int32, dpnp.int64, dpnp.float32, dpnp.float64]
+dtypes = get_all_dtypes(
+    no_bool=True, no_float16=True, no_none=True, no_complex=True
+)
 usm_types = ["device", "shared", "host"]
 
 
@@ -22,7 +25,7 @@ def test_dpnp_zeros_default(shape):
 
     @dpjit
     def func(shape):
-        c = dpnp.zeros(shape)
+        c = dpnp.zeros(shape, dtype=dpnp.float32)
         return c
 
     try:
@@ -37,7 +40,7 @@ def test_dpnp_zeros_default(shape):
 
     assert not c.asnumpy().any()
 
-    dummy = dpnp.zeros(shape)
+    dummy = dpnp.zeros(shape, dtype=dpnp.float32)
 
     assert c.dtype == dummy.dtype
     assert c.usm_type == dummy.usm_type

--- a/numba_dpex/tests/dpjit_tests/dpnp/test_dpnp_zeros_like.py
+++ b/numba_dpex/tests/dpjit_tests/dpnp/test_dpnp_zeros_like.py
@@ -12,9 +12,12 @@ import pytest
 from numba import errors
 
 from numba_dpex import dpjit
+from numba_dpex.tests._helper import get_all_dtypes
 
 shapes = [11, (3, 7)]
-dtypes = [dpnp.int32, dpnp.int64, dpnp.float32, dpnp.float64]
+dtypes = get_all_dtypes(
+    no_bool=True, no_float16=True, no_none=True, no_complex=True
+)
 usm_types = ["device", "shared", "host"]
 
 
@@ -28,7 +31,7 @@ def test_dpnp_zeros_like_default(shape):
         return y
 
     try:
-        a = dpnp.ones(shape)
+        a = dpnp.ones(shape, dtype=dpnp.float32)
         c = func(a)
     except Exception:
         pytest.fail("Calling dpnp.zeros_like() inside dpjit failed.")
@@ -152,7 +155,7 @@ def test_dpnp_zeros_like_exceptions():
 
     try:
         queue = dpctl.SyclQueue()
-        a = dpnp.ones(10)
+        a = dpnp.ones(10, dtype=dpnp.float32)
         func1(a, queue)
     except Exception as e:
         assert isinstance(e, errors.TypingError)
@@ -181,7 +184,7 @@ def test_dpnp_zeros_like_from_numpy():
         y = dpnp.zeros_like(x)
         return y
 
-    a = numpy.ones(10)
+    a = numpy.ones(10, dtype=dpnp.float32)
 
     with pytest.raises(Exception):
         func(a)

--- a/numba_dpex/tests/dpjit_tests/parfors/test_builtin_ops.py
+++ b/numba_dpex/tests/dpjit_tests/parfors/test_builtin_ops.py
@@ -8,6 +8,7 @@ import numpy
 import pytest
 
 from numba_dpex import dpjit
+from numba_dpex.tests._helper import get_all_dtypes
 
 
 def parfor_add(a, b):
@@ -35,7 +36,9 @@ def parfor_exponent(a, b):
 
 
 shapes = [100, (25, 4)]
-dtypes = [dpnp.int32, dpnp.int64, dpnp.float32, dpnp.float64]
+dtypes = get_all_dtypes(
+    no_bool=True, no_float16=True, no_none=True, no_complex=True
+)
 usm_types = ["device"]
 funcs = [
     parfor_add,
@@ -45,6 +48,11 @@ funcs = [
     parfor_modulus,
     parfor_exponent,
 ]
+
+# TODO: fails for integer because it is being cast to float64 internally?
+if dpnp.float64 not in dtypes:
+    funcs.remove(parfor_divide)
+    funcs.remove(parfor_exponent)
 
 
 def parfor_floor(a, b):

--- a/numba_dpex/tests/dpjit_tests/parfors/test_dpnp_logic_ops.py
+++ b/numba_dpex/tests/dpjit_tests/parfors/test_dpnp_logic_ops.py
@@ -9,6 +9,7 @@ import numpy as np
 import pytest
 
 from numba_dpex import dpjit
+from numba_dpex.tests._helper import get_all_dtypes
 
 """ Following cases, dpnp raises NotImplementedError"""
 
@@ -42,12 +43,9 @@ def unary_op(request):
     return request.param
 
 
-list_of_dtypes = [
-    dpnp.int32,
-    dpnp.int64,
-    dpnp.float32,
-    dpnp.float64,
-]
+list_of_dtypes = get_all_dtypes(
+    no_bool=True, no_float16=True, no_none=True, no_complex=True
+)
 
 
 @pytest.fixture(params=list_of_dtypes)

--- a/numba_dpex/tests/dpjit_tests/parfors/test_dpnp_transcedental_functions.py
+++ b/numba_dpex/tests/dpjit_tests/parfors/test_dpnp_transcedental_functions.py
@@ -9,7 +9,7 @@ import numpy as np
 import pytest
 
 from numba_dpex import dpjit
-from numba_dpex.tests._helper import is_gen12
+from numba_dpex.tests._helper import get_all_dtypes, is_gen12
 
 """dpnp raise error on : mod, abs and remainder(float32)"""
 list_of_binary_ops = [
@@ -63,10 +63,9 @@ def unary_op(request):
     return request.param
 
 
-list_of_dtypes = [
-    dpnp.float32,
-    dpnp.float64,
-]
+list_of_dtypes = get_all_dtypes(
+    no_bool=True, no_int=True, no_float16=True, no_none=True, no_complex=True
+)
 
 
 @pytest.fixture(params=list_of_dtypes)

--- a/numba_dpex/tests/dpjit_tests/parfors/test_dpnp_trigonometric_functions.py
+++ b/numba_dpex/tests/dpjit_tests/parfors/test_dpnp_trigonometric_functions.py
@@ -9,7 +9,7 @@ import numpy as np
 import pytest
 
 from numba_dpex import dpjit
-from numba_dpex.tests._helper import is_gen12
+from numba_dpex.tests._helper import get_all_dtypes, is_gen12
 
 list_of_trig_ops = [
     "sin",
@@ -31,20 +31,17 @@ list_of_trig_ops = [
     "radians",
 ]
 
+list_of_dtypes = get_all_dtypes(
+    no_bool=True, no_int=True, no_float16=True, no_none=True, no_complex=True
+)
+
+# TODO: fails for float32 because it uses cast to float64 internally?
+if dpnp.float64 not in list_of_dtypes:
+    list_of_trig_ops.remove("arctan2")
+
 
 @pytest.fixture(params=list_of_trig_ops)
 def trig_op(request):
-    return request.param
-
-
-list_of_dtypes = [
-    dpnp.float32,
-    dpnp.float64,
-]
-
-
-@pytest.fixture(params=list_of_trig_ops)
-def dtype(request):
     return request.param
 
 

--- a/numba_dpex/tests/dpjit_tests/test_dpjit_complex_arg_types.py
+++ b/numba_dpex/tests/dpjit_tests/test_dpjit_complex_arg_types.py
@@ -8,6 +8,10 @@ import numpy
 import pytest
 
 import numba_dpex as dpex
+from numba_dpex.tests._helper import (
+    get_queue_or_skip,
+    skip_if_dtype_not_supported,
+)
 
 N = 1024
 
@@ -34,6 +38,10 @@ list_of_usm_types = ["shared", "device", "host"]
 
 @pytest.fixture(params=list_of_dtypes)
 def input_arrays(request):
+    q = get_queue_or_skip()
+    # TODO: looks like we are using float64 in complex64 lower...
+    skip_if_dtype_not_supported(request.param, q)
+
     a = dpnp.ones(N, dtype=request.param)
     c = dpnp.zeros(N, dtype=request.param)
     b = dpnp.empty_like(a)
@@ -46,8 +54,8 @@ def test_dpjit_scalar_arg_types(input_arrays):
     Args:
         input_arrays (dpnp.ndarray): Array arguments to be passed to a kernel.
     """
-    s = 2
     a, b, _ = input_arrays
+    s = a.dtype.type(2)
 
     prange_arg(a, b, s)
 
@@ -63,8 +71,8 @@ def test_dpjit_arg_complex_scalar(input_arrays):
     Args:
         input_arrays (dpnp.ndarray): Array arguments to be passed to a kernel.
     """
-    s = 2 + 1j
     a, b, _ = input_arrays
+    s = a.dtype.type(2 + 1j)
 
     prange_arg(a, b, s)
 

--- a/numba_dpex/tests/kernel_tests/test_atomic_op.py
+++ b/numba_dpex/tests/kernel_tests/test_atomic_op.py
@@ -7,34 +7,23 @@ import pytest
 
 import numba_dpex as dpex
 from numba_dpex.core.descriptor import dpex_kernel_target
-from numba_dpex.tests._helper import override_config
+from numba_dpex.tests._helper import get_all_dtypes
 
 global_size = 100
 N = global_size
 
 
-list_of_i_dtypes = [
-    np.int32,
-    np.int64,
-]
-
-list_of_f_dtypes = [
-    np.float32,
-    np.float64,
-]
+list_of_dtypes = get_all_dtypes(
+    no_bool=True, no_float16=True, no_none=True, no_complex=True
+)
 
 
-@pytest.fixture(params=list_of_i_dtypes + list_of_f_dtypes)
+@pytest.fixture(params=list_of_dtypes)
 def return_dtype(request):
     return request.param
 
 
-@pytest.fixture(params=list_of_f_dtypes)
-def fdtype(request):
-    return request.param
-
-
-@pytest.fixture(params=list_of_i_dtypes + list_of_f_dtypes)
+@pytest.fixture(params=list_of_dtypes)
 def input_arrays(request):
     def _inpute_arrays():
         a = np.array([0], request.param)
@@ -159,7 +148,16 @@ def test_kernel_atomic_multi_dim(
         ("sub", "__spirv_AtomicFAddEXT"),
     ],
 )
-@pytest.mark.parametrize("dtype", list_of_f_dtypes)
+@pytest.mark.parametrize(
+    "dtype",
+    get_all_dtypes(
+        no_bool=True,
+        no_int=True,
+        no_float16=True,
+        no_none=True,
+        no_complex=True,
+    ),
+)
 def test_atomic_fp_native(
     function_generator,
     operator_name,

--- a/numba_dpex/tests/kernel_tests/test_complex_array.py
+++ b/numba_dpex/tests/kernel_tests/test_complex_array.py
@@ -7,6 +7,7 @@ import numpy
 import pytest
 
 import numba_dpex as dpex
+from numba_dpex.tests._helper import get_all_dtypes
 
 N = 1024
 
@@ -23,10 +24,9 @@ def kernel_array(a, b, c):
     b[i] = a[i] * c[i]
 
 
-list_of_dtypes = [
-    dpnp.complex64,
-    dpnp.complex128,
-]
+list_of_dtypes = get_all_dtypes(
+    no_bool=True, no_int=True, no_float=True, no_none=True
+)
 
 list_of_usm_types = ["shared", "device", "host"]
 
@@ -45,8 +45,8 @@ def test_numeric_kernel_arg_complex_scalar(input_arrays):
     Args:
         input_arrays (dpnp.ndarray): Array arguments to be passed to a kernel.
     """
-    s = 2 + 1j
     a, b, _ = input_arrays
+    s = a.dtype.type(2 + 1j)
 
     kernel_scalar[dpex.Range(N)](a, b, s)
 

--- a/numba_dpex/tests/kernel_tests/test_math_functions.py
+++ b/numba_dpex/tests/kernel_tests/test_math_functions.py
@@ -9,6 +9,7 @@ import numpy
 import pytest
 
 import numba_dpex as dpex
+from numba_dpex.tests._helper import get_all_dtypes
 
 list_of_unary_ops = ["fabs", "exp", "log", "sqrt", "sin", "cos", "tan"]
 
@@ -18,10 +19,9 @@ def unary_op(request):
     return request.param
 
 
-list_of_dtypes = [
-    dpnp.float32,
-    dpnp.float64,
-]
+list_of_dtypes = get_all_dtypes(
+    no_bool=True, no_int=True, no_float16=True, no_none=True, no_complex=True
+)
 
 
 @pytest.fixture(params=list_of_dtypes)

--- a/numba_dpex/tests/kernel_tests/test_scalar_arg_types.py
+++ b/numba_dpex/tests/kernel_tests/test_scalar_arg_types.py
@@ -7,6 +7,7 @@ import numpy
 import pytest
 
 import numba_dpex as dpex
+from numba_dpex.tests._helper import get_all_dtypes
 
 N = 1024
 
@@ -26,14 +27,7 @@ def kernel_with_bool_arg(a, b, test):
         b[i] = a[i] - a[i]
 
 
-list_of_dtypes = [
-    dpnp.int32,
-    dpnp.int64,
-    dpnp.float32,
-    dpnp.float64,
-    dpnp.complex64,
-    dpnp.complex128,
-]
+list_of_dtypes = get_all_dtypes(no_bool=True, no_float16=True, no_none=True)
 
 list_of_usm_types = ["shared", "device", "host"]
 
@@ -52,8 +46,8 @@ def test_numeric_kernel_arg_types1(input_arrays):
     Args:
         input_arrays (dpnp.ndarray): Array arguments to be passed to a kernel.
     """
-    s = 2
     a, b = input_arrays
+    s = a.dtype.type(2)
 
     scaling_kernel[dpex.Range(N)](a, b, s)
 

--- a/numba_dpex/tests/kernel_tests/test_sycl_usm_array_iface_interop.py
+++ b/numba_dpex/tests/kernel_tests/test_sycl_usm_array_iface_interop.py
@@ -7,6 +7,7 @@ import pytest
 from dpctl import tensor as dpt
 
 import numba_dpex as dpex
+from numba_dpex.tests._helper import get_all_dtypes
 
 
 class DuckUSMArray:
@@ -57,12 +58,9 @@ def vecadd(a, b, c):
     c[i] = a[i] + b[i]
 
 
-dtypes = [
-    "i4",
-    "i8",
-    "f4",
-    "f8",
-]
+dtypes = get_all_dtypes(
+    no_bool=True, no_float16=True, no_none=True, no_complex=True
+)
 
 
 @pytest.fixture(params=dtypes)

--- a/numba_dpex/tests/kernel_tests/test_usm_ndarray_interop.py
+++ b/numba_dpex/tests/kernel_tests/test_usm_ndarray_interop.py
@@ -7,13 +7,17 @@ import numpy
 import pytest
 
 import numba_dpex as dpex
+from numba_dpex.tests._helper import get_all_dtypes
 
-list_of_dtype = [
-    numpy.int32,
-    numpy.int64,
-    numpy.float32,
-    numpy.float64,
-]
+# list_of_dtype = [
+#     numpy.int32,
+#     numpy.int64,
+#     numpy.float32,
+#     numpy.float64,
+# ]
+list_of_dtype = get_all_dtypes(
+    no_bool=True, no_float16=True, no_none=True, no_complex=True
+)
 
 
 @pytest.fixture(params=list_of_dtype)

--- a/numba_dpex/tests/test_prange.py
+++ b/numba_dpex/tests/test_prange.py
@@ -167,15 +167,15 @@ def test_two_consecutive_prange():
     device = dpctl.select_default_device()
 
     n = 10
-    a = dpnp.ones((n), dtype=dpnp.float64, device=device)
-    b = dpnp.ones((n), dtype=dpnp.float64, device=device)
-    c = dpnp.zeros((n), dtype=dpnp.float64, device=device)
-    d = dpnp.zeros((n), dtype=dpnp.float64, device=device)
+    a = dpnp.ones((n), dtype=dpnp.float32, device=device)
+    b = dpnp.ones((n), dtype=dpnp.float32, device=device)
+    c = dpnp.zeros((n), dtype=dpnp.float32, device=device)
+    d = dpnp.zeros((n), dtype=dpnp.float32, device=device)
 
     prange_example(a, b, c, d)
 
-    np.testing.assert_equal(c.asnumpy(), np.ones((n), dtype=np.float64) * 2)
-    np.testing.assert_equal(d.asnumpy(), np.zeros((n), dtype=np.float64))
+    np.testing.assert_equal(c.asnumpy(), np.ones((n), dtype=np.float32) * 2)
+    np.testing.assert_equal(d.asnumpy(), np.zeros((n), dtype=np.float32))
 
 
 @pytest.mark.skip(reason="[i,:] like indexing is not supported yet.")


### PR DESCRIPTION
Most of the integrated GPUs does not support doble precision and numba by default uses double precision floats. That makes our tests fail on those GPUs. This changes targeted to add support for tests on single precision GPUs by:
- tests that where using default allocation or only float64/complex128 uses were patched to use float32/complex64 implementations;
- tests that accept dtype parameters where patched to run only on supported types
- few issues where found with lowering or silent crashes. Those tests were patched to bypass these cases.

Discovered issues:
- `arctan2` does not work for `float32` if device does not support `float64` (silent crash)
- `parfor_divide` and `parfor_exponent` does not work on `int32` and `int64` if device does not support `float64` (lowering error)

Issue checks:
- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
