### PR TITLE
Improve __str__ for range_types

### DIFF
--- a/numba_dpex/core/types/range_types.py
+++ b/numba_dpex/core/types/range_types.py
@@ -22,7 +22,7 @@ class RangeType(types.Type):
             raise errors.TypingError(
                 "RangeType can only have 1,2, or 3 dimensions"
             )
-        super(RangeType, self).__init__(name="Range")
+        super(RangeType, self).__init__(name="Range<" + str(ndim) + ">")
 
     @property
     def ndim(self):
@@ -44,7 +44,7 @@ class NdRangeType(types.Type):
             raise errors.TypingError(
                 "RangeType can only have 1,2, or 3 dimensions"
             )
-        super(NdRangeType, self).__init__(name="NdRange")
+        super(NdRangeType, self).__init__(name="NdRange<" + str(ndim) + ">")
 
     @property
     def ndim(self):


### PR DESCRIPTION
Adds the `ndim` attribute to the `name` attribute of `RangeType` and `NdRangeType`. It makes the `__str__` for these types show a more informative string.