### PR TITLE
Add overloads for new atomic_ref and fetch_phi API to numba_dpex.experimental module

### DIFF
--- a/driver.py
+++ b/driver.py
@@ -4,9 +4,6 @@ import dpnp
 import numba_dpex.experimental as nd_exp
 from numba_dpex import Range, dpjit
 
-print(type(nd_exp.MemoryOrder))
-print(type(nd_exp.MemoryOrder.RELAXED))
-
 
 @nd_exp.kernel
 def test_atomic_ref(a, b):

--- a/driver.py
+++ b/driver.py
@@ -1,0 +1,45 @@
+import dpctl
+import dpnp
+
+import numba_dpex.experimental as nd_exp
+from numba_dpex import Range, dpjit
+
+print(type(nd_exp.MemoryOrder))
+print(type(nd_exp.MemoryOrder.RELAXED))
+
+
+@nd_exp.kernel
+def test_atomic_ref(a, b):
+    a[0] = nd_exp.MemoryOrder.RELAXED
+    # i = get_global_id(0)
+    v = nd_exp.AtomicRef(
+        b,
+        nd_exp.MemoryOrder.RELAXED,
+        nd_exp.MemoryScope.DEVICE,
+        nd_exp.AddressSpace.GLOBAL,
+    )
+    v.fetch_add(a[0])  # a[i]
+
+
+q = dpctl.SyclQueue()
+a = dpnp.ones(10, sycl_queue=q, dtype=dpnp.int64)
+b = dpnp.array(0, sycl_queue=q, dtype=dpnp.int64)
+
+nd_exp.call_kernel(test_atomic_ref, Range(10), a, b)
+print(b)
+
+
+@dpjit
+def test_memory_order(a):
+    return nd_exp.MemoryOrder.RELAXED
+    # i = get_global_id(0)
+    # v = nd_exp.AtomicRef(
+    #     b,
+    #     nd_exp.MemoryOrder.RELAXED,
+    #     nd_exp.MemoryScope.DEVICE,
+    #     nd_exp.AddressSpace.GLOBAL,
+    # )
+    # v.fetch_add(a[0])  # a[i]
+
+
+print(test_memory_order(a))

--- a/numba_dpex/core/descriptor.py
+++ b/numba_dpex/core/descriptor.py
@@ -40,6 +40,7 @@ class DpexTargetOptions(CPUTargetOptions):
     release_gil = _option_mapping("release_gil")
     no_compile = _option_mapping("no_compile")
     use_mlir = _option_mapping("use_mlir")
+    generate_device_ir = _option_mapping("generate_device_ir")
 
     def finalize(self, flags, options):
         super().finalize(flags, options)
@@ -47,6 +48,7 @@ class DpexTargetOptions(CPUTargetOptions):
         _inherit_if_not_set(flags, options, "release_gil", False)
         _inherit_if_not_set(flags, options, "no_compile", True)
         _inherit_if_not_set(flags, options, "use_mlir", False)
+        _inherit_if_not_set(flags, options, "generate_device_ir", True)
 
 
 class DpexKernelTarget(TargetDescriptor):

--- a/numba_dpex/core/targets/dpjit_target.py
+++ b/numba_dpex/core/targets/dpjit_target.py
@@ -25,7 +25,6 @@ DPEX_TARGET_NAME = "dpex"
 # permits lookup and reference in user space by the string "dpex"
 target_registry[DPEX_TARGET_NAME] = Dpex
 
-# This is the function registry for the dpu, it just has one registry, this one!
 dpex_function_registry = Registry()
 
 

--- a/numba_dpex/core/types/array_type.py
+++ b/numba_dpex/core/types/array_type.py
@@ -3,8 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np
-from numba.core import types
-from numba.core.datamodel.models import StructModel
 from numba.core.types.npytypes import Array
 
 

--- a/numba_dpex/core/types/dpctl_types.py
+++ b/numba_dpex/core/types/dpctl_types.py
@@ -24,6 +24,10 @@ class DpctlSyclQueue(types.Type):
         # the compute follows data inference pass is fixed to use SyclQueue
         self._device = sycl_queue.sycl_device.filter_string
 
+        self._device_has_aspect_atomic64 = (
+            sycl_queue.sycl_device.has_aspect_atomic64
+        )
+
         try:
             self._unique_id = hash(sycl_queue)
         except Exception:
@@ -44,6 +48,10 @@ class DpctlSyclQueue(types.Type):
             str: A SYCL oneAPI extension filter string
         """
         return self._device
+
+    @property
+    def device_has_aspect_atomic64(self):
+        return self._device_has_aspect_atomic64
 
     @property
     def key(self):

--- a/numba_dpex/experimental/__init__.py
+++ b/numba_dpex/experimental/__init__.py
@@ -9,6 +9,8 @@ yet production ready.
 from numba.core.imputils import Registry
 
 from .decorators import kernel
+from .dpcpp_iface import AddressSpace, AtomicRef, MemoryOrder, MemoryScope
+from .dpcpp_types import AtomicRefType
 from .kernel_dispatcher import KernelDispatcher
 from .launcher import call_kernel
 from .literal_intenum_type import IntEnumLiteral
@@ -30,6 +32,11 @@ def dpex_dispatcher_const(context):
 __all__ = [
     "kernel",
     "call_kernel",
+    "AddressSpace",
+    "AtomicRef",
+    "AtomicRefType",
     "IntEnumLiteral",
     "KernelDispatcher",
+    "MemoryOrder",
+    "MemoryScope",
 ]

--- a/numba_dpex/experimental/__init__.py
+++ b/numba_dpex/experimental/__init__.py
@@ -11,6 +11,7 @@ from numba.core.imputils import Registry
 from .decorators import kernel
 from .kernel_dispatcher import KernelDispatcher
 from .launcher import call_kernel
+from .literal_intenum_type import IntEnumLiteral
 from .models import *
 from .types import KernelDispatcherType
 
@@ -26,4 +27,9 @@ def dpex_dispatcher_const(context):
     return context.get_dummy_value()
 
 
-__all__ = ["kernel", "KernelDispatcher", "call_kernel"]
+__all__ = [
+    "kernel",
+    "call_kernel",
+    "IntEnumLiteral",
+    "KernelDispatcher",
+]

--- a/numba_dpex/experimental/decorators.py
+++ b/numba_dpex/experimental/decorators.py
@@ -26,6 +26,7 @@ def kernel(func_or_sig=None, **options):
     """
     # FIXME: The options need to be evaluated and checked here like it is
     # done in numba.core.decorators.jit
+    options["generate_device_ir"] = True
 
     def _kernel_dispatcher(pyfunc):
         return KernelDispatcher(

--- a/numba_dpex/experimental/decorators.py
+++ b/numba_dpex/experimental/decorators.py
@@ -8,9 +8,13 @@ ready to move to numba_dpex.core.
 import inspect
 
 from numba.core import sigutils
-from numba.core.target_extension import jit_registry, target_registry
+from numba.core.target_extension import (
+    jit_registry,
+    resolve_dispatcher_from_str,
+    target_registry,
+)
 
-from .kernel_dispatcher import KernelDispatcher
+from .target import DPEX_KERNEL_EXP_TARGET_NAME
 
 
 def kernel(func_or_sig=None, **options):
@@ -24,12 +28,15 @@ def kernel(func_or_sig=None, **options):
         * All array arguments passed to a kernel should adhere to compute
           follows data programming model.
     """
+
+    dispatcher = resolve_dispatcher_from_str(DPEX_KERNEL_EXP_TARGET_NAME)
+
     # FIXME: The options need to be evaluated and checked here like it is
     # done in numba.core.decorators.jit
     options["generate_device_ir"] = True
 
     def _kernel_dispatcher(pyfunc):
-        return KernelDispatcher(
+        return dispatcher(
             pyfunc=pyfunc,
             targetoptions=options,
         )
@@ -60,9 +67,7 @@ def kernel(func_or_sig=None, **options):
             func_or_sig = [func_or_sig]
 
         def _specialized_kernel_dispatcher(pyfunc):
-            return KernelDispatcher(
-                pyfunc=pyfunc,
-            )
+            return dispatcher(pyfunc=pyfunc)
 
         return _specialized_kernel_dispatcher
     func = func_or_sig
@@ -93,10 +98,13 @@ def device_func(func_or_sig=None, **options):
         KernelDispatcher: A KernelDispatcher instance with the
         generate_device_ir flag set to False.
     """
+
+    dispatcher = resolve_dispatcher_from_str(DPEX_KERNEL_EXP_TARGET_NAME)
+
     options["generate_device_ir"] = False
 
     def _kernel_dispatcher(pyfunc):
-        return KernelDispatcher(
+        return dispatcher(
             pyfunc=pyfunc,
             targetoptions=options,
         )
@@ -107,4 +115,4 @@ def device_func(func_or_sig=None, **options):
     return _kernel_dispatcher(func_or_sig)
 
 
-jit_registry[target_registry["dpex_kernel"]] = device_func
+jit_registry[target_registry[DPEX_KERNEL_EXP_TARGET_NAME]] = device_func

--- a/numba_dpex/experimental/dpcpp_iface/__init__.py
+++ b/numba_dpex/experimental/dpcpp_iface/__init__.py
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Python classes that are analogous to dpcpp's SYCL API used to write kernels.
+"""
+
+from .atomic_ref import AtomicRef
+from .memory_enums import AddressSpace, MemoryOrder, MemoryScope
+
+__all__ = ["AddressSpace", "AtomicRef", "MemoryOrder", "MemoryScope"]

--- a/numba_dpex/experimental/dpcpp_iface/_spv_atomic_helper.py
+++ b/numba_dpex/experimental/dpcpp_iface/_spv_atomic_helper.py
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from enum import IntEnum
+
+from .memory_enums import MemoryOrder, MemoryScope
+
+
+class _spv_scope(IntEnum):
+    """
+    An enumeration to store the dpcpp values for spirv scope.
+    """
+
+    CrossDevice = 0
+    Device = 1
+    Workgroup = 2
+    Subgroup = 3
+    Invocation = 4
+
+
+class _spv_memory_semantics_mask(IntEnum):
+    """
+    An enumeration to store the dpcpp values for spirv mask.
+
+    """
+
+    NONE = 0x0
+    Acquire = 0x2
+    Release = 0x4
+    AcquireRelease = 0x8
+    SequentiallyConsistent = 0x10
+    UniformMemory = 0x40
+    SubgroupMemory = 0x80
+    WorkgroupMemory = 0x100
+    CrossWorkgroupMemory = 0x200
+    AtomicCounterMemory = 0x400
+    ImageMemory = 0x800
+
+
+def get_memory_semantics_mask(memory_order):
+    """
+    Translates SYCL memory order to SPIRV memory semantics mask, based on the
+    getMemorySemanticsMask function in dpcpp's
+    sycl/include/sycl/detail/spirv.hpp.
+
+
+    """
+
+    spv_order = _spv_memory_semantics_mask.NONE.value
+
+    if memory_order == MemoryOrder.relaxed.value:
+        spv_order = _spv_memory_semantics_mask.NONE.value
+    elif memory_order == MemoryOrder.consume_unsupported.value:
+        pass
+    elif memory_order == MemoryOrder.acquire.value:
+        spv_order = _spv_memory_semantics_mask.Acquire.value
+    elif memory_order == MemoryOrder.release.value:
+        spv_order = _spv_memory_semantics_mask.Release.value
+    elif memory_order == MemoryOrder.acq_rel.value:
+        spv_order = _spv_memory_semantics_mask.AcquireRelease.value
+    elif memory_order == MemoryOrder.seq_cst.value:
+        spv_order = _spv_memory_semantics_mask.SequentiallyConsistent.value
+    else:
+        raise ValueError("Invalid memory order provided")
+
+    return (
+        spv_order
+        | _spv_memory_semantics_mask.SubgroupMemory.value
+        | _spv_memory_semantics_mask.WorkgroupMemory.value
+        | _spv_memory_semantics_mask.CrossWorkgroupMemory.value
+    )
+
+
+def get_scope(memory_scope):
+    """
+    Translates SYCL memory scope to SPIRV scope.
+    """
+
+    if memory_scope == MemoryScope.work_item.value:
+        return _spv_scope.Invocation.value
+    elif memory_scope == MemoryScope.sub_group.value:
+        return _spv_scope.Subgroup.value
+    elif memory_scope == MemoryScope.work_group.value:
+        return _spv_scope.Workgroup.value
+    elif memory_scope == MemoryScope.device.value:
+        return _spv_scope.Device.value
+    elif memory_scope == MemoryScope.system.value:
+        return _spv_scope.CrossDevice.value
+    else:
+        raise ValueError("Invalid memory scope provided")

--- a/numba_dpex/experimental/dpcpp_iface/_spv_atomic_helper.py
+++ b/numba_dpex/experimental/dpcpp_iface/_spv_atomic_helper.py
@@ -9,35 +9,35 @@ from numba.core import types
 from .memory_enums import MemoryOrder, MemoryScope
 
 
-class _spv_scope(IntEnum):
+class _SpvScope(IntEnum):
     """
     An enumeration to store the dpcpp values for spirv scope.
     """
 
-    CrossDevice = 0
-    Device = 1
-    Workgroup = 2
-    Subgroup = 3
-    Invocation = 4
+    CROSS_DEVICE = 0
+    DEVICE = 1
+    WORKGROUP = 2
+    SUBGROUP = 3
+    INVOCATION = 4
 
 
-class _spv_memory_semantics_mask(IntEnum):
+class _SpvMemorySemanticsMask(IntEnum):
     """
     An enumeration to store the dpcpp values for spirv mask.
 
     """
 
     NONE = 0x0
-    Acquire = 0x2
-    Release = 0x4
-    AcquireRelease = 0x8
-    SequentiallyConsistent = 0x10
-    UniformMemory = 0x40
-    SubgroupMemory = 0x80
-    WorkgroupMemory = 0x100
-    CrossWorkgroupMemory = 0x200
-    AtomicCounterMemory = 0x400
-    ImageMemory = 0x800
+    ACQUIRE = 0x2
+    RELEASE = 0x4
+    ACQUIRE_RELEASE = 0x8
+    SEQUENTIALLY_CONSISTENT = 0x10
+    UNIFORM_MEMORY = 0x40
+    SUBGROUP_MEMORY = 0x80
+    WORKGROUP_MEMORY = 0x100
+    CROSS_WORKGROUP_MEMORY = 0x200
+    ATOMIC_COUNTER_MEMORY = 0x400
+    IMAGE_MEMORY = 0x800
 
 
 _spv_atomic_instructions_map = {
@@ -103,28 +103,28 @@ def get_memory_semantics_mask(memory_order):
 
     """
 
-    spv_order = _spv_memory_semantics_mask.NONE.value
+    spv_order = _SpvMemorySemanticsMask.NONE.value
 
-    if memory_order == MemoryOrder.relaxed.value:
-        spv_order = _spv_memory_semantics_mask.NONE.value
-    elif memory_order == MemoryOrder.consume_unsupported.value:
+    if memory_order == MemoryOrder.RELAXED.value:
+        spv_order = _SpvMemorySemanticsMask.NONE.value
+    elif memory_order == MemoryOrder.CONSUME_UNSUPPORTED.value:
         pass
-    elif memory_order == MemoryOrder.acquire.value:
-        spv_order = _spv_memory_semantics_mask.Acquire.value
-    elif memory_order == MemoryOrder.release.value:
-        spv_order = _spv_memory_semantics_mask.Release.value
-    elif memory_order == MemoryOrder.acq_rel.value:
-        spv_order = _spv_memory_semantics_mask.AcquireRelease.value
-    elif memory_order == MemoryOrder.seq_cst.value:
-        spv_order = _spv_memory_semantics_mask.SequentiallyConsistent.value
+    elif memory_order == MemoryOrder.ACQUIRE.value:
+        spv_order = _SpvMemorySemanticsMask.ACQUIRE.value
+    elif memory_order == MemoryOrder.RELEASE.value:
+        spv_order = _SpvMemorySemanticsMask.RELEASE.value
+    elif memory_order == MemoryOrder.ACQ_REL.value:
+        spv_order = _SpvMemorySemanticsMask.ACQUIRE_RELEASE.value
+    elif memory_order == MemoryOrder.SEQ_CST.value:
+        spv_order = _SpvMemorySemanticsMask.SEQUENTIALLY_CONSISTENT.value
     else:
         raise ValueError("Invalid memory order provided")
 
     return (
         spv_order
-        | _spv_memory_semantics_mask.SubgroupMemory.value
-        | _spv_memory_semantics_mask.WorkgroupMemory.value
-        | _spv_memory_semantics_mask.CrossWorkgroupMemory.value
+        | _SpvMemorySemanticsMask.SUBGROUP_MEMORY.value
+        | _SpvMemorySemanticsMask.WORKGROUP_MEMORY.value
+        | _SpvMemorySemanticsMask.CROSS_WORKGROUP_MEMORY.value
     )
 
 
@@ -132,16 +132,18 @@ def get_scope(memory_scope):
     """
     Translates SYCL memory scope to SPIRV scope.
     """
-
-    if memory_scope == MemoryScope.work_item.value:
-        return _spv_scope.Invocation.value
-    elif memory_scope == MemoryScope.sub_group.value:
-        return _spv_scope.Subgroup.value
-    elif memory_scope == MemoryScope.work_group.value:
-        return _spv_scope.Workgroup.value
-    elif memory_scope == MemoryScope.device.value:
-        return _spv_scope.Device.value
-    elif memory_scope == MemoryScope.system.value:
-        return _spv_scope.CrossDevice.value
+    retval = None
+    if memory_scope == MemoryScope.WORK_ITEM.value:
+        retval =  _SpvScope.INVOCATION.value
+    elif memory_scope == MemoryScope.SUB_GROUP.value:
+        retval =  _SpvScope.SUBGROUP.value
+    elif memory_scope == MemoryScope.WORK_GROUP.value:
+        retval = _SpvScope.WORKGROUP.value
+    elif memory_scope == MemoryScope.DEVICE.value:
+        retval = _SpvScope.DEVICE.value
+    elif memory_scope == MemoryScope.SYSTEM.value:
+        retval = _SpvScope.CROSS_DEVICE.value
     else:
         raise ValueError("Invalid memory scope provided")
+
+    return retval

--- a/numba_dpex/experimental/dpcpp_iface/_spv_atomic_helper.py
+++ b/numba_dpex/experimental/dpcpp_iface/_spv_atomic_helper.py
@@ -134,9 +134,9 @@ def get_scope(memory_scope):
     """
     retval = None
     if memory_scope == MemoryScope.WORK_ITEM.value:
-        retval =  _SpvScope.INVOCATION.value
+        retval = _SpvScope.INVOCATION.value
     elif memory_scope == MemoryScope.SUB_GROUP.value:
-        retval =  _SpvScope.SUBGROUP.value
+        retval = _SpvScope.SUBGROUP.value
     elif memory_scope == MemoryScope.WORK_GROUP.value:
         retval = _SpvScope.WORKGROUP.value
     elif memory_scope == MemoryScope.DEVICE.value:

--- a/numba_dpex/experimental/dpcpp_iface/atomic_ref.py
+++ b/numba_dpex/experimental/dpcpp_iface/atomic_ref.py
@@ -1,0 +1,203 @@
+# SPDX-FileCopyrightText: 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from llvmlite import ir as llvmir
+from numba import errors
+from numba.core import cgutils, types
+from numba.extending import intrinsic, overload, overload_method
+
+from numba_dpex.core import itanium_mangler as ext_itanium_mangler
+from numba_dpex.core.datamodel.models import dpex_data_model_manager
+from numba_dpex.core.exceptions import UnreachableError
+from numba_dpex.core.types import USMNdArray
+
+from ..dpcpp_types import AtomicRefType
+from ._spv_atomic_helper import get_memory_semantics_mask, get_scope
+
+
+class AtomicRef(object):
+    """The class provides the ability to perform atomic operations in a
+    kernel function. The class is modeled after the ``sycl::atomic_ref`` class.
+
+    """
+
+    def __init__(self, ref, memory_order, memory_scope, address_space):
+        self._memory_order = memory_order
+        self._memory_scope = memory_scope
+        self._address_space = address_space
+        self._ref = ref
+
+    def fetch_add(self, val):
+        pass
+
+
+@intrinsic
+def _intrinsic_fetch_add(ty_context, ty_atomic_ref, ty_val):
+    sig = types.void(ty_atomic_ref, ty_val)
+
+    def gen(context, builder, sig, args):
+        atomic_ref_ty = sig.args[0]
+        atomic_ref_dtype = atomic_ref_ty.dtype
+
+        ref = args[0]
+        data_attr_pos = dpex_data_model_manager.lookup(
+            sig.args[0]
+        ).get_field_position("ref")
+
+        data_attr = builder.extract_value(ref, data_attr_pos)
+
+        if atomic_ref_dtype in (types.float32, types.float64):
+            # XXX Turn on once the overload is added to DpexKernelTarget
+            # context.extra_compile_options[context.LLVM_SPIRV_ARGS] = [
+            #     "--spirv-ext=+SPV_EXT_shader_atomic_float_add"
+            # ]
+
+            name = "__spirv_AtomicFAddEXT"
+        elif atomic_ref_dtype in (types.int32, types.int64):
+            name = "__spirv_AtomicIAdd"
+        else:
+            raise UnreachableError
+
+        ptr_type = context.get_value_type(atomic_ref_dtype).as_pointer()
+        ptr_type.addrspace = atomic_ref_ty.address_space.literal_value
+        retty = context.get_value_type(atomic_ref_dtype)
+        spirv_fn_arg_types = [
+            ptr_type,
+            llvmir.IntType(32),
+            llvmir.IntType(32),
+            context.get_value_type(atomic_ref_dtype),
+        ]
+        numba_ptr_ty = types.CPointer(
+            atomic_ref_dtype, addrspace=ptr_type.addrspace
+        )
+        mangled_fn_name = ext_itanium_mangler.mangle_ext(
+            name,
+            [
+                numba_ptr_ty,
+                "__spv.Scope.Flag",
+                "__spv.MemorySemanticsMask.Flag",
+                atomic_ref_dtype,
+            ],
+        )
+        fnty = llvmir.FunctionType(retty, spirv_fn_arg_types)
+        fn = cgutils.get_or_insert_function(
+            builder.module, fnty, mangled_fn_name
+        )
+        # XXX Change to DpexKernelTarget.SPIR_FUNC once overloads are added to
+        # DpexKernelTarget
+        fn.calling_convention = "spir_func"
+        spirv_memory_semantics_mask = get_memory_semantics_mask(
+            atomic_ref_ty.memory_order.literal_value
+        )
+        spirv_scope = get_scope(atomic_ref_ty.memory_scope.literal_value)
+
+        # XXX Temporary address space cast is needed as we are using the
+        # DpnpNdArrayModel used in dpjit. Once the overload is moved to
+        # dpex_kernel we will not need the address space cast.
+        addr_sp_casted_ref = builder.addrspacecast(data_attr, ptr_type)
+        fn_args = [
+            addr_sp_casted_ref,
+            context.get_constant(types.int32, spirv_scope),
+            context.get_constant(types.int32, spirv_memory_semantics_mask),
+            args[1],
+        ]
+
+        builder.call(fn, fn_args)
+
+    return sig, gen
+
+
+@intrinsic
+def _intrinsic_atomic_ref_ctor(ty_context, ref, ty_retty_ref):
+    ty_retty = ty_retty_ref.instance_type
+    sig = ty_retty(ref, ty_retty_ref)
+
+    def codegen(context, builder, sig, args):
+        typ = sig.return_type
+        ref = args[0]
+        data_attr_pos = dpex_data_model_manager.lookup(
+            sig.args[0]
+        ).get_field_position("data")
+
+        data_attr = builder.extract_value(ref, data_attr_pos)
+        atomic_ref_struct = cgutils.create_struct_proxy(typ)(context, builder)
+
+        # Populate the atomic ref data model
+        ref_attr_pos = dpex_data_model_manager.lookup(
+            ty_retty
+        ).get_field_position("ref")
+        builder.insert_value(
+            atomic_ref_struct._getvalue(), data_attr, ref_attr_pos
+        )
+        return atomic_ref_struct._getvalue()
+
+    return (
+        sig,
+        codegen,
+    )
+
+
+def _check_if_supported_ref(ref):
+    supported = True
+
+    if not (isinstance(ref, USMNdArray)):
+        raise errors.TypingError(
+            f"Cannot create an AtomicRef from {ref}. "
+            "An AtomicRef can only be constructed from a 0-dimensional "
+            "dpctl.tensor.usm_ndarray or a dpnp.ndarray array."
+        )
+    elif ref.ndim != 0:
+        raise errors.TypingError(
+            f"Cannot create an AtomicRef from a {ref.ndim}-dimensional tensor."
+        )
+    elif ref.dtype not in [
+        types.uint32,
+        types.float32,
+        types.int64,
+        types.uint64,
+        types.float64,
+    ]:
+        raise errors.TypingError(
+            "Cannot create an AtomicRef from a tensor with an unsupported "
+            "element type."
+        )
+    elif ref.dtype in [types.int64, types.float64, types.uint64]:
+        if not ref.queue.device_has_aspect_atomic64:
+            raise errors.TypingError(
+                "Targeted device does not support 64-bit atomic operations."
+            )
+    else:
+        return supported
+
+
+@overload(AtomicRef, prefer_literal=True, inline="always")
+def ol_atomic_ref(ref, memory_order, memory_scope, address_space):
+    _check_if_supported_ref(ref)
+
+    ty_retty = AtomicRefType(
+        dtype=ref.dtype,
+        memory_order=memory_order,
+        memory_scope=memory_scope,
+        address_space=address_space,
+        has_aspect_atomic64=ref.queue.device_has_aspect_atomic64,
+    )
+
+    def impl(ref, memory_order, memory_scope, address_space):
+        return _intrinsic_atomic_ref_ctor(ref, ty_retty)
+
+    return impl
+
+
+@overload_method(AtomicRefType, "fetch_add", inline="always")
+def ol_fetch_add(atomic_ref, val):
+    if atomic_ref.dtype != val:
+        raise errors.TypingError(
+            f"Type of value to add: {val} does not match the type of the "
+            f"reference: {atomic_ref.dtype} stored in the atomic ref."
+        )
+
+    def impl(atomic_ref, val):
+        return _intrinsic_fetch_add(atomic_ref, val)
+
+    return impl

--- a/numba_dpex/experimental/dpcpp_iface/atomic_ref.py
+++ b/numba_dpex/experimental/dpcpp_iface/atomic_ref.py
@@ -47,7 +47,7 @@ def _parse_int_literal(literal_int: types.scalars.IntegerLiteral) -> int:
         )
 
 
-class AtomicRef(object):
+class AtomicRef:
     """The class provides the ability to perform atomic operations in a
     kernel function. The class is modeled after the ``sycl::atomic_ref`` class.
 
@@ -348,7 +348,7 @@ def ol_fetch_and(atomic_ref, val):
             f"reference: {atomic_ref.dtype} stored in the atomic ref."
         )
 
-    if atomic_ref.dtype != types.int32 and atomic_ref.dtype != types.int64:
+    if atomic_ref.dtype not in (types.int32, types.int64):
         raise errors.TypingError(
             "fetch_and operation only supported on int32 and int64 dtypes."
         )
@@ -369,7 +369,7 @@ def ol_fetch_or(atomic_ref, val):
             f"reference: {atomic_ref.dtype} stored in the atomic ref."
         )
 
-    if atomic_ref.dtype != types.int32 and atomic_ref.dtype != types.int64:
+    if atomic_ref.dtype not in (types.int32, types.int64):
         raise errors.TypingError(
             "fetch_or operation only supported on int32 and int64 dtypes."
         )
@@ -390,7 +390,7 @@ def ol_fetch_xor(atomic_ref, val):
             f"reference: {atomic_ref.dtype} stored in the atomic ref."
         )
 
-    if atomic_ref.dtype != types.int32 and atomic_ref.dtype != types.int64:
+    if atomic_ref.dtype not in (types.int32, types.int64):
         raise errors.TypingError(
             "fetch_xor operation only supported on int32 and int64 dtypes."
         )

--- a/numba_dpex/experimental/dpcpp_iface/atomic_ref.py
+++ b/numba_dpex/experimental/dpcpp_iface/atomic_ref.py
@@ -216,7 +216,7 @@ def _intrinsic_atomic_ref_ctor(ty_context, ref, ty_retty_ref):
 def _check_if_supported_ref(ref):
     supported = True
 
-    if not (isinstance(ref, USMNdArray)):
+    if not isinstance(ref, USMNdArray):
         raise errors.TypingError(
             f"Cannot create an AtomicRef from {ref}. "
             "An AtomicRef can only be constructed from a 0-dimensional "

--- a/numba_dpex/experimental/dpcpp_iface/atomic_ref.py
+++ b/numba_dpex/experimental/dpcpp_iface/atomic_ref.py
@@ -8,13 +8,11 @@ from numba.core import cgutils, types
 from numba.extending import intrinsic, overload, overload_method
 
 from numba_dpex.core import itanium_mangler as ext_itanium_mangler
-from numba_dpex.core.targets.kernel_target import (
-    CC_SPIR_FUNC,
-    DPEX_KERNEL_TARGET_NAME,
-)
+from numba_dpex.core.targets.kernel_target import CC_SPIR_FUNC
 from numba_dpex.core.types import USMNdArray
 
 from ..dpcpp_types import AtomicRefType
+from ..target import DPEX_KERNEL_EXP_TARGET_NAME
 from ._spv_atomic_helper import (
     get_atomic_inst_name,
     get_memory_semantics_mask,
@@ -148,42 +146,42 @@ def _intrinsic_helper(ty_context, ty_atomic_ref, ty_val, op_str):
     return sig, gen
 
 
-@intrinsic(target=DPEX_KERNEL_TARGET_NAME)
+@intrinsic(target=DPEX_KERNEL_EXP_TARGET_NAME)
 def _intrinsic_fetch_add(ty_context, ty_atomic_ref, ty_val):
     return _intrinsic_helper(ty_context, ty_atomic_ref, ty_val, "fetch_add")
 
 
-@intrinsic(target=DPEX_KERNEL_TARGET_NAME)
+@intrinsic(target=DPEX_KERNEL_EXP_TARGET_NAME)
 def _intrinsic_fetch_sub(ty_context, ty_atomic_ref, ty_val):
     return _intrinsic_helper(ty_context, ty_atomic_ref, ty_val, "fetch_sub")
 
 
-@intrinsic(target=DPEX_KERNEL_TARGET_NAME)
+@intrinsic(target=DPEX_KERNEL_EXP_TARGET_NAME)
 def _intrinsic_fetch_min(ty_context, ty_atomic_ref, ty_val):
     return _intrinsic_helper(ty_context, ty_atomic_ref, ty_val, "fetch_min")
 
 
-@intrinsic(target=DPEX_KERNEL_TARGET_NAME)
+@intrinsic(target=DPEX_KERNEL_EXP_TARGET_NAME)
 def _intrinsic_fetch_max(ty_context, ty_atomic_ref, ty_val):
     return _intrinsic_helper(ty_context, ty_atomic_ref, ty_val, "fetch_max")
 
 
-@intrinsic(target=DPEX_KERNEL_TARGET_NAME)
+@intrinsic(target=DPEX_KERNEL_EXP_TARGET_NAME)
 def _intrinsic_fetch_and(ty_context, ty_atomic_ref, ty_val):
     return _intrinsic_helper(ty_context, ty_atomic_ref, ty_val, "fetch_and")
 
 
-@intrinsic(target=DPEX_KERNEL_TARGET_NAME)
+@intrinsic(target=DPEX_KERNEL_EXP_TARGET_NAME)
 def _intrinsic_fetch_or(ty_context, ty_atomic_ref, ty_val):
     return _intrinsic_helper(ty_context, ty_atomic_ref, ty_val, "fetch_or")
 
 
-@intrinsic(target=DPEX_KERNEL_TARGET_NAME)
+@intrinsic(target=DPEX_KERNEL_EXP_TARGET_NAME)
 def _intrinsic_fetch_xor(ty_context, ty_atomic_ref, ty_val):
     return _intrinsic_helper(ty_context, ty_atomic_ref, ty_val, "fetch_xor")
 
 
-@intrinsic(target=DPEX_KERNEL_TARGET_NAME)
+@intrinsic(target=DPEX_KERNEL_EXP_TARGET_NAME)
 def _intrinsic_atomic_ref_ctor(ty_context, ref, ty_retty_ref):
     from ..target import dpex_exp_kernel_target
 
@@ -250,8 +248,7 @@ def _check_if_supported_ref(ref):
 @overload(
     AtomicRef,
     prefer_literal=True,
-    inline="always",
-    target=DPEX_KERNEL_TARGET_NAME,
+    target=DPEX_KERNEL_EXP_TARGET_NAME,
 )
 def ol_atomic_ref(ref, memory_order, memory_scope, address_space):
     _check_if_supported_ref(ref)
@@ -274,9 +271,7 @@ def ol_atomic_ref(ref, memory_order, memory_scope, address_space):
     return ol_atomic_ref_ctor_impl
 
 
-@overload_method(
-    AtomicRefType, "fetch_add", inline="always", target=DPEX_KERNEL_TARGET_NAME
-)
+@overload_method(AtomicRefType, "fetch_add", target=DPEX_KERNEL_EXP_TARGET_NAME)
 def ol_fetch_add(atomic_ref, val):
     if atomic_ref.dtype != val:
         raise errors.TypingError(
@@ -290,9 +285,7 @@ def ol_fetch_add(atomic_ref, val):
     return ol_fetch_add_impl
 
 
-@overload_method(
-    AtomicRefType, "fetch_sub", inline="always", target=DPEX_KERNEL_TARGET_NAME
-)
+@overload_method(AtomicRefType, "fetch_sub", target=DPEX_KERNEL_EXP_TARGET_NAME)
 def ol_fetch_sub(atomic_ref, val):
     if atomic_ref.dtype != val:
         raise errors.TypingError(
@@ -306,9 +299,7 @@ def ol_fetch_sub(atomic_ref, val):
     return ol_fetch_sub_impl
 
 
-@overload_method(
-    AtomicRefType, "fetch_min", inline="always", target=DPEX_KERNEL_TARGET_NAME
-)
+@overload_method(AtomicRefType, "fetch_min", target=DPEX_KERNEL_EXP_TARGET_NAME)
 def ol_fetch_min(atomic_ref, val):
     if atomic_ref.dtype != val:
         raise errors.TypingError(
@@ -322,9 +313,7 @@ def ol_fetch_min(atomic_ref, val):
     return ol_fetch_min_impl
 
 
-@overload_method(
-    AtomicRefType, "fetch_max", inline="always", target=DPEX_KERNEL_TARGET_NAME
-)
+@overload_method(AtomicRefType, "fetch_max", target=DPEX_KERNEL_EXP_TARGET_NAME)
 def ol_fetch_max(atomic_ref, val):
     if atomic_ref.dtype != val:
         raise errors.TypingError(
@@ -338,9 +327,7 @@ def ol_fetch_max(atomic_ref, val):
     return ol_fetch_max_impl
 
 
-@overload_method(
-    AtomicRefType, "fetch_and", inline="always", target=DPEX_KERNEL_TARGET_NAME
-)
+@overload_method(AtomicRefType, "fetch_and", target=DPEX_KERNEL_EXP_TARGET_NAME)
 def ol_fetch_and(atomic_ref, val):
     if atomic_ref.dtype != val:
         raise errors.TypingError(
@@ -359,9 +346,7 @@ def ol_fetch_and(atomic_ref, val):
     return ol_fetch_and_impl
 
 
-@overload_method(
-    AtomicRefType, "fetch_or", inline="always", target=DPEX_KERNEL_TARGET_NAME
-)
+@overload_method(AtomicRefType, "fetch_or", target=DPEX_KERNEL_EXP_TARGET_NAME)
 def ol_fetch_or(atomic_ref, val):
     if atomic_ref.dtype != val:
         raise errors.TypingError(
@@ -380,9 +365,7 @@ def ol_fetch_or(atomic_ref, val):
     return ol_fetch_or_impl
 
 
-@overload_method(
-    AtomicRefType, "fetch_xor", inline="always", target=DPEX_KERNEL_TARGET_NAME
-)
+@overload_method(AtomicRefType, "fetch_xor", target=DPEX_KERNEL_EXP_TARGET_NAME)
 def ol_fetch_xor(atomic_ref, val):
     if atomic_ref.dtype != val:
         raise errors.TypingError(

--- a/numba_dpex/experimental/dpcpp_iface/memory_enums.py
+++ b/numba_dpex/experimental/dpcpp_iface/memory_enums.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from numba_dpex.experimental.flag_enum import FlagEnum
+
+
+class MemoryOrder(FlagEnum):
+    """
+    An enumeration of the supported ``sycl::memory_order`` values in dpcpp. The
+    integer values of the enums is kept consistent with the corresponding
+    implementation in dpcpp.
+
+
+    =====================   ============
+    Order                   Enum value
+    =====================   ============
+    relaxed                 0
+    acquire                 1
+    consume_unsupported     2
+    release                 3
+    acq_rel                 4
+    seq_cst                 5
+    =====================   ============
+    """
+
+    relaxed = 0
+    acquire = 1
+    consume_unsupported = 2
+    release = 3
+    acq_rel = 4
+    seq_cst = 5
+
+
+class MemoryScope(FlagEnum):
+    """
+    An enumeration of SYCL memory scope. For more details please refer to
+    SYCL 2020 specification, section 3.8.3.2
+
+    ===============  ============
+    Memory Scope     Enum value
+    ===============  ============
+    work_item        0
+    sub_group        1
+    work_group       2
+    device           3
+    system           4
+    ===============  ============
+    """
+
+    work_item = 0
+    sub_group = 1
+    work_group = 2
+    device = 3
+    system = 4
+
+
+class AddressSpace(FlagEnum):
+    """The address space values supported by numba_dpex.
+
+    ==================   ============
+    Address space        Value
+    ==================   ============
+    PRIVATE              0
+    GLOBAL               1
+    CONSTANT             2
+    LOCAL                3
+    GENERIC              4
+    ==================   ============
+
+    """
+
+    PRIVATE = 0
+    GLOBAL = 1
+    CONSTANT = 2
+    LOCAL = 3
+    GENERIC = 4

--- a/numba_dpex/experimental/dpcpp_iface/memory_enums.py
+++ b/numba_dpex/experimental/dpcpp_iface/memory_enums.py
@@ -15,21 +15,21 @@ class MemoryOrder(FlagEnum):
     =====================   ============
     Order                   Enum value
     =====================   ============
-    relaxed                 0
-    acquire                 1
-    consume_unsupported     2
-    release                 3
-    acq_rel                 4
-    seq_cst                 5
+    RELAXED                 0
+    ACQUIRE                 1
+    CONSUME_UNSUPPORTED     2
+    RELEASE                 3
+    ACQ_REL                 4
+    SEQ_CST                 5
     =====================   ============
     """
 
-    relaxed = 0
-    acquire = 1
-    consume_unsupported = 2
-    release = 3
-    acq_rel = 4
-    seq_cst = 5
+    RELAXED = 0
+    ACQUIRE = 1
+    CONSUME_UNSUPPORTED = 2
+    RELEASE = 3
+    ACQ_REL = 4
+    SEQ_CST = 5
 
 
 class MemoryScope(FlagEnum):
@@ -40,19 +40,19 @@ class MemoryScope(FlagEnum):
     ===============  ============
     Memory Scope     Enum value
     ===============  ============
-    work_item        0
-    sub_group        1
-    work_group       2
-    device           3
-    system           4
+    WORK_ITEM        0
+    SUB_GROUP        1
+    WORK_GROUP       2
+    DEVICE           3
+    SYSTEM           4
     ===============  ============
     """
 
-    work_item = 0
-    sub_group = 1
-    work_group = 2
-    device = 3
-    system = 4
+    WORK_ITEM = 0
+    SUB_GROUP = 1
+    WORK_GROUP = 2
+    DEVICE = 3
+    SYSTEM = 4
 
 
 class AddressSpace(FlagEnum):

--- a/numba_dpex/experimental/dpcpp_types.py
+++ b/numba_dpex/experimental/dpcpp_types.py
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from numba.core.types import Type
+
+
+class AtomicRefType(Type):
+    """numba-dpex internal type to represent an object of
+    :class:`numba_dpex.core.kernel_interface.dpcpp_iface.AtomicRef`.
+    """
+
+    def __init__(
+        self,
+        dtype,
+        memory_order,
+        memory_scope,
+        address_space,
+        has_aspect_atomic64,
+    ):
+        super(AtomicRefType, self).__init__(name="AtomicRef")
+        self._dtype = dtype
+        self._memory_order = memory_order
+        self._memory_scope = memory_scope
+        self._address_space = address_space
+        self._has_aspect_atomic64 = has_aspect_atomic64
+
+    @property
+    def memory_order(self):
+        return self._memory_order
+
+    @property
+    def memory_scope(self):
+        return self._memory_scope
+
+    @property
+    def address_space(self):
+        return self._address_space
+
+    @property
+    def dtype(self):
+        return self._dtype
+
+    @property
+    def has_aspect_atomic64(self):
+        return self._has_aspect_atomic64
+
+    @property
+    def key(self):
+        """
+        A property used for __eq__, __ne__ and __hash__.
+        """
+        return (
+            self.dtype,
+            self.memory_order,
+            self.memory_scope,
+            self.address_space,
+            self.has_aspect_atomic64,
+        )

--- a/numba_dpex/experimental/dpcpp_types.py
+++ b/numba_dpex/experimental/dpcpp_types.py
@@ -25,7 +25,7 @@ class AtomicRefType(Type):
         self._has_aspect_atomic64 = has_aspect_atomic64
         name = (
             f"AtomicRef< {self._dtype}, "
-            "memory_order= {self._memory_order}, "
+            f"memory_order= {self._memory_order}, "
             f"memory_scope= {self._memory_scope}, "
             f"address_space= {self._address_space}>"
         )

--- a/numba_dpex/experimental/dpcpp_types.py
+++ b/numba_dpex/experimental/dpcpp_types.py
@@ -18,12 +18,18 @@ class AtomicRefType(Type):
         address_space,
         has_aspect_atomic64,
     ):
-        super(AtomicRefType, self).__init__(name="AtomicRef")
         self._dtype = dtype
         self._memory_order = memory_order
         self._memory_scope = memory_scope
         self._address_space = address_space
         self._has_aspect_atomic64 = has_aspect_atomic64
+        name = (
+            f"AtomicRef< {self._dtype}, "
+            "memory_order= {self._memory_order}, "
+            f"memory_scope= {self._memory_scope}, "
+            f"address_space= {self._address_space}>"
+        )
+        super(AtomicRefType, self).__init__(name=name)
 
     @property
     def memory_order(self):

--- a/numba_dpex/experimental/flag_enum.py
+++ b/numba_dpex/experimental/flag_enum.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Provides a FlagEnum class to help distinguish IntEnum types that numba-dpex
+intends to use as Integer literal types inside the compiler typie inferring
+infrastructure.
+"""
+from enum import IntEnum
+
+
+class FlagEnum(IntEnum):
+    """Helper class to distinguish IntEnum types that numba-dpex should consider
+    as Numba Literal types.
+    """
+
+    @classmethod
+    def basetype(cls) -> int:
+        """Returns an dummy int object that helps numba-dpex infer the type of
+        an instance of a FlagEnum class.
+
+        Returns:
+            int: Dummy int value
+        """
+        return int(0)

--- a/numba_dpex/experimental/kernel_dispatcher.py
+++ b/numba_dpex/experimental/kernel_dispatcher.py
@@ -316,6 +316,10 @@ class KernelDispatcher(Dispatcher):
                         raise e.bind_fold_arguments(folded)
                     self.add_overload(kcres)
 
+                    kcres.target_context.insert_user_function(
+                        kcres.entry_point, kcres.fndesc, [kcres.library]
+                    )
+
                 # TODO: enable caching of kernel_module
                 # https://github.com/IntelPython/numba-dpex/issues/1197
 
@@ -334,5 +338,5 @@ class KernelDispatcher(Dispatcher):
         raise NotImplementedError
 
 
-_dpex_target = target_registry["dpex_kernel"]
+_dpex_target = target_registry["dpex_kernel_exp"]
 dispatcher_registry[_dpex_target] = KernelDispatcher

--- a/numba_dpex/experimental/kernel_dispatcher.py
+++ b/numba_dpex/experimental/kernel_dispatcher.py
@@ -84,6 +84,7 @@ class _KernelCompiler(_FunctionCompiler):
         # makes sure that the spir_func is completely inlined into the
         # spir_kernel wrapper
         kernel_library.optimize_final_module()
+        # kernel_library.finalize()
         # Compiled the LLVM IR to SPIR-V
         kernel_spirv_module = spirv_generator.llvm_to_spirv(
             kernel_targetctx,
@@ -159,9 +160,15 @@ class _KernelCompiler(_FunctionCompiler):
                             "Compiled kernel and device_func should be "
                             "compiled with compile_cfunc option turned off"
                         )
-                    # XXX We will need to figure out what a valid entry_point
-                    # should be in our case.
-                    cres_attr = cres.fndesc.qualname
+                    # XXX temporary super hack to continue development till
+                    # a fix is applied upstream.
+                    if "fetch_" in cres.fndesc.qualname:
+                        cres_attr = (
+                            type(cres.fndesc.argtypes[0]),
+                            cres.fndesc.qualname.split(".")[0][3:],
+                        )
+                    else:
+                        cres_attr = cres.fndesc.qualname
                 kcres_attrs.append(cres_attr)
 
             kcres_attrs.append(kernel_device_ir_module)

--- a/numba_dpex/experimental/kernel_dispatcher.py
+++ b/numba_dpex/experimental/kernel_dispatcher.py
@@ -148,9 +148,12 @@ class _KernelCompiler(_FunctionCompiler):
             kernel_fndesc = kernel_cres.fndesc
             kernel_targetctx = kernel_cres.target_context
 
-            kernel_module = self._compile_to_spirv(
-                kernel_library, kernel_fndesc, kernel_targetctx
-            )
+            if self.targetoptions["generate_device_ir"] is True:
+                kernel_module: _KernelModule = self._compile_to_spirv(
+                    kernel_library, kernel_fndesc, kernel_targetctx
+                )
+            else:
+                kernel_module = kernel_library
 
             if config.DUMP_KERNEL_LLVM:
                 with open(

--- a/numba_dpex/experimental/kernel_dispatcher.py
+++ b/numba_dpex/experimental/kernel_dispatcher.py
@@ -161,9 +161,7 @@ class _KernelCompiler(_FunctionCompiler):
                         )
                     # XXX We will need to figure out what a valid entry_point
                     # should be in our case.
-                    cres_attr = cres.library.get_function(
-                        cres.fndesc.llvm_func_name
-                    )
+                    cres_attr = cres.fndesc.qualname
                 kcres_attrs.append(cres_attr)
 
             kcres_attrs.append(kernel_device_ir_module)
@@ -292,7 +290,7 @@ class KernelDispatcher(Dispatcher):
                 # Don't recompile if signature already exists
                 existing = self.overloads.get(tuple(args))
                 if existing is not None:
-                    return existing
+                    return existing.entry_point
 
                 # TODO: Enable caching
                 # Add code to enable on disk caching of a binary spirv kernel.

--- a/numba_dpex/experimental/literal_intenum_type.py
+++ b/numba_dpex/experimental/literal_intenum_type.py
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Definition of a new Literal type in numba-dpex that allows treating IntEnum
+members as integer literals inside a JIT compiled function.
+"""
+from enum import IntEnum
+
+from numba.core.pythonapi import box
+from numba.core.typeconv import Conversion
+from numba.core.types import Integer, Literal
+from numba.core.typing.typeof import typeof
+
+from numba_dpex.experimental.flag_enum import FlagEnum
+
+
+class IntEnumLiteral(Literal, Integer):
+    """A Literal type for IntEnum objects. The type contains the original Python
+    value of the IntEnum class in it.
+    """
+
+    #  pylint: disable=W0231
+    def __init__(self, value):
+        self._literal_init(value)
+        self.name = f"Literal[IntEnum]({value})"
+        if isinstance(value, FlagEnum) or issubclass(value, FlagEnum):
+            basetype = typeof(value.basetype())
+            Integer.__init__(
+                self,
+                name=self.name,
+                bitwidth=basetype.bitwidth,
+                signed=basetype.signed,
+            )
+        else:
+            raise AssertionError
+
+    def can_convert_to(self, typingctx, other) -> bool:
+        conv = typingctx.can_convert(self.literal_type, other)
+        if conv is not None:
+            return max(conv, Conversion.promote)
+        return False
+
+
+Literal.ctor_map[IntEnum] = IntEnumLiteral
+
+
+@box(IntEnumLiteral)
+def box_literal_integer(typ, val, c):
+    """Defines how a Numba representation for an IntEnumLiteral object should
+    be converted to a PyObject* object and returned back to Python.
+    """
+    val = c.context.cast(c.builder, val, typ, typ.literal_type)
+    return c.box(typ.literal_type, val)

--- a/numba_dpex/experimental/models.py
+++ b/numba_dpex/experimental/models.py
@@ -7,14 +7,29 @@ numba_dpex.experimental module.
 """
 
 from llvmlite import ir as llvmir
+from numba.core import types
 from numba.core.datamodel import models
-from numba.core.datamodel.models import PrimitiveModel
+from numba.core.datamodel.models import PrimitiveModel, StructModel
 from numba.core.extending import register_model
 
 from numba_dpex.experimental.target import dpex_exp_kernel_target
 
+from .dpcpp_types import AtomicRefType
 from .literal_intenum_type import IntEnumLiteral
 from .types import KernelDispatcherType
+
+
+class AtomicRefModel(StructModel):
+    """Datamodel for AtomicRefType."""
+
+    def __init__(self, dmm, fe_type):
+        members = [
+            (
+                "ref",
+                types.CPointer(fe_type.dtype, addrspace=fe_type.address_space),
+            ),
+        ]
+        super().__init__(dmm, fe_type, members)
 
 
 class LiteralIntEnumModel(PrimitiveModel):
@@ -32,6 +47,7 @@ class LiteralIntEnumModel(PrimitiveModel):
 exp_dmm = dpex_exp_kernel_target.target_context.data_model_manager
 
 exp_dmm.register(KernelDispatcherType, models.OpaqueModel)
+exp_dmm.register(AtomicRefType, AtomicRefModel)
 exp_dmm.register(IntEnumLiteral, LiteralIntEnumModel)
 
 # Register the types and datamodel in the DpexTargetContext

--- a/numba_dpex/experimental/models.py
+++ b/numba_dpex/experimental/models.py
@@ -2,19 +2,37 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Provides Numba datamodel for the numba_dpex types introduced in the
+"""Provides the Numba data models for the numba_dpex types introduced in the
 numba_dpex.experimental module.
 """
 
+from llvmlite import ir as llvmir
 from numba.core.datamodel import models
+from numba.core.datamodel.models import PrimitiveModel
 from numba.core.extending import register_model
 
-from numba_dpex.core.datamodel.models import dpex_data_model_manager as dmm
+from numba_dpex.experimental.target import dpex_exp_kernel_target
 
+from .literal_intenum_type import IntEnumLiteral
 from .types import KernelDispatcherType
 
+
+class LiteralIntEnumModel(PrimitiveModel):
+    """Representation of an object of LiteralIntEnum type using Numba's
+    PrimitiveModel that can be represented natively in the target in all
+    usage contexts.
+    """
+
+    def __init__(self, dmm, fe_type):
+        be_type = llvmir.IntType(fe_type.bitwidth)
+        super().__init__(dmm, fe_type, be_type)
+
+
 # Register the types and datamodel in the DpexKernelTargetContext
-dmm.register(KernelDispatcherType, models.OpaqueModel)
+exp_dmm = dpex_exp_kernel_target.target_context.data_model_manager
+
+exp_dmm.register(KernelDispatcherType, models.OpaqueModel)
+exp_dmm.register(IntEnumLiteral, LiteralIntEnumModel)
 
 # Register the types and datamodel in the DpexTargetContext
 register_model(KernelDispatcherType)(models.OpaqueModel)

--- a/numba_dpex/experimental/target.py
+++ b/numba_dpex/experimental/target.py
@@ -11,17 +11,26 @@ from functools import cached_property
 from llvmlite import ir as llvmir
 from numba.core import types
 from numba.core.descriptors import TargetDescriptor
+from numba.core.target_extension import GPU, target_registry
 from numba.core.types.scalars import IntEnumClass
 
 from numba_dpex.core.descriptor import DpexTargetOptions
 from numba_dpex.core.targets.kernel_target import (
-    DPEX_KERNEL_TARGET_NAME,
     DpexKernelTargetContext,
     DpexKernelTypingContext,
 )
 
 from .flag_enum import FlagEnum
 from .literal_intenum_type import IntEnumLiteral
+
+
+class SyclDeviceExp(GPU):
+    """Mark the hardware target as SYCL Device."""
+
+
+DPEX_KERNEL_EXP_TARGET_NAME = "dpex_kernel_exp"
+
+target_registry[DPEX_KERNEL_EXP_TARGET_NAME] = SyclDeviceExp
 
 
 class DpexExpKernelTypingContext(DpexKernelTypingContext):
@@ -88,7 +97,7 @@ class DpexExpKernelTargetContext(DpexKernelTargetContext):
             #  pylint: disable=W0613
             def enum_literal_getattr_imp(context, builder, typ, val, attr):
                 enum_attr_value = getattr(typ.literal_value, attr).value
-                return llvmir.Constant(llvmir.IntType(32), enum_attr_value)
+                return llvmir.Constant(llvmir.IntType(64), enum_attr_value)
 
             return enum_literal_getattr_imp
 
@@ -130,4 +139,4 @@ class DpexExpKernelTarget(TargetDescriptor):
 
 
 # A global instance of the DpexKernelTarget with the experimental features
-dpex_exp_kernel_target = DpexExpKernelTarget(DPEX_KERNEL_TARGET_NAME)
+dpex_exp_kernel_target = DpexExpKernelTarget(DPEX_KERNEL_EXP_TARGET_NAME)

--- a/numba_dpex/experimental/typeof.py
+++ b/numba_dpex/experimental/typeof.py
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from numba.extending import typeof_impl
+
+from .dpcpp_iface import AtomicRef
+from .dpcpp_types import AtomicRefType
+
+
+@typeof_impl.register(AtomicRef)
+def typeof_atomic_ref(val, c):
+    return AtomicRefType(val)


### PR DESCRIPTION
- [X] Have you provided a meaningful PR description?

The PR introduces new API functions to numba_dpex.kernel decorated functions using Numba high-level extending API (`overload`). The feature is going to be added to the numba_dpex.experimental module till it is ready for everyday use. Eventually, the new API will replace the numba_dpex.ocl module.

- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [X] If this PR is a work in progress, are you filing the PR as a draft?
