### PR TITLE
Enables adding overload to DpexExpKernelTarget and fully inline them into the final module.

### DIFF
--- a/numba_dpex/core/descriptor.py
+++ b/numba_dpex/core/descriptor.py
@@ -41,6 +41,7 @@ class DpexTargetOptions(CPUTargetOptions):
     release_gil = _option_mapping("release_gil")
     no_compile = _option_mapping("no_compile")
     use_mlir = _option_mapping("use_mlir")
+    inline_threshold = _option_mapping("inline_threshold")
     _compilation_mode = _option_mapping("_compilation_mode")
 
     def finalize(self, flags, options):
@@ -49,6 +50,7 @@ class DpexTargetOptions(CPUTargetOptions):
         _inherit_if_not_set(flags, options, "release_gil", False)
         _inherit_if_not_set(flags, options, "no_compile", True)
         _inherit_if_not_set(flags, options, "use_mlir", False)
+        _inherit_if_not_set(flags, options, "inline_threshold", 0)
         _inherit_if_not_set(
             flags, options, "_compilation_mode", CompilationMode.KERNEL
         )

--- a/numba_dpex/core/descriptor.py
+++ b/numba_dpex/core/descriptor.py
@@ -11,6 +11,7 @@ from numba.core.descriptors import TargetDescriptor
 from .targets.dpjit_target import DPEX_TARGET_NAME, DpexTargetContext
 from .targets.kernel_target import (
     DPEX_KERNEL_TARGET_NAME,
+    CompilationMode,
     DpexKernelTargetContext,
     DpexKernelTypingContext,
 )
@@ -40,6 +41,7 @@ class DpexTargetOptions(CPUTargetOptions):
     release_gil = _option_mapping("release_gil")
     no_compile = _option_mapping("no_compile")
     use_mlir = _option_mapping("use_mlir")
+    _compilation_mode = _option_mapping("_compilation_mode")
 
     def finalize(self, flags, options):
         super().finalize(flags, options)
@@ -47,6 +49,9 @@ class DpexTargetOptions(CPUTargetOptions):
         _inherit_if_not_set(flags, options, "release_gil", False)
         _inherit_if_not_set(flags, options, "no_compile", True)
         _inherit_if_not_set(flags, options, "use_mlir", False)
+        _inherit_if_not_set(
+            flags, options, "_compilation_mode", CompilationMode.KERNEL
+        )
 
 
 class DpexKernelTarget(TargetDescriptor):

--- a/numba_dpex/core/descriptor.py
+++ b/numba_dpex/core/descriptor.py
@@ -8,6 +8,8 @@ from numba.core import options, targetconfig, typing
 from numba.core.cpu import CPUTargetOptions
 from numba.core.descriptors import TargetDescriptor
 
+from numba_dpex import config
+
 from .targets.dpjit_target import DPEX_TARGET_NAME, DpexTargetContext
 from .targets.kernel_target import (
     DPEX_KERNEL_TARGET_NAME,
@@ -50,7 +52,12 @@ class DpexTargetOptions(CPUTargetOptions):
         _inherit_if_not_set(flags, options, "release_gil", False)
         _inherit_if_not_set(flags, options, "no_compile", True)
         _inherit_if_not_set(flags, options, "use_mlir", False)
-        _inherit_if_not_set(flags, options, "inline_threshold", 0)
+        if config.INLINE_THRESHOLD is not None:
+            _inherit_if_not_set(
+                flags, options, "inline_threshold", config.INLINE_THRESHOLD
+            )
+        else:
+            _inherit_if_not_set(flags, options, "inline_threshold", 0)
         _inherit_if_not_set(
             flags, options, "_compilation_mode", CompilationMode.KERNEL
         )

--- a/numba_dpex/core/targets/kernel_target.py
+++ b/numba_dpex/core/targets/kernel_target.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
+from enum import IntEnum
 from functools import cached_property
 
 import dpnp
@@ -28,6 +29,28 @@ from .. import codegen
 CC_SPIR_KERNEL = "spir_kernel"
 CC_SPIR_FUNC = "spir_func"
 LLVM_SPIRV_ARGS = 112
+
+
+class CompilationMode(IntEnum):
+    """Flags used to determine how a function should be compiled by the
+    numba_dpex.experimental.dispatcher.KernelDispatcher. Note the functionality
+    will be merged into numba_dpex.core.kernel_interface.dispatcher in the
+    future.
+
+        KERNEL :         Indicates that the function will be compiled into an
+                         LLVM function that has ``spir_kernel`` calling
+                         convention and is compiled down to SPIR-V.
+                         Additionally, the function cannot return any value and
+                         input arguments to the function have to adhere to
+                         "compute follows data" to ensure execution queue
+                         inference.
+        DEVICE_FUNCTION: Indicates that the function will be compiled into an
+                         LLVM function that has ``spir_func`` calling convention
+                         and will be compiled only into LLVM bitcode.
+    """
+
+    KERNEL = 1
+    DEVICE_FUNC = 2
 
 
 class DpexKernelTypingContext(typing.BaseContext):

--- a/numba_dpex/core/types/dpctl_types.py
+++ b/numba_dpex/core/types/dpctl_types.py
@@ -28,7 +28,9 @@ class DpctlSyclQueue(types.Type):
             self._unique_id = hash(sycl_queue)
         except Exception:
             self._unique_id = self.rand_digit_str(16)
-        super(DpctlSyclQueue, self).__init__(name="DpctlSyclQueue")
+        super(DpctlSyclQueue, self).__init__(
+            name=f"DpctlSyclQueue on {self._device}"
+        )
 
     def rand_digit_str(self, n):
         return "".join(

--- a/numba_dpex/experimental/kernel_dispatcher.py
+++ b/numba_dpex/experimental/kernel_dispatcher.py
@@ -84,7 +84,14 @@ class _KernelCompiler(_FunctionCompiler):
         kernel_fn = kernel_targetctx.prepare_spir_kernel(
             kernel_func, kernel_fndesc.argtypes
         )
-
+        # If the inline_threshold option was set then set the property in the
+        # kernel_library to force inlining ``overload`` calls into a kernel.
+        try:
+            kernel_library.inline_threshold = self.targetoptions[
+                "inline_threshold"
+            ]
+        except KeyError:
+            pass
         # Call finalize on the LLVM module. Finalization will result in
         # all linking libraries getting linked together and final optimization
         # including inlining of functions if an inlining level is specified.

--- a/numba_dpex/experimental/kernel_dispatcher.py
+++ b/numba_dpex/experimental/kernel_dispatcher.py
@@ -15,14 +15,17 @@ from numba.core.compiler import CompileResult
 from numba.core.compiler_lock import global_compiler_lock
 from numba.core.dispatcher import Dispatcher, _FunctionCompiler
 from numba.core.target_extension import dispatcher_registry, target_registry
+from numba.core.types import void
 from numba.core.typing.typeof import Purpose, typeof
 
 from numba_dpex import config, spirv_generator
 from numba_dpex.core.exceptions import (
     ExecutionQueueInferenceError,
+    KernelHasReturnValueError,
     UnsupportedKernelArgumentError,
 )
 from numba_dpex.core.pipelines import kernel_compiler
+from numba_dpex.core.targets.kernel_target import CompilationMode
 from numba_dpex.core.types import DpnpNdArray
 
 from .target import DPEX_KERNEL_EXP_TARGET_NAME, dpex_exp_kernel_target
@@ -82,9 +85,10 @@ class _KernelCompiler(_FunctionCompiler):
             kernel_func, kernel_fndesc.argtypes
         )
 
-        # makes sure that the spir_func is completely inlined into the
-        # spir_kernel wrapper
-        kernel_library.optimize_final_module()
+        # Call finalize on the LLVM module. Finalization will result in
+        # all linking libraries getting linked together and final optimization
+        # including inlining of functions if an inlining level is specified.
+        kernel_library.finalize()
         # Compiled the LLVM IR to SPIR-V
         kernel_spirv_module = spirv_generator.llvm_to_spirv(
             kernel_targetctx,
@@ -144,9 +148,15 @@ class _KernelCompiler(_FunctionCompiler):
         try:
             cres: CompileResult = self._compile_core(args, return_type)
 
-            kernel_device_ir_module = self._compile_to_spirv(
-                cres.library, cres.fndesc, cres.target_context
-            )
+            if (
+                self.targetoptions["_compilation_mode"]
+                == CompilationMode.KERNEL
+            ):
+                kernel_device_ir_module: _KernelModule = self._compile_to_spirv(
+                    cres.library, cres.fndesc, cres.target_context
+                )
+            else:
+                kernel_device_ir_module = None
 
             kcres_attrs = []
 
@@ -282,12 +292,28 @@ class KernelDispatcher(Dispatcher):
             with self._compiling_counter:
                 args, return_type = sigutils.normalize_signature(sig)
 
-                try:
-                    self._compiler.check_queue_equivalence_of_args(
-                        self._kernel_name, args
-                    )
-                except ExecutionQueueInferenceError as eqie:
-                    raise eqie
+                if (
+                    self.targetoptions["_compilation_mode"]
+                    == CompilationMode.KERNEL
+                ):
+                    # Compute follows data based queue equivalence is only
+                    # evaluated for kernel functions whose arguments are
+                    # supposed to be arrays. For device_func decorated
+                    # functions, the arguments can be scalar and we skip queue
+                    # equivalence check.
+                    try:
+                        self._compiler.check_queue_equivalence_of_args(
+                            self._kernel_name, args
+                        )
+                    except ExecutionQueueInferenceError as eqie:
+                        raise eqie
+
+                    # A function being compiled in the KERNEL compilation mode
+                    # cannot have a non-void return value
+                    if return_type and return_type != void:
+                        raise KernelHasReturnValueError(
+                            kernel_name=None, return_type=return_type, sig=sig
+                        )
 
                 # Don't recompile if signature already exists
                 existing = self.overloads.get(tuple(args))

--- a/numba_dpex/tests/experimental/codegen/__init__.py
+++ b/numba_dpex/tests/experimental/codegen/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/numba_dpex/tests/experimental/codegen/test_inline_threshold_codegen.py
+++ b/numba_dpex/tests/experimental/codegen/test_inline_threshold_codegen.py
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import dpctl
+from numba.core import types
+
+import numba_dpex as dpex
+from numba_dpex import DpctlSyclQueue, DpnpNdArray
+from numba_dpex import experimental as dpex_exp
+from numba_dpex import int64
+
+
+def kernel_func(a, b, c):
+    i = dpex.get_global_id(0)
+    c[i] = a[i] + b[i]
+
+
+def test_codegen_with_max_inline_threshold():
+    """Tests if the inline_threshold option leads to a fully inlined kernel
+    function generation.
+
+    By default, numba_dpex compiles a function passed to the `kernel` decorator
+    into a `spir_func` LLVM function. Then before lowering to device IR, the
+    DpexTargetContext creates a "wrapper" function that has the "spir_kernel"
+    calling convention. It is done so that we can use the same target context
+    and pipeline to compile both host callable "kernels" and device-only
+    "device_func" functions.
+
+    Unless the inline_threshold is set to 3, the `spir_func` function is not
+    inlined into the wrapper function. The test checks if the `spir_func`
+    function is fully inlined into the wrapper. The test is rather rudimentary
+    and only checks the count of function in the generated module.
+    With inlining, the count should be one and without inlining it will be two.
+    """
+
+    queue_ty = DpctlSyclQueue(dpctl.SyclQueue())
+    i64arr_ty = DpnpNdArray(ndim=1, dtype=int64, layout="C", queue=queue_ty)
+    kernel_sig = types.void(i64arr_ty, i64arr_ty, i64arr_ty)
+
+    disp = dpex_exp.kernel(inline_threshold=3)(kernel_func)
+    disp.compile(kernel_sig)
+    kcres = disp.overloads[kernel_sig.args]
+    llvm_ir_mod = kcres.library._final_module
+
+    count_of_non_declaration_type_functions = 0
+
+    for f in llvm_ir_mod.functions:
+        if not f.is_declaration:
+            count_of_non_declaration_type_functions += 1
+
+    assert count_of_non_declaration_type_functions == 1
+
+
+def test_codegen_without_max_inline_threshold():
+    """See docstring of :func:`test_codegen_with_max_inline_threshold`."""
+
+    queue_ty = DpctlSyclQueue(dpctl.SyclQueue())
+    i64arr_ty = DpnpNdArray(ndim=1, dtype=int64, layout="C", queue=queue_ty)
+    kernel_sig = types.void(i64arr_ty, i64arr_ty, i64arr_ty)
+
+    disp = dpex_exp.kernel(kernel_func)
+    disp.compile(kernel_sig)
+    kcres = disp.overloads[kernel_sig.args]
+    llvm_ir_mod = kcres.library._final_module
+
+    count_of_non_declaration_type_functions = 0
+
+    for f in llvm_ir_mod.functions:
+        if not f.is_declaration:
+            count_of_non_declaration_type_functions += 1
+
+    assert count_of_non_declaration_type_functions == 2

--- a/numba_dpex/tests/experimental/test_compiler_warnings.py
+++ b/numba_dpex/tests/experimental/test_compiler_warnings.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import warnings
+
+import pytest
+
+import numba_dpex as dpex
+from numba_dpex import experimental as dpex_exp
+
+
+def test_compilation_mode_option_user_definition():
+    def kernel_func(a, b, c):
+        i = dpex.get_global_id(0)
+        c[i] = a[i] + b[i]
+
+    with pytest.warns(warnings.warn(UserWarning)):
+        dpex_exp.kernel(_compilation_mode="kernel")(kernel_func)

--- a/numba_dpex/tests/experimental/test_inline_threshold_config.py
+++ b/numba_dpex/tests/experimental/test_inline_threshold_config.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/numba_dpex/tests/experimental/test_inline_threshold_config.py
+++ b/numba_dpex/tests/experimental/test_inline_threshold_config.py
@@ -1,3 +1,57 @@
 # SPDX-FileCopyrightText: 2023 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
+
+from numba.core import compiler
+
+import numba_dpex as dpex
+from numba_dpex import experimental as dpex_exp
+
+
+def kernel_func(a, b, c):
+    i = dpex.get_global_id(0)
+    c[i] = a[i] + b[i]
+
+
+def test_inline_threshold_set_using_config():
+    oldConfig = dpex.config.INLINE_THRESHOLD
+    dpex.config.INLINE_THRESHOLD = None
+
+    disp = dpex_exp.kernel(kernel_func)
+    flags = compiler.Flags()
+    disp.targetdescr.options.parse_as_flags(flags, disp.targetoptions)
+
+    assert flags.inline_threshold == 0
+
+    dpex.config.INLINE_THRESHOLD = 2
+
+    flags = compiler.Flags()
+    disp.targetdescr.options.parse_as_flags(flags, disp.targetoptions)
+
+    assert flags.inline_threshold == 2
+
+    dpex.config.INLINE_THRESHOLD = oldConfig
+
+
+def test_inline_threshold_set_using_decorator_option():
+    """Test setting the inline_threshold value using the kernel decorator flag"""
+
+    disp = dpex_exp.kernel(inline_threshold=2)(kernel_func)
+    flags = compiler.Flags()
+    disp.targetdescr.options.parse_as_flags(flags, disp.targetoptions)
+
+    assert flags.inline_threshold == 2
+
+
+def test_inline_threshold_set_using_decorator_supersedes_config_option():
+    oldConfig = dpex.config.INLINE_THRESHOLD
+    dpex.config.INLINE_THRESHOLD = None
+
+    disp = dpex_exp.kernel(inline_threshold=3)(kernel_func)
+    flags = compiler.Flags()
+    disp.targetdescr.options.parse_as_flags(flags, disp.targetoptions)
+
+    print(flags.inline_threshold)
+    assert flags.inline_threshold == 3
+
+    dpex.config.INLINE_THRESHOLD = oldConfig

--- a/numba_dpex/tests/experimental/test_target_specific_overload.py
+++ b/numba_dpex/tests/experimental/test_target_specific_overload.py
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import dpnp
+from numba.core.extending import overload
+
+import numba_dpex as dpex
+import numba_dpex.experimental as dpex_exp
+from numba_dpex.core.descriptor import dpex_kernel_target
+from numba_dpex.experimental.target import (
+    DPEX_KERNEL_EXP_TARGET_NAME,
+    dpex_exp_kernel_target,
+)
+
+
+def scalar_add(a, b):
+    return a + b
+
+
+@overload(scalar_add, target=DPEX_KERNEL_EXP_TARGET_NAME)
+def _ol_scalar_add(a, b):
+    def ol_scalar_add_impl(a, b):
+        return a + b
+
+    return ol_scalar_add_impl
+
+
+@dpex_exp.kernel
+def kernel_calling_overload(a, b, c):
+    i = dpex.get_global_id(0)
+    c[i] = scalar_add(a[i], b[i])
+
+
+a = dpnp.ones(10, dtype=dpnp.int64)
+b = dpnp.ones(10, dtype=dpnp.int64)
+c = dpnp.zeros(10, dtype=dpnp.int64)
+
+dpex_exp.call_kernel(kernel_calling_overload, dpex.Range(10), a, b, c)
+
+
+def test_end_to_end_overload_execution():
+    """Tests that an overload function can be called from an experimental.kernel
+    decorated function and works end to end.
+    """
+    for i in range(c.shape[0]):
+        assert c[i] == scalar_add(a[i], b[i])
+
+
+def test_overload_registration():
+    """Tests that the overload _ol_scalar_add is registered only in the
+    "dpex_kernel_exp" target and not in the "dpex_kernel" target.
+    """
+
+    def check_for_overload_registration(targetctx, key):
+        found_key = False
+        for fn_key in targetctx._defns.keys():
+            if isinstance(fn_key, str) and fn_key.startswith(key):
+                found_key = True
+                break
+        return found_key
+
+    assert check_for_overload_registration(
+        dpex_exp_kernel_target.target_context, "_ol_scalar_add"
+    )
+    assert not check_for_overload_registration(
+        dpex_kernel_target.target_context, "_ol_scalar_add"
+    )


### PR DESCRIPTION
- [X] Have you provided a meaningful PR description?
Add a new `device_func` decorator to compile `DpexKernelTarget` overloads 
   - A new `generate_device_ir` option for `DpexTargetDescriptor` is introduced. The new option can be used to prevent a module to be compiled to device IR binary.
    - A new `device_func` decorator that is registered to compile overloads in `DpexExpKernelTarget`. The `device_func` decorated
      functions are not compiled to device IR.
    - The `kernel` decorator is updated to compile a finalized module to device IR.

- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
