### PR TITLE
Use NumPy as python sublibrary in cmake

### DIFF
--- a/numba_dpex/core/runtime/CMakeLists.txt
+++ b/numba_dpex/core/runtime/CMakeLists.txt
@@ -83,15 +83,14 @@ message(STATUS "CMAKE_MODULE_PATH=" "${CMAKE_MODULE_PATH}")
 
 # Add packages
 find_package(Python 3.9 REQUIRED
-  COMPONENTS Interpreter Development.Module)
+  COMPONENTS Interpreter Development.Module NumPy)
 find_package(Dpctl REQUIRED)
-find_package(NumPy REQUIRED)
 find_package(IntelSYCL REQUIRED)
 
 # Includes
 include(GNUInstallDirs)
 include_directories(${Python_INCLUDE_DIRS})
-include_directories(${NumPy_INCLUDE_DIRS})
+include_directories(${Python_NumPy_INCLUDE_DIRS})
 include_directories(${Numba_INCLUDE_DIRS})
 include_directories(${Dpctl_INCLUDE_DIRS})
 include_directories(.)


### PR DESCRIPTION
Link numpy libraries as python submodule instead of linking it as a standalone package. This the second and the last PR to enable VSCode cpp integration via CMake toolset plugin. First one (https://github.com/IntelPython/dpctl/pull/1484)

Old way of integration seems to be outdated and for some strange reason was not working in vscode.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
