### PR TITLE
Removes the deprecated feature of providing kernel launch params as lists and tuple

### DIFF
--- a/numba_dpex/tests/kernel_tests/test_atomic_op.py
+++ b/numba_dpex/tests/kernel_tests/test_atomic_op.py
@@ -96,7 +96,7 @@ def test_kernel_atomic_local(input_arrays, return_list_of_op):
     op_type, expected = return_list_of_op
     f = get_func_local(op_type, dtype)
     kernel = dpex.kernel(f)
-    kernel[dpex.Range(N), dpex.Range(N)](a)
+    kernel[dpex.NdRange(dpex.Range(N), dpex.Range(N))](a)
     assert a[0] == expected
 
 

--- a/numba_dpex/tests/kernel_tests/test_barrier.py
+++ b/numba_dpex/tests/kernel_tests/test_barrier.py
@@ -2,13 +2,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import dpctl
 import dpctl.tensor as dpt
 import numpy as np
-import pytest
 
 import numba_dpex as dpex
-from numba_dpex import float32, usm_ndarray, void
+from numba_dpex import NdRange, Range, float32, usm_ndarray, void
 
 f32arrty = usm_ndarray(ndim=1, dtype=float32, layout="C")
 
@@ -27,7 +25,7 @@ def test_proper_lowering():
     orig = dpt.asnumpy(arr)
     global_size = (N,)
     local_size = (N // 2,)
-    twice[global_size, local_size](arr)
+    twice[NdRange(global_size, local_size)](arr)
     after = dpt.asnumpy(arr)
     # The computation is correct?
     np.testing.assert_allclose(orig * 2, after)
@@ -45,7 +43,7 @@ def test_no_arg_barrier_support():
     N = 256
     arr = dpt.arange(N, dtype=dpt.float32)
     orig = dpt.asnumpy(arr)
-    twice[N](arr)
+    twice[Range(N)](arr)
     after = dpt.asnumpy(arr)
     # The computation is correct?
     np.testing.assert_allclose(orig * 2, after)
@@ -68,7 +66,7 @@ def test_local_memory():
 
     arr = dpt.arange(blocksize, dtype=dpt.float32)
     orig = dpt.asnumpy(arr)
-    reverse_array[(blocksize,), (blocksize,)](arr)
+    reverse_array[NdRange(Range(blocksize), Range(blocksize))](arr)
     after = dpt.asnumpy(arr)
     expected = orig[::-1] + orig
     np.testing.assert_allclose(expected, after)

--- a/numba_dpex/tests/kernel_tests/test_caching.py
+++ b/numba_dpex/tests/kernel_tests/test_caching.py
@@ -6,7 +6,6 @@ import string
 
 import dpctl.tensor as dpt
 import numpy as np
-import pytest
 
 import numba_dpex as dpex
 from numba_dpex.core.caching import LRUCache
@@ -130,7 +129,7 @@ def test_caching_hit_counts():
 
     d = JitKernel(data_parallel_sum)
 
-    d_launcher = d[100]
+    d_launcher = d[dpex.Range(100)]
 
     N = 10
     for i in range(N):

--- a/numba_dpex/tests/kernel_tests/test_kernel_launch_params.py
+++ b/numba_dpex/tests/kernel_tests/test_kernel_launch_params.py
@@ -21,96 +21,16 @@ def vecadd(a, b, c):
     a[i] = b[i] + c[i]
 
 
-def test_1D_global_range_as_int():
-    with pytest.deprecated_call():
-        k = vecadd[10]
-        assert k._global_range == [10]
-        assert k._local_range is None
-
-
 def test_1D_global_range_as_one_tuple():
     k = vecadd[Range(10)]
     assert k._global_range == [10]
     assert k._local_range is None
 
 
-def test_1D_global_range_as_list():
-    with pytest.deprecated_call():
-        k = vecadd[[10]]
-        assert k._global_range == [10]
-        assert k._local_range is None
-
-
-def test_1D_global_range_and_1D_local_range1():
-    with pytest.deprecated_call():
-        k = vecadd[[10, 10]]
-        assert k._global_range == [10]
-        assert k._local_range == [10]
-
-
-def test_1D_global_range_and_1D_local_range2():
-    with pytest.deprecated_call():
-        k = vecadd[(10,), (10,)]
-        assert k._global_range == [10]
-        assert k._local_range == [10]
-
-
-def test_2D_global_range_and_2D_local_range1():
-    with pytest.deprecated_call():
-        k = vecadd[(10, 10), (10, 10)]
-        assert k._global_range == [10, 10]
-        assert k._local_range == [10, 10]
-
-
-def test_2D_global_range_and_2D_local_range2():
-    with pytest.deprecated_call():
-        k = vecadd[[10, 10], (10, 10)]
-        assert k._global_range == [10, 10]
-        assert k._local_range == [10, 10]
-
-
-def test_2D_global_range_and_2D_local_range3():
-    with pytest.deprecated_call():
-        k = vecadd[(10, 10), [10, 10]]
-        assert k._global_range == [10, 10]
-        assert k._local_range == [10, 10]
-
-
 def test_2D_global_range_and_2D_local_range4():
     k = vecadd[dpex.NdRange((10, 10), (10, 10))]
     assert k._global_range == [10, 10]
     assert k._local_range == [10, 10]
-
-
-def test_deprecation_warning_for_empty_local_range1():
-    with pytest.deprecated_call():
-        k = vecadd[[10, 10], []]
-    assert k._global_range == [10, 10]
-    assert k._local_range is None
-
-
-def test_deprecation_warning_for_empty_local_range2():
-    with pytest.deprecated_call():
-        k = vecadd[10, []]
-    assert k._global_range == [10]
-    assert k._local_range is None
-
-
-def test_ambiguous_kernel_launch_params():
-    with pytest.deprecated_call():
-        k = vecadd[10, 10]
-    assert k._global_range == [10]
-    assert k._local_range == [10]
-
-    with pytest.deprecated_call():
-        k = vecadd[(10, 10)]
-    assert k._global_range == [10]
-    assert k._local_range == [10]
-
-    with pytest.deprecated_call():
-        k = vecadd[((10), (10))]
-    assert k._global_range == [10]
-    assert k._local_range == [10]
 
 
 def test_unknown_global_range_error():
@@ -122,36 +42,6 @@ def test_unknown_global_range_error():
         vecadd(a, b, c)
     except UnknownGlobalRangeError as e:
         assert "No global range" in e.message
-
-
-def test_illegal_kernel_launch_arg1():
-    with pytest.raises(InvalidKernelLaunchArgsError):
-        with pytest.deprecated_call():
-            vecadd[()]
-
-
-def test_illegal_kernel_launch_arg2():
-    with pytest.raises(InvalidKernelLaunchArgsError):
-        with pytest.deprecated_call():
-            vecadd[10, 10, []]
-
-
-def test_illegal_range_error1():
-    with pytest.raises(IllegalRangeValueError):
-        with pytest.deprecated_call():
-            vecadd[[], []]
-
-
-def test_illegal_range_error2():
-    with pytest.raises(IllegalRangeValueError):
-        with pytest.deprecated_call():
-            vecadd[[], 10]
-
-
-def test_illegal_range_error3():
-    with pytest.raises(IllegalRangeValueError):
-        with pytest.deprecated_call():
-            vecadd[(), 10]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- [X] Have you provided a meaningful PR description?

The existing `numba_dpex.kernel` functions can be launched by providing either a `Range` or `NdRange` object to `numba_dpex.core.kernel_interface.dispatcher.JitKernel.__getitem__`, or the global and local sizes as lists or tuples. The use of list and tuples was deprecated a while back. This PR removes the deprecated support and now only `Range` or `NdRange` arguments are supported as kernel launch parameters.

- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
No, but existing tests have been fixed and updated.
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?

Fixes #1040
