### PR TITLE
Add experimental kernel decorator to numba jit_registry

### DIFF
--- a/numba_dpex/experimental/decorators.py
+++ b/numba_dpex/experimental/decorators.py
@@ -8,6 +8,7 @@ ready to move to numba_dpex.core.
 import inspect
 
 from numba.core import sigutils
+from numba.core.target_extension import jit_registry, target_registry
 
 from .kernel_dispatcher import KernelDispatcher
 
@@ -78,3 +79,6 @@ def kernel(func_or_sig=None, debug=False, cache=False, **options):
             "the return type as void explicitly."
         )
     return _kernel_dispatcher(func)
+
+
+jit_registry[target_registry["dpex_kernel"]] = kernel


### PR DESCRIPTION
- [X] Have you provided a meaningful PR description?
Fixes compilation with the experimental kernel decorator using `NUMBA_CAPTURED_ERROR=new_style`
- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?

Fixes #1195 