### PR TITLE
Register the experimental kernel target as a fully standalone Numba hardware target

### DIFF
--- a/numba_dpex/experimental/kernel_dispatcher.py
+++ b/numba_dpex/experimental/kernel_dispatcher.py
@@ -7,6 +7,7 @@ call numba_dpex.kernel decorated function.
 """
 from collections import namedtuple
 from contextlib import ExitStack
+from typing import Tuple
 
 import numba.core.event as ev
 from numba.core import errors, sigutils, types
@@ -103,7 +104,7 @@ class _KernelCompiler(_FunctionCompiler):
 
     def _compile_cached(
         self, args, return_type: types.Type
-    ) -> _KernelCompileResult:
+    ) -> Tuple[bool, _KernelCompileResult]:
         """Compiles the kernel function to bitcode and generates a host-callable
         wrapper to submit the kernel to a SYCL queue.
 

--- a/numba_dpex/experimental/kernel_dispatcher.py
+++ b/numba_dpex/experimental/kernel_dispatcher.py
@@ -24,7 +24,7 @@ from numba_dpex.core.exceptions import (
 from numba_dpex.core.pipelines import kernel_compiler
 from numba_dpex.core.types import DpnpNdArray
 
-from .target import dpex_exp_kernel_target
+from .target import DPEX_KERNEL_EXP_TARGET_NAME, dpex_exp_kernel_target
 
 _KernelModule = namedtuple("_KernelModule", ["kernel_name", "kernel_bitcode"])
 
@@ -318,5 +318,5 @@ class KernelDispatcher(Dispatcher):
         raise NotImplementedError
 
 
-_dpex_target = target_registry["dpex_kernel"]
+_dpex_target = target_registry[DPEX_KERNEL_EXP_TARGET_NAME]
 dispatcher_registry[_dpex_target] = KernelDispatcher

--- a/numba_dpex/experimental/kernel_dispatcher.py
+++ b/numba_dpex/experimental/kernel_dispatcher.py
@@ -29,8 +29,7 @@ from .target import DPEX_KERNEL_EXP_TARGET_NAME, dpex_exp_kernel_target
 _KernelModule = namedtuple("_KernelModule", ["kernel_name", "kernel_bitcode"])
 
 _KernelCompileResult = namedtuple(
-    "_KernelCompileResult",
-    ["status", "cres_or_error", "entry_point"],
+    "_KernelCompileResult", CompileResult._fields + ("kernel_device_ir_module",)
 )
 
 
@@ -96,11 +95,11 @@ class _KernelCompiler(_FunctionCompiler):
         )
 
     def compile(self, args, return_type):
-        kcres = self._compile_cached(args, return_type)
-        if kcres.status:
+        status, kcres = self._compile_cached(args, return_type)
+        if status:
             return kcres
 
-        raise kcres.cres_or_error
+        raise kcres
 
     def _compile_cached(
         self, args, return_type: types.Type
@@ -137,34 +136,45 @@ class _KernelCompiler(_FunctionCompiler):
         """
         key = tuple(args), return_type
         try:
-            return _KernelCompileResult(False, self._failed_cache[key], None)
+            return False, self._failed_cache[key]
         except KeyError:
             pass
 
         try:
-            kernel_cres: CompileResult = self._compile_core(args, return_type)
+            cres: CompileResult = self._compile_core(args, return_type)
 
-            kernel_library = kernel_cres.library
-            kernel_fndesc = kernel_cres.fndesc
-            kernel_targetctx = kernel_cres.target_context
-
-            kernel_module = self._compile_to_spirv(
-                kernel_library, kernel_fndesc, kernel_targetctx
+            kernel_device_ir_module = self._compile_to_spirv(
+                cres.library, cres.fndesc, cres.target_context
             )
+
+            kcres_attrs = []
+
+            for cres_field in cres._fields:
+                cres_attr = getattr(cres, cres_field)
+                if cres_field == "entry_point":
+                    if cres_attr is not None:
+                        raise AssertionError(
+                            "Compiled kernel and device_func should be "
+                            "compiled with compile_cfunc option turned off"
+                        )
+                    cres_attr = cres.fndesc.qualname
+                kcres_attrs.append(cres_attr)
+
+            kcres_attrs.append(kernel_device_ir_module)
 
             if config.DUMP_KERNEL_LLVM:
                 with open(
-                    kernel_cres.fndesc.llvm_func_name + ".ll",
+                    cres.fndesc.llvm_func_name + ".ll",
                     "w",
                     encoding="UTF-8",
                 ) as f:
-                    f.write(kernel_cres.library.final_module)
+                    f.write(cres.library.final_module)
 
         except errors.TypingError as e:
             self._failed_cache[key] = e
-            return _KernelCompileResult(False, e, None)
+            return False, e
 
-        return _KernelCompileResult(True, kernel_cres, kernel_module)
+        return True, _KernelCompileResult(*kcres_attrs)
 
 
 class KernelDispatcher(Dispatcher):
@@ -234,7 +244,14 @@ class KernelDispatcher(Dispatcher):
 
     def add_overload(self, cres):
         args = tuple(cres.signature.args)
-        self.overloads[args] = cres.entry_point
+        self.overloads[args] = cres
+
+    def get_overload_device_ir(self, sig):
+        """
+        Return the compiled device bitcode for the given signature.
+        """
+        args, _ = sigutils.normalize_signature(sig)
+        return self.overloads[tuple(args)].kernel_device_ir_module
 
     def compile(self, sig) -> _KernelCompileResult:
         disp = self._get_dispatcher_for_current_target()
@@ -274,7 +291,7 @@ class KernelDispatcher(Dispatcher):
                 # Don't recompile if signature already exists
                 existing = self.overloads.get(tuple(args))
                 if existing is not None:
-                    return existing
+                    return existing.entry_point
 
                 # TODO: Enable caching
                 # Add code to enable on disk caching of a binary spirv kernel.
@@ -298,7 +315,11 @@ class KernelDispatcher(Dispatcher):
                             )[1]
 
                         raise e.bind_fold_arguments(folded)
-                    self.add_overload(kcres.cres_or_error)
+                    self.add_overload(kcres)
+
+                    kcres.target_context.insert_user_function(
+                        kcres.entry_point, kcres.fndesc, [kcres.library]
+                    )
 
                 # TODO: enable caching of kernel_module
                 # https://github.com/IntelPython/numba-dpex/issues/1197

--- a/numba_dpex/experimental/launcher.py
+++ b/numba_dpex/experimental/launcher.py
@@ -11,6 +11,7 @@ from typing import Union
 
 from llvmlite import ir as llvmir
 from numba.core import cgutils, cpu, types
+from numba.core.datamodel import default_manager as numba_default_dmm
 from numba.extending import intrinsic, overload
 
 from numba_dpex import config, dpjit
@@ -192,23 +193,27 @@ class _LaunchTrampolineFunctionBodyGenerator:
         ndim = indexer_argty.ndim
         grange_extents = []
         lrange_extents = []
-        datamodel = self._kernel_targetctx.data_model_manager.lookup(
-            indexer_argty
-        )
+        indexer_datamodel = numba_default_dmm.lookup(indexer_argty)
 
         if isinstance(indexer_argty, RangeType):
             for dim_num in range(ndim):
-                dim_pos = datamodel.get_field_position("dim" + str(dim_num))
+                dim_pos = indexer_datamodel.get_field_position(
+                    "dim" + str(dim_num)
+                )
                 grange_extents.append(
                     self._builder.extract_value(index_space_arg, dim_pos)
                 )
         elif isinstance(indexer_argty, NdRangeType):
             for dim_num in range(ndim):
-                gdim_pos = datamodel.get_field_position("gdim" + str(dim_num))
+                gdim_pos = indexer_datamodel.get_field_position(
+                    "gdim" + str(dim_num)
+                )
                 grange_extents.append(
                     self._builder.extract_value(index_space_arg, gdim_pos)
                 )
-                ldim_pos = datamodel.get_field_position("ldim" + str(dim_num))
+                ldim_pos = indexer_datamodel.get_field_position(
+                    "ldim" + str(dim_num)
+                )
                 lrange_extents.append(
                     self._builder.extract_value(index_space_arg, ldim_pos)
                 )

--- a/numba_dpex/experimental/models.py
+++ b/numba_dpex/experimental/models.py
@@ -2,19 +2,38 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Provides Numba datamodel for the numba_dpex types introduced in the
+"""Provides the Numba data models for the numba_dpex types introduced in the
 numba_dpex.experimental module.
 """
 
-from numba.core.datamodel import models
+from numba.core.datamodel import DataModelManager, models
 from numba.core.extending import register_model
 
-from numba_dpex.core.datamodel.models import dpex_data_model_manager as dmm
+import numba_dpex.core.datamodel.models as dpex_core_models
 
 from .types import KernelDispatcherType
 
-# Register the types and datamodel in the DpexKernelTargetContext
-dmm.register(KernelDispatcherType, models.OpaqueModel)
 
-# Register the types and datamodel in the DpexTargetContext
+def _init_exp_data_model_manager() -> DataModelManager:
+    """Initializes a DpexExpKernelTarget-specific data model manager.
+
+    Extends the DpexKernelTargetContext's datamodel manager with all
+    experimental types that are getting added to the kernel API.
+
+    Returns:
+        DataModelManager: A numba-dpex DpexExpKernelTarget-specific data model
+        manager
+    """
+
+    dmm = dpex_core_models.dpex_data_model_manager.copy()
+
+    # Register the types and data model in the DpexExpTargetContext
+    # Add here...
+
+    return dmm
+
+
+exp_dmm = _init_exp_data_model_manager()
+
+# Register any new type that should go into numba.core.datamodel.default_manager
 register_model(KernelDispatcherType)(models.OpaqueModel)

--- a/numba_dpex/experimental/target.py
+++ b/numba_dpex/experimental/target.py
@@ -9,13 +9,23 @@ eventually move into the numba_dpex.core.
 from functools import cached_property
 
 from numba.core.descriptors import TargetDescriptor
+from numba.core.target_extension import GPU, target_registry
 
 from numba_dpex.core.descriptor import DpexTargetOptions
 from numba_dpex.core.targets.kernel_target import (
-    DPEX_KERNEL_TARGET_NAME,
     DpexKernelTargetContext,
     DpexKernelTypingContext,
 )
+
+
+#  pylint: disable=R0903
+class SyclDeviceExp(GPU):
+    """Mark the hardware target as SYCL Device."""
+
+
+DPEX_KERNEL_EXP_TARGET_NAME = "dpex_kernel_exp"
+
+target_registry[DPEX_KERNEL_EXP_TARGET_NAME] = SyclDeviceExp
 
 
 class DpexExpKernelTypingContext(DpexKernelTypingContext):
@@ -77,4 +87,4 @@ class DpexExpKernelTarget(TargetDescriptor):
 
 
 # A global instance of the DpexKernelTarget with the experimental features
-dpex_exp_kernel_target = DpexExpKernelTarget(DPEX_KERNEL_TARGET_NAME)
+dpex_exp_kernel_target = DpexExpKernelTarget(DPEX_KERNEL_EXP_TARGET_NAME)

--- a/numba_dpex/experimental/target.py
+++ b/numba_dpex/experimental/target.py
@@ -16,6 +16,7 @@ from numba_dpex.core.targets.kernel_target import (
     DpexKernelTargetContext,
     DpexKernelTypingContext,
 )
+from numba_dpex.experimental.models import exp_dmm
 
 
 #  pylint: disable=R0903
@@ -50,6 +51,10 @@ class DpexExpKernelTargetContext(DpexKernelTargetContext):
     to LLVM IR. All such experimental functionality should be added here till
     they are stable enough to be migrated to DpexKernelTargetContext.
     """
+
+    def __init__(self, typingctx, target=DPEX_KERNEL_EXP_TARGET_NAME):
+        super().__init__(typingctx, target)
+        self.data_model_manager = exp_dmm
 
 
 class DpexExpKernelTarget(TargetDescriptor):


### PR DESCRIPTION
- [X] Have you provided a meaningful PR description?

- The experimental target is now fully separated from the `DpexKernelTarget` with a different string identifier and device class.
- A clone of the DpexKernelTarget's datamodel manager is added that will store all experimental types' data models till they are ready to move into core.

- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
