### PR TITLE
Workaround: pin dpcpp version to 2024.0.0

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -13,7 +13,7 @@ build:
 requirements:
     build:
         - {{ compiler('cxx') }}
-        - {{ compiler('dpcpp') }}  # [not osx]
+        - {{ compiler('dpcpp') }} <2024.0.1  # [not osx]
     host:
         - python
         - setuptools >=63.*

--- a/environment.yml
+++ b/environment.yml
@@ -1,33 +1,33 @@
 name: dev
 channels:
-  - defaults
-  - dppy/label/dev
-  - numba
-  - intel
-  - numba/label/dev
-  - nodefaults
+- defaults
+- dppy/label/dev
+- numba
+- intel
+- numba/label/dev
+- nodefaults
 dependencies:
-  - python=3.9
-  - gxx_linux-64
-  - dpcpp_linux-64
-  - numba ==0.58*
-  - dpctl >=0.14*
-  - dpnp >=0.11*
-  - mkl >=2021.3.0  # for dpnp
-  - dpcpp-llvm-spirv
-  - packaging
-  - scikit-build >=0.15*
-  - cmake >=3.26*
-  - pytest
-  - pip
-  - pip:
-    - coverage
-    - pre-commit
-    - flake8
-    - black==20.8b1
-    - pytest-cov
-    - pytest-xdist
-    - pexpect
+- python=3.9
+- gxx_linux-64
+- dpcpp_linux-64==2024.0.0
+- numba ==0.58*
+- dpctl >=0.14*
+- dpnp >=0.11*
+- mkl >=2021.3.0 # for dpnp
+- dpcpp-llvm-spirv
+- packaging
+- scikit-build >=0.15*
+- cmake >=3.26*
+- pytest
+- pip
+- pip:
+  - coverage
+  - pre-commit
+  - flake8
+  - black==20.8b1
+  - pytest-cov
+  - pytest-xdist
+  - pexpect
 variables:
   CHANNELS: -c defaults -c numba -c intel -c numba/label/dev -c dppy/label/dev --override-channels
   CHANNELS_DEV: -c dppy/label/dev -c defaults -c numba -c intel -c numba/label/dev --override-channels

--- a/environment/coverage.yml
+++ b/environment/coverage.yml
@@ -1,23 +1,23 @@
 name: dev
 channels:
-  - dppy/label/dev
-  - numba
-  - intel
-  - conda-forge
-  - nodefaults
+- dppy/label/dev
+- numba
+- intel
+- conda-forge
+- nodefaults
 dependencies:
-  - libffi
-  - gxx_linux-64
-  - dpcpp_linux-64
-  - numba==0.58*
-  - dpctl
-  - dpnp
-  - dpcpp-llvm-spirv
-  - opencl_rt
-  - coverage
-  - pytest
-  - pytest-cov
-  - pytest-xdist
-  - pexpect
-  - scikit-build>=0.15*
-  - cmake>=3.26*
+- libffi
+- gxx_linux-64
+- dpcpp_linux-64==2024.0.0
+- numba==0.58*
+- dpctl
+- dpnp
+- dpcpp-llvm-spirv
+- opencl_rt
+- coverage
+- pytest
+- pytest-cov
+- pytest-xdist
+- pexpect
+- scikit-build>=0.15*
+- cmake>=3.26*

--- a/environment/docs.yml
+++ b/environment/docs.yml
@@ -1,29 +1,29 @@
 name: dpex-docs-dev
 channels:
-  - dppy/label/dev
-  - numba
-  - intel
-  - conda-forge
-  - nodefaults
+- dppy/label/dev
+- numba
+- intel
+- conda-forge
+- nodefaults
 dependencies:
-  - libffi
-  - gxx_linux-64
-  - dpcpp_linux-64
-  - numba==0.58*
-  - scikit-build>=0.15*
-  - cmake>=3.26*
-  - dpctl
-  - dpnp
-  - dpcpp-llvm-spirv
-  - opencl_rt
-  - pip
-  - pip:
-    - sphinx
-    - autodoc # there is no conda package
-    - recommonmark
-    - sphinx-rtd-theme
-    - sphinxcontrib-apidoc
-    - sphinxcontrib-googleanalytics
-    - sphinxcontrib.programoutput
-    - pydata-sphinx-theme
-    - myst-parser
+- libffi
+- gxx_linux-64
+- dpcpp_linux-64==2024.0.0
+- numba==0.58*
+- scikit-build>=0.15*
+- cmake>=3.26*
+- dpctl
+- dpnp
+- dpcpp-llvm-spirv
+- opencl_rt
+- pip
+- pip:
+  - sphinx
+  - autodoc # there is no conda package
+  - recommonmark
+  - sphinx-rtd-theme
+  - sphinxcontrib-apidoc
+  - sphinxcontrib-googleanalytics
+  - sphinxcontrib.programoutput
+  - pydata-sphinx-theme
+  - myst-parser

--- a/environment/pre-commit.yml
+++ b/environment/pre-commit.yml
@@ -1,25 +1,25 @@
 name: dev
 channels:
-  - dppy/label/dev
-  - numba
-  - intel
-  - conda-forge
-  - nodefaults
+- dppy/label/dev
+- numba
+- intel
+- conda-forge
+- nodefaults
 dependencies:
-  - libffi
-  - gxx_linux-64
-  - dpcpp_linux-64
-  - numba==0.58*
-  - dpctl
-  - dpnp
-  - dpcpp-llvm-spirv
-  - opencl_rt
-  - coverage
-  - pytest
-  - pytest-cov
-  - pytest-xdist
-  - pexpect
-  - scikit-build>=0.15*
-  - cmake>=3.26*
-  - pre-commit
-  - pylint
+- libffi
+- gxx_linux-64
+- dpcpp_linux-64==2024.0.0
+- numba==0.58*
+- dpctl
+- dpnp
+- dpcpp-llvm-spirv
+- opencl_rt
+- coverage
+- pytest
+- pytest-cov
+- pytest-xdist
+- pexpect
+- scikit-build>=0.15*
+- cmake>=3.26*
+- pre-commit
+- pylint


### PR DESCRIPTION
2024.0.1 dpcpp conda package is broken. Until it is resolved, let's merge this workaround

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
