### PR TITLE
Extend kernel launcher

### DIFF
--- a/numba_dpex/experimental/launcher.py
+++ b/numba_dpex/experimental/launcher.py
@@ -10,30 +10,19 @@ from typing import NamedTuple, Union
 
 import dpctl
 from llvmlite import ir as llvmir
-from numba.core import cgutils, cpu, types
-from numba.core.datamodel import default_manager as numba_default_dmm
+from numba.core import cgutils, types
+from numba.core.cpu import CPUContext
 from numba.core.types.containers import UniTuple
 from numba.core.types.functions import Dispatcher
 from numba.extending import intrinsic
 
-from numba_dpex import config, dpjit, utils
-from numba_dpex.core.exceptions import UnreachableError
-from numba_dpex.core.runtime.context import DpexRTContext
+from numba_dpex import dpjit
 from numba_dpex.core.targets.kernel_target import DpexKernelTargetContext
-from numba_dpex.core.types import (
-    DpctlSyclEvent,
-    DpnpNdArray,
-    NdRangeType,
-    RangeType,
-)
+from numba_dpex.core.types import DpctlSyclEvent, NdRangeType, RangeType
 from numba_dpex.core.utils import kernel_launcher as kl
 from numba_dpex.dpctl_iface import libsyclinterface_bindings as sycl
 from numba_dpex.dpctl_iface.wrappers import wrap_event_reference
-from numba_dpex.experimental.kernel_dispatcher import (
-    KernelDispatcher,
-    _KernelModule,
-)
-from numba_dpex.utils import create_null_ptr
+from numba_dpex.experimental.kernel_dispatcher import KernelDispatcher
 
 
 class LLRange(NamedTuple):
@@ -43,347 +32,131 @@ class LLRange(NamedTuple):
     local_range_extents: list
 
 
-class CallKernelBuilder:
-    """
-    Helper class to build LLVM IR for a numba function that calls kernel.
-    """
+def wrap_event_reference_tuple(ctx, builder, event1, event2):
+    """Creates tuple datamodel from two event datamodels, so it can be
+    boxed to Python."""
+    ty_event = DpctlSyclEvent()
+    tupty = types.Tuple([ty_event, ty_event])
 
-    def __init__(
-        self,
-        codegen_targetctx: cpu.CPUContext,
-        builder: llvmir.IRBuilder,
-    ):
-        self.context = codegen_targetctx
-        self.builder = builder
-        # TODO: get dpex RT from cached property once the PR is merged
-        # https://github.com/IntelPython/numba-dpex/pull/1027
-        # and get rid of the global variable. Use self.context.dpexrt instead.
-        self.dpexrt = DpexRTContext(self.context)
+    lltupty = ctx.get_value_type(tupty)
+    tup = cgutils.get_null_value(lltupty)
+    tup = builder.insert_value(tup, event1, 0)
+    tup = builder.insert_value(tup, event2, 1)
 
-        if config.DEBUG_KERNEL_LAUNCHER:
-            cgutils.printf(
-                self.builder,
-                "DPEX-DEBUG: Inside the kernel launcher function\n",
-            )
-
-    def extract_arguments_from_tuple(
-        self,
-        ty_kernel_args_tuple: UniTuple,
-        ll_kernel_args_tuple: llvmir.Instruction,
-    ) -> list[llvmir.Instruction]:
-        """Extracts LLVM IR values from llvm tuple into python array."""
-
-        kernel_args = []
-        for pos in range(len(ty_kernel_args_tuple)):
-            kernel_args.append(
-                self.builder.extract_value(ll_kernel_args_tuple, pos)
-            )
-
-        return kernel_args
-
-    def allocate_meminfo_array(
-        self,
-        kernel_argtys: tuple[types.Type, ...],
-        kernel_args: [llvmir.Instruction, ...],
-    ) -> tuple[int, list[llvmir.Instruction]]:
-        """Allocates an LLVM array value to store each memory info from all
-        kernel arguments. The array is the populated with the LLVM value for
-        every meminfo of the kernel arguments.
-        """
-        meminfos = []
-        for arg_num, argtype in enumerate(kernel_argtys):
-            llvm_val = kernel_args[arg_num]
-
-            meminfos += [
-                meminfo
-                for ty, meminfo in self.context.nrt.get_meminfos(
-                    self.builder, argtype, llvm_val
-                )
-            ]
-
-        meminfo_list = cgutils.alloca_once(
-            self.builder,
-            utils.get_llvm_type(context=self.context, type=types.voidptr),
-            size=self.context.get_constant(types.uintp, len(meminfos)),
-        )
-
-        for meminfo_num, meminfo in enumerate(meminfos):
-            meminfo_arg_dst = self.builder.gep(
-                meminfo_list,
-                [self.context.get_constant(types.int32, meminfo_num)],
-            )
-            meminfo_ptr = self.builder.bitcast(
-                meminfo,
-                utils.get_llvm_type(context=self.context, type=types.voidptr),
-            )
-            self.builder.store(meminfo_ptr, meminfo_arg_dst)
-
-        return len(meminfos), meminfo_list
-
-    def get_queue_ref_val(
-        self,
-        kernel_argtys: tuple[types.Type, ...],
-        kernel_args: [llvmir.Instruction, ...],
-    ):
-        """
-        Get the sycl queue from the first DpnpNdArray argument. Prior passes
-        before lowering make sure that compute-follows-data is enforceable
-        for a specific call to a kernel. As such, at the stage of lowering
-        the queue from the first DpnpNdArray argument can be extracted.
-        """
-
-        for arg_num, argty in enumerate(kernel_argtys):
-            if isinstance(argty, DpnpNdArray):
-                llvm_val = kernel_args[arg_num]
-                datamodel = self.context.data_model_manager.lookup(argty)
-                sycl_queue_attr_pos = datamodel.get_field_position("sycl_queue")
-                ptr_to_queue_ref = self.builder.extract_value(
-                    llvm_val, sycl_queue_attr_pos
-                )
-                break
-
-        return ptr_to_queue_ref
-
-    def get_kernel(self, queue_ref, kernel_module: _KernelModule):
-        """Returns the pointer to the sycl::kernel object in a passed in
-        sycl::kernel_bundle wrapper object.
-        """
-        # Inserts a global constant byte string in the current LLVM module to
-        # store the passed in SPIR-V binary blob.
-        kernel_bc_byte_str = self.context.insert_const_bytes(
-            self.builder.module,
-            bytes=kernel_module.kernel_bitcode,
-        )
-
-        kernel_name = self.context.insert_const_string(
-            self.builder.module, kernel_module.kernel_name
-        )
-
-        context_ref = sycl.dpctl_queue_get_context(self.builder, queue_ref)
-        device_ref = sycl.dpctl_queue_get_device(self.builder, queue_ref)
-
-        # build_or_get_kernel stills reference to context and device cause it
-        # needs to keep them alive for keys.
-        kernel_ref = self.dpexrt.build_or_get_kernel(
-            self.builder,
-            [
-                context_ref,
-                device_ref,
-                llvmir.Constant(
-                    llvmir.IntType(64), hash(kernel_module.kernel_bitcode)
-                ),
-                kernel_bc_byte_str,
-                llvmir.Constant(
-                    llvmir.IntType(64), len(kernel_module.kernel_bitcode)
-                ),
-                self.builder.load(create_null_ptr(self.builder, self.context)),
-                kernel_name,
-            ],
-        )
-
-        return kernel_ref
-
-    def create_llvm_values_for_index_space(
-        self,
-        ty_indexer_arg: Union[RangeType, NdRangeType],
-        index_arg: llvmir.BaseStructType,
-    ) -> LLRange:
-        """Returns two lists of LLVM IR Values that hold the unboxed extents of
-        a Python Range or NdRange object.
-        """
-        ndim = ty_indexer_arg.ndim
-        global_range_extents = []
-        local_range_extents = []
-        indexer_datamodel = numba_default_dmm.lookup(ty_indexer_arg)
-
-        if isinstance(ty_indexer_arg, RangeType):
-            for dim_num in range(ndim):
-                dim_pos = indexer_datamodel.get_field_position(
-                    "dim" + str(dim_num)
-                )
-                global_range_extents.append(
-                    self.builder.extract_value(index_arg, dim_pos)
-                )
-        elif isinstance(ty_indexer_arg, NdRangeType):
-            for dim_num in range(ndim):
-                gdim_pos = indexer_datamodel.get_field_position(
-                    "gdim" + str(dim_num)
-                )
-                global_range_extents.append(
-                    self.builder.extract_value(index_arg, gdim_pos)
-                )
-                ldim_pos = indexer_datamodel.get_field_position(
-                    "ldim" + str(dim_num)
-                )
-                local_range_extents.append(
-                    self.builder.extract_value(index_arg, ldim_pos)
-                )
-        else:
-            raise UnreachableError
-
-        return LLRange(global_range_extents, local_range_extents)
-
-    def acquire_meminfo_and_schedule_release(
-        self,
-        queue_ref,
-        event_ref,
-        ty_kernel_args,
-        kernel_args,
-    ):
-        """Schedule sycl host task to release nrt meminfo of the arguments used
-        to run job. Use it to keep arguments alive during kernel execution."""
-        total_meminfos, meminfo_list = self.allocate_meminfo_array(
-            ty_kernel_args, kernel_args
-        )
-
-        event_ref_ptr = self.builder.alloca(event_ref.type)
-        self.builder.store(event_ref, event_ref_ptr)
-
-        status_ptr = cgutils.alloca_once(
-            self.builder, self.context.get_value_type(types.uint64)
-        )
-        host_eref = self.dpexrt.acquire_meminfo_and_schedule_release(
-            self.builder,
-            [
-                self.context.nrt.get_nrt_api(self.builder),
-                queue_ref,
-                meminfo_list,
-                self.context.get_constant(types.uintp, total_meminfos),
-                event_ref_ptr,
-                self.context.get_constant(types.uintp, 1),
-                status_ptr,
-            ],
-        )
-        return host_eref
+    return tup
 
 
 @intrinsic(target="cpu")
+def _submit_kernel_async(
+    typingctx,
+    ty_kernel_fn: Dispatcher,
+    ty_index_space: Union[RangeType, NdRangeType],
+    ty_kernel_args_tuple: UniTuple,
+):
+    """Generates IR code for call_kernel_async dpjit function."""
+    return _submit_kernel(
+        typingctx,
+        ty_kernel_fn,
+        ty_index_space,
+        ty_kernel_args_tuple,
+        sync=False,
+    )
+
+
+@intrinsic(target="cpu")
+def _submit_kernel_sync(
+    typingctx,
+    ty_kernel_fn: Dispatcher,
+    ty_index_space: Union[RangeType, NdRangeType],
+    ty_kernel_args_tuple: UniTuple,
+):
+    """Generates IR code for call_kernel dpjit function."""
+    return _submit_kernel(
+        typingctx,
+        ty_kernel_fn,
+        ty_index_space,
+        ty_kernel_args_tuple,
+        sync=True,
+    )
+
+
 def _submit_kernel(
     typingctx,  # pylint: disable=W0613
     ty_kernel_fn: Dispatcher,
     ty_index_space: Union[RangeType, NdRangeType],
     ty_kernel_args_tuple: UniTuple,
+    sync: bool,
 ):
-    """Generates IR code for call_kernel dpjit function.
+    """Generates IR code for call_kernel_{async|sync} dpjit function.
 
     The intrinsic first compiles the kernel function to SPIRV, and then to a
     sycl kernel bundle. The arguments to the kernel are also packed into
     flattened arrays and the sycl queue to which the kernel will be submitted
     extracted from the args. Finally, the actual kernel is extracted from the
     kernel bundle and submitted to the sycl queue.
+
+    If sync set to False, it acquires memory infos from kernel arguments to
+    prevent garbage collection on them. Then it schedules host task to release
+    that arguments and unblock garbage collection. Tuple of host task and device
+    tasks are returned.
     """
     # signature of this intrinsic
-    ty_event = DpctlSyclEvent()
-    sig = ty_event(ty_kernel_fn, ty_index_space, ty_kernel_args_tuple)
+    ty_return = types.void
+    if not sync:
+        ty_event = DpctlSyclEvent()
+        ty_return = types.Tuple([ty_event, ty_event])
+
+    sig = ty_return(ty_kernel_fn, ty_index_space, ty_kernel_args_tuple)
     kernel_sig = types.void(*ty_kernel_args_tuple)
     # ty_kernel_fn is type specific to exact function, so we can get function
     # directly from type and compile it. Thats why we don't need to get it in
     # codegen
     kernel_dispatcher: KernelDispatcher = ty_kernel_fn.dispatcher
     kernel_dispatcher.compile(kernel_sig)
-    kernel_module: _KernelModule = kernel_dispatcher.get_overload_kcres(
+    kernel_module: kl.SPIRVKernelModule = kernel_dispatcher.get_overload_kcres(
         kernel_sig
     ).kernel_device_ir_module
     kernel_targetctx: DpexKernelTargetContext = kernel_dispatcher.targetctx
 
-    def codegen(cgctx, builder, sig, llargs):
-        # llargs[0] is kernel function that we don't need anymore (see above)
+    def codegen(
+        cgctx: CPUContext, builder: llvmir.IRBuilder, sig, llargs: list
+    ):
         ty_index_space: Union[RangeType, NdRangeType] = sig.args[1]
         ll_index_space: llvmir.Instruction = llargs[1]
         ty_kernel_args_tuple: UniTuple = sig.args[2]
         ll_kernel_args_tuple: llvmir.Instruction = llargs[2]
 
-        generator = CallKernelBuilder(
-            codegen_targetctx=cgctx,
-            builder=builder,
-        )
-
-        kernel_args = generator.extract_arguments_from_tuple(
-            ty_kernel_args_tuple=ty_kernel_args_tuple,
-            ll_kernel_args_tuple=ll_kernel_args_tuple,
-        )
-
-        # queue_ref is just a pointer to the attribute, so we don't have to
-        # clean it up
-        queue_ref = generator.get_queue_ref_val(
-            kernel_argtys=ty_kernel_args_tuple,
-            kernel_args=kernel_args,
-        )
-
-        # creates new object, so we must clean it up
-        kernel_ref = generator.get_kernel(queue_ref, kernel_module)
-
-        ll_range = generator.create_llvm_values_for_index_space(
-            ty_indexer_arg=ty_index_space,
-            index_arg=ll_index_space,
-        )
-
         kl_builder = kl.KernelLaunchIRBuilder(
-            cgctx, builder, kernel_targetctx.data_model_manager
+            cgctx,
+            builder,
+            kernel_targetctx.data_model_manager,
         )
-        kl_builder.set_kernel(kernel_ref)
-        kl_builder.set_queue(queue_ref)
-        kl_builder.set_range(
-            ll_range.global_range_extents, ll_range.local_range_extents
+        kl_builder.set_range_from_indexer(
+            ty_indexer_arg=ty_index_space,
+            ll_index_arg=ll_index_space,
         )
-        kl_builder.set_arguments(ty_kernel_args_tuple, kernel_args)
-        kl_builder.set_dependant_event_list(dep_events=[])
+        kl_builder.set_arguments_form_tuple(
+            ty_kernel_args_tuple, ll_kernel_args_tuple
+        )
+        kl_builder.set_queue_from_arguments()
+        kl_builder.set_kernel_from_spirv(kernel_module)
+        kl_builder.set_dependant_event_list([])
         device_event_ref = kl_builder.submit()
 
-        # Clean up
-        sycl.dpctl_kernel_delete(builder, kernel_ref)
+        if not sync:
+            host_event_ref = kl_builder.acquire_meminfo_and_submit_release()
 
-        return wrap_event_reference(cgctx, builder, device_event_ref)
+            return wrap_event_reference_tuple(
+                cgctx,
+                builder,
+                wrap_event_reference(cgctx, builder, host_event_ref),
+                wrap_event_reference(cgctx, builder, device_event_ref),
+            )
 
-    return sig, codegen
+        sycl.dpctl_event_wait(builder, device_event_ref)
+        sycl.dpctl_event_delete(builder, device_event_ref)
 
-
-@intrinsic(target="cpu")
-def _acquire_meminfo_and_schedule_release(
-    typingctx,  # pylint: disable=W0613
-    ty_device_event,  # pylint: disable=W0613
-    ty_kernel_args,
-):
-    """Generates IR code to keep arguments alive during kernel execution.
-
-    The intrinsic collects all memory infos from the kernel arguments, acquires
-    them and schecules host task to release them. Returns host task's event.
-    """
-    # signature of this intrinsic
-    ty_event = DpctlSyclEvent()
-    sig = ty_event(ty_event, ty_kernel_args)
-
-    def codegen(cgctx, builder, sig, llargs):
-        device_event = cgutils.create_struct_proxy(sig.args[0])(
-            cgctx, builder, value=llargs[0]
-        )
-
-        ll_kernel_args_tuple = llargs[1]
-        ty_kernel_args_tuple = sig.args[1]
-
-        generator = CallKernelBuilder(
-            codegen_targetctx=cgctx,
-            builder=builder,
-        )
-
-        kernel_args = generator.extract_arguments_from_tuple(
-            ty_kernel_args_tuple=ty_kernel_args_tuple,
-            ll_kernel_args_tuple=ll_kernel_args_tuple,
-        )
-
-        qref = generator.get_queue_ref_val(
-            kernel_argtys=ty_kernel_args_tuple,
-            kernel_args=kernel_args,
-        )
-
-        host_eref = generator.acquire_meminfo_and_schedule_release(
-            queue_ref=qref,
-            event_ref=device_event.event_ref,
-            ty_kernel_args=ty_kernel_args_tuple,
-            kernel_args=kernel_args,
-        )
-
-        return wrap_event_reference(cgctx, builder, host_eref)
+        return None
 
     return sig, codegen
 
@@ -403,12 +176,11 @@ def call_kernel(kernel_fn, index_space, *kernel_args) -> None:
         kernel_args : List of objects that are passed to the numba_dpex.kernel
         decorated function.
     """
-    device_event = _submit_kernel(  # pylint: disable=E1120
+    _submit_kernel_sync(  # pylint: disable=E1120
         kernel_fn,
         index_space,
         kernel_args,
     )
-    device_event.wait()  # pylint: disable=E1101
 
 
 @dpjit
@@ -435,12 +207,8 @@ def call_kernel_async(
         that releases use of any kernel argument so it can be deallocated.
         This task may be executed only after device task is done.
     """
-    device_event = _submit_kernel(  # pylint: disable=E1120
+    return _submit_kernel_async(  # pylint: disable=E1120
         kernel_fn,
         index_space,
         kernel_args,
     )
-    host_event = _acquire_meminfo_and_schedule_release(  # pylint: disable=E1120
-        device_event, kernel_args
-    )
-    return host_event, device_event


### PR DESCRIPTION
Changes:
- Get rid of `CallKernelBuilder` and extend `KernelLaunchIRBuilder`. 
- call_kernel and call_kernel_async now uses same function to generate IR
- call_kernel no longer allocates meminfo for event_ref

Checklist:
- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
