### PR TITLE
Add sycl event constructor overload

### DIFF
--- a/numba_dpex/core/datamodel/models.py
+++ b/numba_dpex/core/datamodel/models.py
@@ -180,6 +180,10 @@ class SyclEventModel(StructModel):
                 types.MemInfoPointer(types.pyobject),
             ),
             (
+                "parent",
+                types.pyobject,
+            ),
+            (
                 "event_ref",
                 types.CPointer(types.int8),
             ),

--- a/numba_dpex/core/runtime/_eventstruct.c
+++ b/numba_dpex/core/runtime/_eventstruct.c
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "_eventstruct.h"
+#include "_dbg_printer.h"
+
+/*!
+ * @brief A destructor that is called from NRT on object destruction. Deletes
+ * dpctl event reference.
+ *
+ * @param    data           A dpctl event reference.
+ * @return   {return}       Nothing.
+ */
+void NRT_MemInfo_EventRef_Delete(void *data)
+{
+    DPCTLSyclEventRef eref = data;
+
+    DPCTLEvent_Delete(eref);
+
+    DPEXRT_DEBUG(
+        drt_debug_print("DPEXRT-DEBUG: deleting dpctl event reference.\n"););
+}

--- a/numba_dpex/core/runtime/_eventstruct.h
+++ b/numba_dpex/core/runtime/_eventstruct.h
@@ -9,12 +9,21 @@
 ///
 //===----------------------------------------------------------------------===//
 
-#pragma once
+#ifndef _EVENTSTRUCT_H_
+#define _EVENTSTRUCT_H_
 
+#include "_nrt_helper.h"
+#include "dpctl_sycl_interface.h"
 #include "numba/core/runtime/nrt_external.h"
+#include <Python.h>
 
 typedef struct
 {
     NRT_MemInfo *meminfo;
+    PyObject *parent;
     void *event_ref;
 } eventstruct_t;
+
+void NRT_MemInfo_EventRef_Delete(void *data);
+
+#endif /* _EVENTSTRUCT_H_ */

--- a/numba_dpex/core/runtime/context.py
+++ b/numba_dpex/core/runtime/context.py
@@ -242,6 +242,24 @@ class DpexRTContext(object):
 
         return self.error
 
+    def eventstruct_init(self, pyapi, event, struct):
+        """Calls the c function DPEXRT_sycl_event_init"""
+
+        fnty = llvmir.FunctionType(
+            llvmir.IntType(32), [pyapi.voidptr, pyapi.voidptr, pyapi.voidptr]
+        )
+        nrt_api = self._context.nrt.get_nrt_api(pyapi.builder)
+
+        fn = pyapi._get_function(fnty, "DPEXRT_sycl_event_init")
+        fn.args[0].add_attribute("nocapture")
+        fn.args[1].add_attribute("nocapture")
+        fn.args[2].add_attribute("nocapture")
+
+        ptr = pyapi.builder.bitcast(struct, pyapi.voidptr)
+        self.error = pyapi.builder.call(fn, [nrt_api, event, ptr])
+
+        return self.error
+
     def usm_ndarray_to_python_acqref(self, pyapi, aryty, ary, dtypeptr):
         """Boxes a DpnpNdArray native object into a Python dpnp.ndarray.
 

--- a/numba_dpex/core/types/dpctl_types.py
+++ b/numba_dpex/core/types/dpctl_types.py
@@ -176,8 +176,6 @@ def box_sycl_event(typ, val, c):
     if not c.context.enable_nrt:
         raise UnreachableError
 
-    print("boxing...")
-
     dpexrtCtx = dpexrt.DpexRTContext(c.context)
     event = dpexrtCtx.eventstruct_to_python(c.pyapi, val)
 

--- a/numba_dpex/dpctl_iface/_intrinsic.py
+++ b/numba_dpex/dpctl_iface/_intrinsic.py
@@ -2,12 +2,56 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import dpctl
+from llvmlite.ir import IRBuilder
 from numba import types
+from numba.core import cgutils, imputils
 from numba.core.datamodel import default_manager
-from numba.extending import intrinsic, overload_method
+from numba.extending import intrinsic, overload, overload_method, type_callable
 
 import numba_dpex.dpctl_iface.libsyclinterface_bindings as sycl
 from numba_dpex.core import types as dpex_types
+from numba_dpex.core.runtime import context as dpexrt
+
+
+@intrinsic
+def sycl_event_create(
+    ty_context,
+):
+    """A numba "intrinsic" function to inject dpctl.SyclEvent constructor code.
+
+    Args:
+        ty_context (numba.core.typing.context.Context): The typing context
+            for the codegen.
+
+    Returns:
+        tuple(numba.core.typing.templates.Signature, function): A tuple of
+            numba function signature type and a function object.
+    """
+    ty_event = dpex_types.DpctlSyclEvent()
+
+    sig = ty_event(types.void)
+
+    def codegen(context, builder: IRBuilder, sig, args: list):
+        pyapi = context.get_python_api(builder)
+
+        event_struct_proxy = cgutils.create_struct_proxy(ty_event)(
+            context, builder
+        )
+
+        event = sycl.dpctl_event_create(builder)
+        dpexrtCtx = dpexrt.DpexRTContext(context)
+
+        # Ref count after the call is equal to 1.
+        dpexrtCtx.eventstruct_init(
+            pyapi, event, event_struct_proxy._getpointer()
+        )
+
+        event_value = event_struct_proxy._getvalue()
+
+        return event_value
+
+    return sig, codegen
 
 
 @intrinsic
@@ -27,11 +71,19 @@ def sycl_event_wait(typingctx, ty_event: dpex_types.DpctlSyclEvent):
     return sig, codegen
 
 
+@overload(dpctl.SyclEvent)
+def ol_dpctl_sycl_event_create():
+    """Implementation of an overload to support dpctl.SyclEvent() inside
+    a dpjit function.
+    """
+    return lambda: sycl_event_create()
+
+
 @overload_method(dpex_types.DpctlSyclEvent, "wait")
 def ol_dpctl_sycl_event_wait(
     event,
 ):
-    """Implementation of an overload to support dpctl.SyclEvent() inside
+    """Implementation of an overload to support dpctl.SyclEvent.wait() inside
     a dpjit function.
     """
     return lambda event: sycl_event_wait(event)

--- a/numba_dpex/dpctl_iface/libsyclinterface_bindings.py
+++ b/numba_dpex/dpctl_iface/libsyclinterface_bindings.py
@@ -69,6 +69,20 @@ def dpctl_queue_memcpy(builder: llvmir.IRBuilder, *args):
     return ret
 
 
+def dpctl_event_create(builder: llvmir.IRBuilder, *args):
+    """Inserts LLVM IR to call DPCTLEvent_Create."""
+    mod = builder.module
+    fn = _build_dpctl_function(
+        llvm_module=mod,
+        return_ty=cgutils.voidptr_t,
+        arg_list=[],
+        func_name="DPCTLEvent_Create",
+    )
+    ret = builder.call(fn, args)
+
+    return ret
+
+
 def dpctl_queue_delete(builder: llvmir.IRBuilder, *args):
     """Inserts LLVM IR to call DPCTLQueue_Delete."""
     mod = builder.module

--- a/numba_dpex/tests/core/types/DpctlSyclEvent/test_box.py
+++ b/numba_dpex/tests/core/types/DpctlSyclEvent/test_box.py
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests for boxing and allocating for dpctl.SyclEvent
+"""
+
+import sys
+
+from dpctl import SyclEvent
+
+from numba_dpex import dpjit
+
+
+def test_dpjit_constructor():
+    """Test event delete that does not have parent"""
+
+    @dpjit
+    def func() -> SyclEvent:
+        SyclEvent()
+        return None
+
+    # We just want to make sure execution did not crush. There are currently
+    # no way to check if event wast destroyed, except manual run with debug
+    # logs on.
+    func()
+
+
+def test_boxing_without_parent():
+    """Test unboxing of the event that does not have parent"""
+
+    @dpjit
+    def func() -> SyclEvent:
+        event = SyclEvent()
+        return event
+
+    e: SyclEvent = func()
+    ref_cnt = sys.getrefcount(e)
+
+    assert isinstance(e, SyclEvent)
+    assert ref_cnt == 2

--- a/numba_dpex/tests/core/types/DpctlSyclQueue/test_box.py
+++ b/numba_dpex/tests/core/types/DpctlSyclQueue/test_box.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Tests for boxing for dpnp.ndarray
+Tests for boxing for dpctl.SyclQueue
 """
 
 import dpnp

--- a/numba_dpex/tests/dpjit_tests/test_slicing.py
+++ b/numba_dpex/tests/dpjit_tests/test_slicing.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Tests for boxing for dpnp.ndarray
+Tests for slicing dpnp.ndarray
 """
 
 import dpnp


### PR DESCRIPTION
Introduce a way to define sycl event inside dpjit and return it back to python.

- `SyclEvent()` is overloaded.
- `syclevent_to_python` handles structures without parent.
- datamodel was extended to have parent (same as in sycl queue).

PR checks:
- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?

Closes: #1184
