### PR TITLE
Adds Range and NdRange as supported types in numba_dpex.dpjit.

### DIFF
--- a/numba_dpex/core/datamodel/models.py
+++ b/numba_dpex/core/datamodel/models.py
@@ -14,6 +14,8 @@ from ..types import (
     DpctlSyclEvent,
     DpctlSyclQueue,
     DpnpNdArray,
+    NdRangeType,
+    RangeType,
     USMNdArray,
 )
 
@@ -195,6 +197,39 @@ class SyclEventModel(StructModel):
         super(SyclEventModel, self).__init__(dmm, fe_type, members)
 
 
+class RangeModel(StructModel):
+    """The native data model for a
+    numba_dpex.core.kernel_interface.indexers.Range PyObject.
+    """
+
+    def __init__(self, dmm, fe_type):
+        members = [
+            ("ndim", types.int64),
+            ("dim0", types.int64),
+            ("dim1", types.int64),
+            ("dim2", types.int64),
+        ]
+        super(RangeModel, self).__init__(dmm, fe_type, members)
+
+
+class NdRangeModel(StructModel):
+    """The native data model for a
+    numba_dpex.core.kernel_interface.indexers.NdRange PyObject.
+    """
+
+    def __init__(self, dmm, fe_type):
+        members = [
+            ("ndim", types.int64),
+            ("gdim0", types.int64),
+            ("gdim1", types.int64),
+            ("gdim2", types.int64),
+            ("ldim0", types.int64),
+            ("ldim1", types.int64),
+            ("ldim2", types.int64),
+        ]
+        super(NdRangeModel, self).__init__(dmm, fe_type, members)
+
+
 def _init_data_model_manager() -> datamodel.DataModelManager:
     """Initializes a DpexKernelTarget-specific data model manager.
 
@@ -249,3 +284,8 @@ register_model(DpctlSyclQueue)(SyclQueueModel)
 
 # Register the DpctlSyclEvent type
 register_model(DpctlSyclEvent)(SyclEventModel)
+# Register the RangeType type
+register_model(RangeType)(RangeModel)
+
+# Register the NdRangeType type
+register_model(NdRangeType)(NdRangeModel)

--- a/numba_dpex/core/kernel_interface/indexers.py
+++ b/numba_dpex/core/kernel_interface/indexers.py
@@ -4,6 +4,11 @@
 
 from collections.abc import Iterable
 
+from llvmlite import ir as llvmir
+from numba.core import cgutils, errors, types
+from numba.core.datamodel import default_manager
+from numba.extending import intrinsic, overload
+
 
 class Range(tuple):
     """A data structure to encapsulate a single kernel launch parameter.
@@ -73,6 +78,50 @@ class Range(tuple):
             return self[0] * self[1]
         else:
             return self[0]
+
+    @property
+    def ndim(self) -> int:
+        """Returns the rank of a Range object.
+
+        Returns:
+            int: Number of dimensions in the Range object
+        """
+        return len(self)
+
+    @property
+    def dim0(self) -> int:
+        """Return the extent of the first dimension for the Range object.
+
+        Returns:
+            int: Extent of first dimension for the Range object
+        """
+        return self[0]
+
+    @property
+    def dim1(self) -> int:
+        """Return the extent of the second dimension for the Range object.
+
+        Returns:
+            int: Extent of second dimension for the Range object or -1 for 1D
+            Range
+        """
+        try:
+            return self[1]
+        except:
+            return -1
+
+    @property
+    def dim2(self) -> int:
+        """Return the extent of the second dimension for the Range object.
+
+        Returns:
+            int: Extent of second dimension for the Range object or -1 for 1D or
+            2D Range
+        """
+        try:
+            return self[2]
+        except:
+            return -1
 
 
 class NdRange:
@@ -169,3 +218,157 @@ class NdRange:
             str: str representation for NdRange class.
         """
         return self.__str__()
+
+
+@intrinsic
+def _intrin_range_alloc(typingctx, ty_dim0, ty_dim1, ty_dim2, ty_range):
+    ty_retty = ty_range.instance_type
+    sig = ty_retty(
+        ty_dim0,
+        ty_dim1,
+        ty_dim2,
+        ty_range,
+    )
+
+    def codegen(context, builder, sig, args):
+        typ = sig.return_type
+        dim0, dim1, dim2, _ = args
+        range_struct = cgutils.create_struct_proxy(typ)(context, builder)
+        range_struct.dim0 = dim0
+
+        if not isinstance(sig.args[1], types.NoneType):
+            range_struct.dim1 = dim1
+        else:
+            range_struct.dim1 = llvmir.Constant(llvmir.types.IntType(64), -1)
+
+        if not isinstance(sig.args[2], types.NoneType):
+            range_struct.dim2 = dim2
+        else:
+            range_struct.dim2 = llvmir.Constant(llvmir.types.IntType(64), -1)
+
+        range_struct.ndim = llvmir.Constant(llvmir.types.IntType(64), typ.ndim)
+
+        return range_struct._getvalue()
+
+    return sig, codegen
+
+
+@intrinsic
+def _intrin_ndrange_alloc(
+    typingctx, ty_global_range, ty_local_range, ty_ndrange
+):
+    ty_retty = ty_ndrange.instance_type
+    sig = ty_retty(
+        ty_global_range,
+        ty_local_range,
+        ty_ndrange,
+    )
+    range_datamodel = default_manager.lookup(ty_global_range)
+
+    def codegen(context, builder, sig, args):
+        typ = sig.return_type
+
+        global_range, local_range, _ = args
+        ndrange_struct = cgutils.create_struct_proxy(typ)(context, builder)
+        ndrange_struct.ndim = llvmir.Constant(
+            llvmir.types.IntType(64), typ.ndim
+        )
+        ndrange_struct.gdim0 = builder.extract_value(
+            global_range,
+            range_datamodel.get_field_position("dim0"),
+        )
+        ndrange_struct.gdim1 = builder.extract_value(
+            global_range,
+            range_datamodel.get_field_position("dim1"),
+        )
+        ndrange_struct.gdim2 = builder.extract_value(
+            global_range,
+            range_datamodel.get_field_position("dim2"),
+        )
+        ndrange_struct.ldim0 = builder.extract_value(
+            local_range,
+            range_datamodel.get_field_position("dim0"),
+        )
+        ndrange_struct.ldim1 = builder.extract_value(
+            local_range,
+            range_datamodel.get_field_position("dim1"),
+        )
+        ndrange_struct.ldim2 = builder.extract_value(
+            local_range,
+            range_datamodel.get_field_position("dim2"),
+        )
+
+        return ndrange_struct._getvalue()
+
+    return sig, codegen
+
+
+@overload(Range)
+def _ol_range_init(dim0, dim1=None, dim2=None):
+    """Numba overload of the Range constructor to make it usable inside an
+    njit and dpjit decorated function.
+
+    """
+    from numba_dpex.core.types import RangeType
+
+    ndims = 1
+    ty_optional_dims = (dim1, dim2)
+
+    # A Range should at least have the 0th dimension populated
+    if not isinstance(dim0, types.Integer):
+        raise errors.TypingError(
+            "Expected a Range's dimension should to be an Integer value, but "
+            "encountered " + dim0.name
+        )
+
+    for ty_dim in ty_optional_dims:
+        if isinstance(ty_dim, types.Integer):
+            ndims += 1
+        elif ty_dim is not None:
+            raise errors.TypingError(
+                "Expected a Range's dimension to be an Integer value, "
+                f"but {type(ty_dim)} was provided."
+            )
+
+    ret_ty = RangeType(ndims)
+
+    def impl(dim0, dim1=None, dim2=None):
+        return _intrin_range_alloc(dim0, dim1, dim2, ret_ty)
+
+    return impl
+
+
+@overload(NdRange)
+def _ol_ndrange_init(global_range, local_range):
+    """Numba overload of the NdRange constructor to make it usable inside an
+    njit and dpjit decorated function.
+
+    """
+    from numba_dpex.core.exceptions import UnmatchedNumberOfRangeDimsError
+    from numba_dpex.core.types import NdRangeType, RangeType
+
+    if not isinstance(global_range, RangeType):
+        raise errors.TypingError(
+            "Only global range values specified as a Range are "
+            "supported inside dpjit"
+        )
+
+    if not isinstance(local_range, RangeType):
+        raise errors.TypingError(
+            "Only local range values specified as a Range are "
+            "supported inside dpjit"
+        )
+
+    if not global_range.ndim == local_range.ndim:
+        raise UnmatchedNumberOfRangeDimsError(
+            kernel_name="",
+            global_ndims=global_range.ndim,
+            local_ndims=local_range.ndim,
+        )
+
+    ret_ty = NdRangeType(global_range.ndim)
+
+    def impl(global_range, local_range):
+        return _intrin_ndrange_alloc(global_range, local_range, ret_ty)
+
+    return impl

--- a/numba_dpex/core/kernel_interface/indexers.py
+++ b/numba_dpex/core/kernel_interface/indexers.py
@@ -219,6 +219,12 @@ class NdRange:
         """
         return self.__str__()
 
+    def __eq__(self, other):
+        return (
+            self.global_range == other.global_range
+            and self.local_range == other.local_range
+        )
+
 
 @intrinsic
 def _intrin_range_alloc(typingctx, ty_dim0, ty_dim1, ty_dim2, ty_range):

--- a/numba_dpex/core/types/__init__.py
+++ b/numba_dpex/core/types/__init__.py
@@ -26,6 +26,7 @@ from .numba_types_short_names import (
     uint64,
     void,
 )
+from .range_types import NdRangeType, RangeType
 from .usm_ndarray_type import USMNdArray
 
 usm_ndarray = USMNdArray
@@ -35,6 +36,8 @@ __all__ = [
     "DpctlSyclQueue",
     "DpctlSyclEvent",
     "DpnpNdArray",
+    "RangeType",
+    "NdRangeType",
     "USMNdArray",
     "none",
     "boolean",

--- a/numba_dpex/core/types/range_types.py
+++ b/numba_dpex/core/types/range_types.py
@@ -169,9 +169,6 @@ def box_range(typ, val, c):
             c.context, c.builder, value=val
         )
 
-        ndim_obj = c.box(types.int64, range_struct.ndim)
-        with cgutils.early_exit_if_null(c.builder, stack, ndim_obj):
-            c.builder.store(fail_obj, ret_ptr)
         dim0_obj = c.box(types.int64, range_struct.dim0)
         with cgutils.early_exit_if_null(c.builder, stack, dim0_obj):
             c.builder.store(fail_obj, ret_ptr)
@@ -184,7 +181,6 @@ def box_range(typ, val, c):
 
         class_obj = c.pyapi.unserialize(c.pyapi.serialize_object(Range))
         with cgutils.early_exit_if_null(c.builder, stack, class_obj):
-            c.pyapi.decref(ndim_obj)
             c.pyapi.decref(dim0_obj)
             c.pyapi.decref(dim1_obj)
             c.pyapi.decref(dim2_obj)
@@ -203,7 +199,6 @@ def box_range(typ, val, c):
         else:
             raise ValueError("Cannot unbox Range instance.")
 
-        c.pyapi.decref(ndim_obj)
         c.pyapi.decref(dim0_obj)
         c.pyapi.decref(dim1_obj)
         c.pyapi.decref(dim2_obj)

--- a/numba_dpex/core/types/range_types.py
+++ b/numba_dpex/core/types/range_types.py
@@ -1,0 +1,267 @@
+# SPDX-FileCopyrightText: 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from contextlib import ExitStack
+
+from numba.core import cgutils, errors, types
+from numba.core.datamodel import default_manager
+from numba.extending import NativeValue, box, unbox
+
+from ..kernel_interface.indexers import NdRange, Range
+
+
+class RangeType(types.Type):
+    """Numba-dpex type corresponding to
+    :class:`numba_dpex.core.kernel_interface.indexers.Range`
+    """
+
+    def __init__(self, ndim: int):
+        self._ndim = ndim
+        if ndim < 1 or ndim > 3:
+            raise errors.TypingError(
+                "RangeType can only have 1,2, or 3 dimensions"
+            )
+        super(RangeType, self).__init__(name="Range")
+
+    @property
+    def ndim(self):
+        return self._ndim
+
+    @property
+    def key(self):
+        return self._ndim
+
+
+class NdRangeType(types.Type):
+    """Numba-dpex type corresponding to
+    :class:`numba_dpex.core.kernel_interface.indexers.NdRange`
+    """
+
+    def __init__(self, ndim: int):
+        self._ndim = ndim
+        if ndim < 1 or ndim > 3:
+            raise errors.TypingError(
+                "RangeType can only have 1,2, or 3 dimensions"
+            )
+        super(NdRangeType, self).__init__(name="NdRange")
+
+    @property
+    def ndim(self):
+        return self._ndim
+
+    @property
+    def key(self):
+        return self._ndim
+
+
+@unbox(RangeType)
+def unbox_range(typ, obj, c):
+    """
+    Converts a Python Range object to numba-dpex's native struct representation
+    for RangeType.
+    """
+    is_error_ptr = cgutils.alloca_once_value(c.builder, cgutils.false_bit)
+    range_struct = cgutils.create_struct_proxy(typ)(c.context, c.builder)
+    with ExitStack() as stack:
+        range_attr_native_value_map = {
+            "ndim": None,
+            "dim0": None,
+            "dim1": None,
+            "dim2": None,
+        }
+
+        for attr in range_attr_native_value_map.keys():
+            attr_obj = c.pyapi.object_getattr_string(obj, attr)
+            with cgutils.early_exit_if_null(c.builder, stack, attr_obj):
+                c.builder.store(cgutils.true_bit, is_error_ptr)
+            attr_native = c.unbox(types.int64, attr_obj)
+            c.pyapi.decref(attr_obj)
+            with cgutils.early_exit_if(c.builder, stack, attr_native.is_error):
+                c.builder.store(cgutils.true_bit, is_error_ptr)
+            range_attr_native_value_map[attr] = attr_native
+
+        range_struct.ndim = range_attr_native_value_map["ndim"].value
+        range_struct.dim0 = range_attr_native_value_map["dim0"].value
+        range_struct.dim1 = range_attr_native_value_map["dim1"].value
+        range_struct.dim2 = range_attr_native_value_map["dim2"].value
+
+    return NativeValue(
+        range_struct._getvalue(), is_error=c.builder.load(is_error_ptr)
+    )
+
+
+@unbox(NdRangeType)
+def unbox_ndrange(typ, obj, c):
+    """
+    Converts a Python Range object to numba-dpex's native struct representation
+    for NdRangeType.
+    """
+    is_error_ptr = cgutils.alloca_once_value(c.builder, cgutils.false_bit)
+    ndrange_struct = cgutils.create_struct_proxy(typ)(c.context, c.builder)
+
+    with ExitStack() as stack:
+        ndrange_attr_native_value_map = {
+            "global_range": None,
+            "local_range": None,
+        }
+
+        for attr in ndrange_attr_native_value_map.keys():
+            attr_obj = c.pyapi.object_getattr_string(obj, attr)
+            with cgutils.early_exit_if_null(c.builder, stack, attr_obj):
+                c.builder.store(cgutils.true_bit, is_error_ptr)
+            attr_native = c.unbox(RangeType(typ.ndim), attr_obj)
+            c.pyapi.decref(attr_obj)
+            with cgutils.early_exit_if(c.builder, stack, attr_native.is_error):
+                c.builder.store(cgutils.true_bit, is_error_ptr)
+            ndrange_attr_native_value_map[attr] = attr_native
+
+        global_range_struct = ndrange_attr_native_value_map[
+            "global_range"
+        ].value
+        local_range_struct = ndrange_attr_native_value_map["local_range"].value
+
+        range_datamodel = default_manager.lookup(RangeType(typ.ndim))
+        ndrange_struct.ndim = c.builder.extract_value(
+            global_range_struct,
+            range_datamodel.get_field_position("ndim"),
+        )
+        ndrange_struct.gdim0 = c.builder.extract_value(
+            global_range_struct,
+            range_datamodel.get_field_position("dim0"),
+        )
+        ndrange_struct.gdim1 = c.builder.extract_value(
+            global_range_struct,
+            range_datamodel.get_field_position("dim1"),
+        )
+        ndrange_struct.gdim2 = c.builder.extract_value(
+            global_range_struct,
+            range_datamodel.get_field_position("dim2"),
+        )
+        ndrange_struct.ldim0 = c.builder.extract_value(
+            local_range_struct,
+            range_datamodel.get_field_position("dim0"),
+        )
+        ndrange_struct.ldim1 = c.builder.extract_value(
+            local_range_struct,
+            range_datamodel.get_field_position("dim1"),
+        )
+        ndrange_struct.ldim2 = c.builder.extract_value(
+            local_range_struct,
+            range_datamodel.get_field_position("dim2"),
+        )
+
+    return NativeValue(
+        ndrange_struct._getvalue(), is_error=c.builder.load(is_error_ptr)
+    )
+
+
+@box(RangeType)
+def box_range(typ, val, c):
+    """
+    Convert a native range structure to a Range object.
+    """
+    ret_ptr = cgutils.alloca_once(c.builder, c.pyapi.pyobj)
+    fail_obj = c.pyapi.get_null_object()
+
+    with ExitStack() as stack:
+        range_struct = cgutils.create_struct_proxy(typ)(
+            c.context, c.builder, value=val
+        )
+
+        ndim_obj = c.box(types.int64, range_struct.ndim)
+        with cgutils.early_exit_if_null(c.builder, stack, ndim_obj):
+            c.builder.store(fail_obj, ret_ptr)
+        dim0_obj = c.box(types.int64, range_struct.dim0)
+        with cgutils.early_exit_if_null(c.builder, stack, dim0_obj):
+            c.builder.store(fail_obj, ret_ptr)
+        dim1_obj = c.box(types.int64, range_struct.dim1)
+        with cgutils.early_exit_if_null(c.builder, stack, dim1_obj):
+            c.builder.store(fail_obj, ret_ptr)
+        dim2_obj = c.box(types.int64, range_struct.dim2)
+        with cgutils.early_exit_if_null(c.builder, stack, dim2_obj):
+            c.builder.store(fail_obj, ret_ptr)
+
+        class_obj = c.pyapi.unserialize(c.pyapi.serialize_object(Range))
+        with cgutils.early_exit_if_null(c.builder, stack, class_obj):
+            c.pyapi.decref(ndim_obj)
+            c.pyapi.decref(dim0_obj)
+            c.pyapi.decref(dim1_obj)
+            c.pyapi.decref(dim2_obj)
+            c.builder.store(fail_obj, ret_ptr)
+        # NOTE: The result of this call is not checked as the clean up
+        # has to occur regardless of whether it is successful. If it
+        # fails `res` is set to NULL and a Python exception is set.
+        if typ.ndim == 1:
+            res = c.pyapi.call_function_objargs(class_obj, (dim0_obj,))
+        elif typ.ndim == 2:
+            res = c.pyapi.call_function_objargs(class_obj, (dim0_obj, dim1_obj))
+        elif typ.ndim == 3:
+            res = c.pyapi.call_function_objargs(
+                class_obj, (dim0_obj, dim1_obj, dim2_obj)
+            )
+        else:
+            raise ValueError("Cannot unbox Range instance.")
+
+        c.pyapi.decref(ndim_obj)
+        c.pyapi.decref(dim0_obj)
+        c.pyapi.decref(dim1_obj)
+        c.pyapi.decref(dim2_obj)
+        c.pyapi.decref(class_obj)
+        c.builder.store(res, ret_ptr)
+
+    return c.builder.load(ret_ptr)
+
+
+@box(NdRangeType)
+def box_ndrange(typ, val, c):
+    """
+    Convert a native range structure to a Range object.
+    """
+    ret_ptr = cgutils.alloca_once(c.builder, c.pyapi.pyobj)
+    fail_obj = c.pyapi.get_null_object()
+
+    with ExitStack() as stack:
+        ndrange_struct = cgutils.create_struct_proxy(typ)(
+            c.context, c.builder, value=val
+        )
+        grange_struct = cgutils.create_struct_proxy(RangeType(typ.ndim))(
+            c.context, c.builder
+        )
+        lrange_struct = cgutils.create_struct_proxy(RangeType(typ.ndim))(
+            c.context, c.builder
+        )
+        grange_struct.ndim = ndrange_struct.ndim
+        grange_struct.dim0 = ndrange_struct.gdim0
+        grange_struct.dim1 = ndrange_struct.gdim1
+        grange_struct.dim2 = ndrange_struct.gdim2
+        lrange_struct.dim0 = ndrange_struct.ldim0
+        lrange_struct.dim1 = ndrange_struct.ldim1
+        lrange_struct.dim2 = ndrange_struct.ldim2
+
+        grange_obj = c.box(RangeType(typ.ndim), grange_struct._getvalue())
+        with cgutils.early_exit_if_null(c.builder, stack, grange_obj):
+            c.builder.store(fail_obj, ret_ptr)
+
+        lrange_obj = c.box(RangeType(typ.ndim), lrange_struct._getvalue())
+        with cgutils.early_exit_if_null(c.builder, stack, lrange_obj):
+            c.builder.store(fail_obj, ret_ptr)
+
+        class_obj = c.pyapi.unserialize(c.pyapi.serialize_object(NdRange))
+        with cgutils.early_exit_if_null(c.builder, stack, class_obj):
+            c.pyapi.decref(grange_obj)
+            c.pyapi.decref(lrange_obj)
+            c.builder.store(fail_obj, ret_ptr)
+
+        # NOTE: The result of this call is not checked as the clean up
+        # has to occur regardless of whether it is successful. If it
+        # fails `res` is set to NULL and a Python exception is set.
+
+        res = c.pyapi.call_function_objargs(class_obj, (grange_obj, lrange_obj))
+
+        c.pyapi.decref(grange_obj)
+        c.pyapi.decref(lrange_obj)
+        c.pyapi.decref(class_obj)
+        c.builder.store(res, ret_ptr)
+
+    return c.builder.load(ret_ptr)

--- a/numba_dpex/core/typing/typeof.py
+++ b/numba_dpex/core/typing/typeof.py
@@ -10,12 +10,8 @@ from numba.np import numpy_support
 
 from numba_dpex.utils import address_space
 
-<<<<<<< HEAD
-from ..types.dpctl_types import DpctlSyclEvent, DpctlSyclQueue
-=======
 from ..kernel_interface.indexers import NdRange, Range
-from ..types.dpctl_types import DpctlSyclQueue
->>>>>>> 1d5800cf8 (Adds Range and NdRange as supported types in numba_dpex.dpjit.)
+from ..types.dpctl_types import DpctlSyclEvent, DpctlSyclQueue
 from ..types.dpnp_ndarray_type import DpnpNdArray
 from ..types.range_types import NdRangeType, RangeType
 from ..types.usm_ndarray_type import USMNdArray
@@ -126,6 +122,8 @@ def typeof_dpctl_sycl_event(val, c):
     Returns: A numba_dpex.core.types.dpctl_types.DpctlSyclEvent instance.
     """
     return DpctlSyclEvent(val)
+
+
 @typeof_impl.register(Range)
 def typeof_range(val, c):
     """Registers the type inference implementation function for a

--- a/numba_dpex/core/typing/typeof.py
+++ b/numba_dpex/core/typing/typeof.py
@@ -10,8 +10,14 @@ from numba.np import numpy_support
 
 from numba_dpex.utils import address_space
 
+<<<<<<< HEAD
 from ..types.dpctl_types import DpctlSyclEvent, DpctlSyclQueue
+=======
+from ..kernel_interface.indexers import NdRange, Range
+from ..types.dpctl_types import DpctlSyclQueue
+>>>>>>> 1d5800cf8 (Adds Range and NdRange as supported types in numba_dpex.dpjit.)
 from ..types.dpnp_ndarray_type import DpnpNdArray
+from ..types.range_types import NdRangeType, RangeType
 from ..types.usm_ndarray_type import USMNdArray
 
 
@@ -120,3 +126,29 @@ def typeof_dpctl_sycl_event(val, c):
     Returns: A numba_dpex.core.types.dpctl_types.DpctlSyclEvent instance.
     """
     return DpctlSyclEvent(val)
+@typeof_impl.register(Range)
+def typeof_range(val, c):
+    """Registers the type inference implementation function for a
+    numba_dpex.Range PyObject.
+
+    Args:
+        val : An instance of numba_dpex.Range.
+        c : Unused argument used to be consistent with Numba API.
+
+    Returns: A numba_dpex.core.types.range_types.RangeType instance.
+    """
+    return RangeType(val.ndim)
+
+
+@typeof_impl.register(NdRange)
+def typeof_ndrange(val, c):
+    """Registers the type inference implementation function for a
+    numba_dpex.NdRange PyObject.
+
+    Args:
+        val : An instance of numba_dpex.Range.
+        c : Unused argument used to be consistent with Numba API.
+
+    Returns: A numba_dpex.core.types.range_types.RangeType instance.
+    """
+    return NdRangeType(val.global_range.ndim)

--- a/numba_dpex/tests/core/types/range_types/__init__.py
+++ b/numba_dpex/tests/core/types/range_types/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/numba_dpex/tests/core/types/range_types/test_constructor_overloads.py
+++ b/numba_dpex/tests/core/types/range_types/test_constructor_overloads.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from numba_dpex import NdRange, Range, dpjit
+
+ranges = [(10,), (10, 10), (10, 10, 10)]
+
+
+@pytest.mark.parametrize("r", ranges)
+def test_range_ctor(r):
+    @dpjit
+    def _tester(r):
+        return Range(*r)
+
+    r_expected = Range(*r)
+    r_out = _tester(r)
+
+    assert r_out.ndim == r_expected.ndim
+    assert r_out.dim0 == r_expected.dim0
+    assert r_out.dim1 == r_expected.dim1
+    assert r_out.dim2 == r_expected.dim2
+
+
+@pytest.mark.parametrize("r", ranges)
+def test_ndrange_unbox_box(r):
+    @dpjit
+    def _tester(r):
+        gr = lr = Range(*r)
+        return NdRange(gr, lr)
+
+    gr = lr = Range(*r)
+    r_expected = NdRange(gr, lr)
+    r_out = _tester(r)
+
+    assert r_out.global_range.ndim == r_expected.global_range.ndim
+    assert r_out.local_range.ndim == r_expected.local_range.ndim
+    assert r_out.global_range.dim0 == r_expected.global_range.dim0
+    assert r_out.global_range.dim1 == r_expected.global_range.dim1
+    assert r_out.global_range.dim2 == r_expected.global_range.dim2
+    assert r_out.local_range.dim0 == r_expected.local_range.dim0
+    assert r_out.local_range.dim1 == r_expected.local_range.dim1
+    assert r_out.local_range.dim2 == r_expected.local_range.dim2

--- a/numba_dpex/tests/core/types/range_types/test_constructor_overloads.py
+++ b/numba_dpex/tests/core/types/range_types/test_constructor_overloads.py
@@ -18,10 +18,7 @@ def test_range_ctor(r):
     r_expected = Range(*r)
     r_out = _tester(r)
 
-    assert r_out.ndim == r_expected.ndim
-    assert r_out.dim0 == r_expected.dim0
-    assert r_out.dim1 == r_expected.dim1
-    assert r_out.dim2 == r_expected.dim2
+    assert r_out == r_expected
 
 
 @pytest.mark.parametrize("r", ranges)
@@ -35,11 +32,4 @@ def test_ndrange_unbox_box(r):
     r_expected = NdRange(gr, lr)
     r_out = _tester(r)
 
-    assert r_out.global_range.ndim == r_expected.global_range.ndim
-    assert r_out.local_range.ndim == r_expected.local_range.ndim
-    assert r_out.global_range.dim0 == r_expected.global_range.dim0
-    assert r_out.global_range.dim1 == r_expected.global_range.dim1
-    assert r_out.global_range.dim2 == r_expected.global_range.dim2
-    assert r_out.local_range.dim0 == r_expected.local_range.dim0
-    assert r_out.local_range.dim1 == r_expected.local_range.dim1
-    assert r_out.local_range.dim2 == r_expected.local_range.dim2
+    assert r_out == r_expected

--- a/numba_dpex/tests/core/types/range_types/test_data_model.py
+++ b/numba_dpex/tests/core/types/range_types/test_data_model.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from numba.core.datamodel import default_manager
+
+from numba_dpex.core.datamodel.models import (
+    NdRangeModel,
+    RangeModel,
+    dpex_data_model_manager,
+)
+from numba_dpex.core.types.range_types import NdRangeType, RangeType
+
+rfields = ["ndim", "dim0", "dim1", "dim2"]
+ndrfields = ["ndim", "gdim0", "gdim1", "gdim2", "ldim0", "ldim1", "ldim2"]
+
+
+def test_datamodel_registration():
+    """Test the datamodel for RangeType and NdRangeType are found in numba's
+    default datamodel manager but not in numba_dpex's kernel data model manager.
+    """
+    range_ty = RangeType(ndim=1)
+    ndrange_ty = NdRangeType(ndim=1)
+
+    with pytest.raises(KeyError):
+        dpex_data_model_manager.lookup(range_ty)
+        dpex_data_model_manager.lookup(ndrange_ty)
+
+    default_range_model = default_manager.lookup(range_ty)
+    default_ndrange_model = default_manager.lookup(ndrange_ty)
+
+    assert isinstance(default_range_model, RangeModel)
+    assert isinstance(default_ndrange_model, NdRangeModel)
+
+
+@pytest.mark.parametrize("field", rfields)
+def test_range_model_fields(field):
+    """Tests that the expected fields are found in the data model for
+    RangeType
+    """
+    range_ty = RangeType(ndim=1)
+    dm = default_manager.lookup(range_ty)
+    try:
+        dm.get_field_position(field)
+    except:
+        pytest.fail(f"Expected field {field} not present in RangeModel")
+
+
+@pytest.mark.parametrize("field", ndrfields)
+def test_ndrange_model_fields(field):
+    """Tests that the expected fields are found in the data model for
+    NdRangeType
+    """
+    ndrange_ty = NdRangeType(ndim=1)
+    dm = default_manager.lookup(ndrange_ty)
+    try:
+        dm.get_field_position(field)
+    except:
+        pytest.fail(f"Expected field {field} not present in NdRangeModel")

--- a/numba_dpex/tests/core/types/range_types/test_unbox_box.py
+++ b/numba_dpex/tests/core/types/range_types/test_unbox_box.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from numba_dpex import NdRange, Range, dpjit
+
+ranges = [(10,), (10, 10), (10, 10, 10)]
+
+
+@pytest.mark.parametrize("r", ranges)
+def test_range_unbox_box(r):
+    @dpjit
+    def _tester(r):
+        return r
+
+    r_in = Range(*r)
+    r_out = _tester(r_in)
+
+    assert r_out.ndim == r_in.ndim
+    assert r_out.dim0 == r_in.dim0
+    assert r_out.dim1 == r_in.dim1
+    assert r_out.dim2 == r_in.dim2
+
+
+@pytest.mark.parametrize("r", ranges)
+def test_ndrange_unbox_box(r):
+    @dpjit
+    def _tester(r):
+        return r
+
+    gr = lr = Range(*r)
+    r_in = NdRange(gr, lr)
+    r_out = _tester(r_in)
+
+    assert r_out.global_range.ndim == r_in.global_range.ndim
+    assert r_out.local_range.ndim == r_in.local_range.ndim
+    assert r_out.global_range.dim0 == r_in.global_range.dim0
+    assert r_out.global_range.dim1 == r_in.global_range.dim1
+    assert r_out.global_range.dim2 == r_in.global_range.dim2
+    assert r_out.local_range.dim0 == r_in.local_range.dim0
+    assert r_out.local_range.dim1 == r_in.local_range.dim1
+    assert r_out.local_range.dim2 == r_in.local_range.dim2

--- a/numba_dpex/tests/core/types/range_types/test_unbox_box.py
+++ b/numba_dpex/tests/core/types/range_types/test_unbox_box.py
@@ -18,10 +18,7 @@ def test_range_unbox_box(r):
     r_in = Range(*r)
     r_out = _tester(r_in)
 
-    assert r_out.ndim == r_in.ndim
-    assert r_out.dim0 == r_in.dim0
-    assert r_out.dim1 == r_in.dim1
-    assert r_out.dim2 == r_in.dim2
+    assert r_out == r_in
 
 
 @pytest.mark.parametrize("r", ranges)
@@ -34,11 +31,4 @@ def test_ndrange_unbox_box(r):
     r_in = NdRange(gr, lr)
     r_out = _tester(r_in)
 
-    assert r_out.global_range.ndim == r_in.global_range.ndim
-    assert r_out.local_range.ndim == r_in.local_range.ndim
-    assert r_out.global_range.dim0 == r_in.global_range.dim0
-    assert r_out.global_range.dim1 == r_in.global_range.dim1
-    assert r_out.global_range.dim2 == r_in.global_range.dim2
-    assert r_out.local_range.dim0 == r_in.local_range.dim0
-    assert r_out.local_range.dim1 == r_in.local_range.dim1
-    assert r_out.local_range.dim2 == r_in.local_range.dim2
+    assert r_out == r_in


### PR DESCRIPTION
- [X] Have you provided a meaningful PR description?
    - The numba_dpex.core.kernel_interface.indexers.Range and
      NdRange classes can now be used inside a numba_dpex.dpjit
      decorated function, as arguments to a dpjit decorated function,
      and returned from a dpjit decorated function.
    - Defines a datamodel, type class, overloads for the constructors,
      box, and unbox functions for both classes.
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
~~The PR should be merged post 0.21.3 tag~~
