### PR TITLE
Fix lifetime management for sycl queue

### DIFF
--- a/numba_dpex/core/datamodel/models.py
+++ b/numba_dpex/core/datamodel/models.py
@@ -145,8 +145,8 @@ class SyclQueueModel(StructModel):
     def __init__(self, dmm, fe_type):
         members = [
             (
-                "parent",
-                types.CPointer(types.int8),
+                "meminfo",
+                types.MemInfoPointer(types.pyobject),
             ),
             (
                 "queue_ref",

--- a/numba_dpex/core/runtime/_queuestruct.h
+++ b/numba_dpex/core/runtime/_queuestruct.h
@@ -11,10 +11,10 @@
 
 #pragma once
 
-#include <Python.h>
+#include "numba/core/runtime/nrt_external.h"
 
 typedef struct
 {
-    PyObject *parent;
+    NRT_MemInfo *meminfo;
     void *queue_ref;
 } queuestruct_t;

--- a/numba_dpex/core/runtime/context.py
+++ b/numba_dpex/core/runtime/context.py
@@ -181,26 +181,32 @@ class DpexRTContext(object):
     def queuestruct_from_python(self, pyapi, obj, ptr):
         """Calls the c function DPEXRT_sycl_queue_from_python"""
         fnty = llvmir.FunctionType(
-            llvmir.IntType(32), [pyapi.pyobj, pyapi.voidptr]
+            llvmir.IntType(32), [pyapi.voidptr, pyapi.pyobj, pyapi.voidptr]
         )
+        nrt_api = self._context.nrt.get_nrt_api(pyapi.builder)
 
         fn = pyapi._get_function(fnty, "DPEXRT_sycl_queue_from_python")
         fn.args[0].add_attribute("nocapture")
         fn.args[1].add_attribute("nocapture")
+        fn.args[2].add_attribute("nocapture")
 
-        self.error = pyapi.builder.call(fn, (obj, ptr))
+        self.error = pyapi.builder.call(fn, (nrt_api, obj, ptr))
         return self.error
 
     def queuestruct_to_python(self, pyapi, val):
         """Calls the c function DPEXRT_sycl_queue_to_python"""
 
-        fnty = llvmir.FunctionType(pyapi.pyobj, [pyapi.voidptr])
+        fnty = llvmir.FunctionType(pyapi.pyobj, [pyapi.voidptr, pyapi.voidptr])
+        nrt_api = self._context.nrt.get_nrt_api(pyapi.builder)
 
         fn = pyapi._get_function(fnty, "DPEXRT_sycl_queue_to_python")
         fn.args[0].add_attribute("nocapture")
+        fn.args[1].add_attribute("nocapture")
+
         qptr = cgutils.alloca_once_value(pyapi.builder, val)
         ptr = pyapi.builder.bitcast(qptr, pyapi.voidptr)
-        self.error = pyapi.builder.call(fn, [ptr])
+
+        self.error = pyapi.builder.call(fn, [nrt_api, ptr])
 
         return self.error
 


### PR DESCRIPTION
Memory lifetime wasn't set properly which resulted in core dumps of running kernels if boxed sycl event argument where destroyed by GC. New implementation wraps parent into `MemInfo` object and lifetime of the object is managed by it which is properly managed by numba's compiler.

Similar changes to https://github.com/IntelPython/numba-dpex/pull/1188

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?

Closes https://github.com/IntelPython/numba-dpex/issues/1180
