### PR TITLE
Fixes bug in boxing a DpnpNdArray from parent.

### DIFF
--- a/numba_dpex/tests/core/types/DpnpNdArray/test_boxing_unboxing.py
+++ b/numba_dpex/tests/core/types/DpnpNdArray/test_boxing_unboxing.py
@@ -32,6 +32,8 @@ def test_boxing_unboxing():
     assert a.device == b.device
     assert a.strides == b.strides
     assert a.dtype == b.dtype
+    # To ensure we are returning the original array when boxing
+    assert id(a) == id(b)
 
 
 def test_stride_calc_at_unboxing():


### PR DESCRIPTION
- [X] Have you provided a meaningful PR description?
    - When boxing a dpnp.ndarray using the reference of the parent
      stored during unboxing, there is a validation step on the strides.
      However, as a dpnp.ndarray object does not store any stride
      information when an array is unit strided the strides need to be
      calculated and validated against the strides in the Numba
      usmarraystruct object.

      The PR fixes the stride calculation that was previously done
      incorrectly.
- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
