### PR TITLE
Upload wheel to the same version

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -247,9 +247,12 @@ jobs:
       - name: Upload
         run: anaconda --token ${{ secrets.ANACONDA_TOKEN }} upload --user dppy --label dev ${{ env.PACKAGE_NAME }}-*.tar.bz2
 
+      - name: Package version
+        run: echo "PACKAGE_VERSION=$(basename ${{ env.PACKAGE_NAME }}-*.tar.bz2 | sed 's/^${{ env.PACKAGE_NAME }}-\([^-]*\).*/\1/')" >> $GITHUB_ENV
+
       - name: Store wheels name
         run: |
           echo "WHEELS_NAME=$PACKAGE_NAME" | tr "-" "_" >> $GITHUB_ENV
 
       - name: Upload Wheels
-        run: anaconda --token ${{ secrets.ANACONDA_TOKEN }} upload --user dppy --label dev ${{ env.WHEELS_NAME }}-*.whl
+        run: anaconda --token ${{ secrets.ANACONDA_TOKEN }} upload --user dppy --label dev ${{ env.WHEELS_NAME }}-*.whl --version ${{ env.PACKAGE_VERSION }}

--- a/conda-recipe/bld.bat
+++ b/conda-recipe/bld.bat
@@ -7,7 +7,7 @@ set "PATH=%BUILD_PREFIX%\Library\bin-llvm;%PATH%"
 
 rem Build wheel package
 if NOT "%WHEELS_OUTPUT_FOLDER%"=="" (
-    %PYTHON% setup.py bdist_wheel
+    %PYTHON% setup.py bdist_wheel --build-number %GIT_DESCRIBE_NUMBER%
     if errorlevel 1 exit 1
     copy dist\numba_dpex*.whl %WHEELS_OUTPUT_FOLDER%
     if errorlevel 1 exit 1

--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -9,11 +9,7 @@ export PATH=$CONDA_PREFIX/bin-llvm:$PATH
 ${PYTHON} setup.py install --single-version-externally-managed --record=record.txt
 
 # Build wheel package
-if [ "$CONDA_PY" == "36" ]; then
-    WHEELS_BUILD_ARGS=(-p manylinux1_x86_64)
-else
-    WHEELS_BUILD_ARGS=(-p manylinux2014_x86_64)
-fi
+WHEELS_BUILD_ARGS=(-p manylinux2014_x86_64 --build-number "$GIT_DESCRIBE_NUMBER")
 if [[ -v WHEELS_OUTPUT_FOLDER ]]; then
     $PYTHON setup.py bdist_wheel "${WHEELS_BUILD_ARGS[@]}"
     cp dist/numba_dpex*.whl "${WHEELS_OUTPUT_FOLDER[@]}"


### PR DESCRIPTION
Wheels are uploaded to the version from wheels package that comes from versioner. That version is different for wheel and Conda and contains GitHub stash. That results into junk in Conda registry version list. PR simply uploads same wheel to the version of Conda package.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
