### PR TITLE
Fix barrier issue

### DIFF
--- a/numba_dpex/ocl/oclimpl.py
+++ b/numba_dpex/ocl/oclimpl.py
@@ -105,6 +105,7 @@ def barrier_one_arg_impl(context, builder, sig, args):
     barrier = _declare_function(
         context, builder, "barrier", sig, ["unsigned int"]
     )
+    barrier.attributes.add("noduplicate")
     builder.call(barrier, [flags])
     return _void_value
 
@@ -116,6 +117,7 @@ def barrier_no_arg_impl(context, builder, sig, args):
     barrier = _declare_function(
         context, builder, "barrier", sig, ["unsigned int"]
     )
+    barrier.attributes.add("noduplicate")
     flags = context.get_constant(types.uint32, stubs.GLOBAL_MEM_FENCE)
     builder.call(barrier, [flags])
     return _void_value
@@ -138,6 +140,7 @@ def sub_group_barrier_impl(context, builder, sig, args):
     barrier = _declare_function(
         context, builder, "barrier", sig, ["unsigned int"]
     )
+    barrier.attributes.add("noduplicate")
     flags = context.get_constant(types.uint32, stubs.LOCAL_MEM_FENCE)
     builder.call(barrier, [flags])
     return _void_value


### PR DESCRIPTION
LLVM optimizer was tranforming code
```
i = get_global_id(0)
if i < 1:
    arr1[0] = ...

barrier()

if i < 0:
    arr2[0] = ...
```
into
```
i = get_global_id(0)
if i < 1:
    arr1[0] = ...
    barrier()
    arr2[0] = ...
else:
    barrier()
```
Which is valid transform for LLVM IR, but is UB per OpenCL spec.
Add `noduplicate` attr to barrier funcs to avoid this transform.