### PR TITLE
Miscellaneous changes to compiler internals

### DIFF
--- a/numba_dpex/core/parfors/reduction_helper.py
+++ b/numba_dpex/core/parfors/reduction_helper.py
@@ -393,13 +393,17 @@ class ReductionKernelVariables:
     def work_group_size(self):
         return self._work_group_size
 
-    def copy_final_sum_to_host(self, psrfor_kernel):
+    def copy_final_sum_to_host(self, parfor_kernel):
         lowerer = self.lowerer
-        ir_builder = KernelLaunchIRBuilder(lowerer, psrfor_kernel.kernel)
+        ir_builder = KernelLaunchIRBuilder(
+            lowerer.context,
+            lowerer.builder,
+            parfor_kernel.kernel.addressof_ref(),
+        )
 
         # Create a local variable storing a pointer to a DPCTLSyclQueueRef
         # pointer.
-        curr_queue = ir_builder.get_queue(exec_queue=psrfor_kernel.queue)
+        curr_queue = ir_builder.get_queue(exec_queue=parfor_kernel.queue)
 
         builder = lowerer.builder
         context = lowerer.context

--- a/numba_dpex/core/pipelines/kernel_compiler.py
+++ b/numba_dpex/core/pipelines/kernel_compiler.py
@@ -140,7 +140,6 @@ class _KernelPassBuilder(object):
         )
         pm.add_pass(IRLegalization, "ensure IR is legal prior to lowering")
 
-        # lower
         # NativeLowering has some issue with freevar ambiguity,
         # therefore, we are using QualNameDisambiguationLowering instead
         # numba-dpex github issue: https://github.com/IntelPython/numba-dpex/issues/898
@@ -173,7 +172,7 @@ class _KernelPassBuilder(object):
 
 
 class KernelCompiler(CompilerBase):
-    """Dpex's  kernel compilation pipeline."""
+    """Dpex's kernel compilation pipeline."""
 
     def define_pipelines(self):
         pms = []
@@ -181,4 +180,14 @@ class KernelCompiler(CompilerBase):
             pms.append(_KernelPassBuilder.define_nopython_pipeline(self.state))
         if self.state.status.can_fallback or self.state.flags.force_pyobject:
             raise UnsupportedCompilationModeError()
+
+        # Compile the kernel without generating a cpython or a cfunc wrapper
+        self.state.flags.no_cpython_wrapper = True
+        self.state.flags.no_cfunc_wrapper = True
+        # The pass pipeline does not generate an executable when compiling a
+        # kernel function. Instead, the
+        # kernel_dispatcher._KernelCompiler.compile generates the executable in
+        # the form of a host callable launcher function
+        self.state.flags.no_compile = True
+
         return pms


### PR DESCRIPTION
- [X] Have you provided a meaningful PR description?

 - Changes to the kernel_launcher.KernelLaunchIRBuilder  class constructor to make it easier to use from
   places other than the parfor_lowerer. Removed the need to pass a lowerer object and instead pass a context and builder.
- Adds a new helper function populate_kernel_args_and_args_ty_arrays that populates arrays storing kernel args and kernel 
  arg types.
- We should not generate a cpython or a cfunc wrapper for a kernel decorated function.
- The no_compile is also set to True as the kernel LLVM IR will not be compiled to an executable object code by Numba.
  Instead, numba-dpex will compile the LLVM IR to SPIR-V and generate a sycl::kernel_bundle.

- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
