### PR TITLE
Fix lifetime management for sycl event

### DIFF
--- a/numba_dpex/core/datamodel/models.py
+++ b/numba_dpex/core/datamodel/models.py
@@ -172,8 +172,8 @@ class SyclEventModel(StructModel):
     def __init__(self, dmm, fe_type):
         members = [
             (
-                "parent",
-                types.CPointer(types.int8),
+                "meminfo",
+                types.MemInfoPointer(types.pyobject),
             ),
             (
                 "event_ref",

--- a/numba_dpex/core/runtime/_eventstruct.h
+++ b/numba_dpex/core/runtime/_eventstruct.h
@@ -11,10 +11,10 @@
 
 #pragma once
 
-#include <Python.h>
+#include "numba/core/runtime/nrt_external.h"
 
 typedef struct
 {
-    PyObject *parent;
+    NRT_MemInfo *meminfo;
     void *event_ref;
 } eventstruct_t;

--- a/numba_dpex/core/runtime/_nrt_helper.c
+++ b/numba_dpex/core/runtime/_nrt_helper.c
@@ -134,3 +134,15 @@ void NRT_MemInfo_destroy(NRT_MemInfo *mi)
         TheMSys.stats.mi_free++;
     }
 }
+
+void NRT_MemInfo_pyobject_dtor(void *data)
+{
+    PyGILState_STATE gstate;
+    PyObject *ownerobj = data;
+
+    gstate = PyGILState_Ensure(); /* ensure the GIL */
+    Py_DECREF(data);              /* release the python object */
+    PyGILState_Release(gstate);   /* release the GIL */
+
+    DPEXRT_DEBUG(drt_debug_print("DPEXRT-DEBUG: pyobject destructor\n"););
+}

--- a/numba_dpex/core/runtime/_nrt_helper.h
+++ b/numba_dpex/core/runtime/_nrt_helper.h
@@ -19,5 +19,6 @@ size_t NRT_MemInfo_refcount(NRT_MemInfo *mi);
 void NRT_Free(void *ptr);
 void NRT_dealloc(NRT_MemInfo *mi);
 void NRT_MemInfo_destroy(NRT_MemInfo *mi);
+void NRT_MemInfo_pyobject_dtor(void *data);
 
 #endif /* _NRT_HELPER_H_ */

--- a/numba_dpex/dpctl_iface/libsyclinterface_bindings.py
+++ b/numba_dpex/dpctl_iface/libsyclinterface_bindings.py
@@ -71,7 +71,7 @@ def dpctl_event_wait(builder: llvmir.IRBuilder, *args):
     mod = builder.module
     fn = _build_dpctl_function(
         llvm_module=mod,
-        return_ty=cgutils.voidptr_t,
+        return_ty=llvmir.VoidType(),
         arg_list=[cgutils.voidptr_t],
         func_name="DPCTLEvent_Wait",
     )
@@ -85,7 +85,7 @@ def dpctl_event_delete(builder: llvmir.IRBuilder, *args):
     mod = builder.module
     fn = _build_dpctl_function(
         llvm_module=mod,
-        return_ty=cgutils.voidptr_t,
+        return_ty=llvmir.VoidType(),
         arg_list=[cgutils.voidptr_t],
         func_name="DPCTLEvent_Delete",
     )
@@ -99,7 +99,7 @@ def dpctl_queue_delete(builder: llvmir.IRBuilder, *args):
     mod = builder.module
     fn = _build_dpctl_function(
         llvm_module=mod,
-        return_ty=cgutils.voidptr_t,
+        return_ty=llvmir.VoidType(),
         arg_list=[cgutils.voidptr_t],
         func_name="DPCTLQueue_Delete",
     )


### PR DESCRIPTION
Memory lifetime wasn't set properly which resulted in core dumps of running kernels if boxed sycl event argument where destroyed by GC. New implementation wraps parent into `MemInfo` object and lifetime of the object is managed by it which is properly managed by numba's compiler.

P.S. : also fixed functions signature for dpctl sycl binding.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
