### PR TITLE
Improve spirv error reporting in numba

### DIFF
--- a/numba_dpex/core/exceptions.py
+++ b/numba_dpex/core/exceptions.py
@@ -398,3 +398,17 @@ class IllegalIntEnumLiteralValueError(Exception):
             "An IntEnumLiteral can only be initialized from a FlagEnum member"
         )
         super().__init__(self.message)
+
+
+class InternalError(Exception):
+    """
+    Exception raise when something in the internal compiler machinery failed.
+    """
+
+    def __init__(self, extra_msg=None) -> None:
+        if extra_msg is None:
+            self.message = "An internal compiler error happened and the "
+            "compilation failed."
+        else:
+            self.message = extra_msg
+        super().__init__(self.message)


### PR DESCRIPTION
Instead of reporting a command line with randomly generated filenames and exit code, returns an output (both stdout and stderr) from `dpcpp-llvm-spirv` tool. Uses numba style error.

Before:
```
numba_dpex/tests/kernel_tests/test_atomic_op.py:59:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
numba_dpex/core/kernel_interface/dispatcher.py:455: in __call__
    ) = self._compile_and_cache(
numba_dpex/core/kernel_interface/dispatcher.py:141: in _compile_and_cache
    kernel.compile(
numba_dpex/core/kernel_interface/spirv_kernel.py:171: in compile
    self._device_driver_ir_module = spirv_generator.llvm_to_spirv(
numba_dpex/spirv_generator.py:240: in llvm_to_spirv
    return mod.finalize()
numba_dpex/spirv_generator.py:179: in finalize
    self._cmd.generate(
numba_dpex/spirv_generator.py:92: in generate
    check_call([llvm_spirv_tool, *llvm_spirv_args, "-o", opath, ipath])
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

popenargs = (['/home/yevhenii/.miniconda3/envs/dpex-dev/lib/python3.11/site-packages/dpcpp_llvm_spirv/llvm-spirv', '-o', '/tmp/tmp0g4gxvhd/1-generated-spirv', '/tmp/tmp0g4gxvhd/0-llvm-friendly-spir'],)
kwargs = {}, retcode = 18
cmd = ['/home/yevhenii/.miniconda3/envs/dpex-dev/lib/python3.11/site-packages/dpcpp_llvm_spirv/llvm-spirv', '-o', '/tmp/tmp0g4gxvhd/1-generated-spirv', '/tmp/tmp0g4gxvhd/0-llvm-friendly-spir']

    def check_call(*popenargs, **kwargs):
        """Run command with arguments.  Wait for command to complete.  If
        the exit code was zero then return, otherwise raise
        CalledProcessError.  The CalledProcessError object will have the
        return code in the returncode attribute.

        The arguments are the same as for the call function.  Example:

        check_call(["ls", "-l"])
        """
        retcode = call(*popenargs, **kwargs)
        if retcode:
            cmd = kwargs.get("args")
            if cmd is None:
                cmd = popenargs[0]
>           raise CalledProcessError(retcode, cmd)
E           subprocess.CalledProcessError: Command '['/home/yevhenii/.miniconda3/envs/dpex-dev/lib/python3.11/site-packages/dpcpp_llvm_spirv/llvm-spirv', '-o', '/tmp/tmp0g4gxvhd/1-generated-spirv', '/tmp/tmp0g4gxvhd/0-llvm-friendly-spir']' returned non-zero exit status 18.

../../.miniconda3/envs/dpex-dev/lib/python3.11/subprocess.py:413: CalledProcessError
----------------------------------------------------------------------------------- Captured stderr call -----------------------------------------------------------------------------------
RequiresExtension: Feature requires the following SPIR-V extension:
 SPV_EXT_shader_atomic_float_add
```

After:
```
numba_dpex/tests/kernel_tests/test_atomic_op.py:59:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
numba_dpex/core/kernel_interface/dispatcher.py:455: in __call__
    ) = self._compile_and_cache(
numba_dpex/core/kernel_interface/dispatcher.py:141: in _compile_and_cache
    kernel.compile(
numba_dpex/core/kernel_interface/spirv_kernel.py:171: in compile
    self._device_driver_ir_module = spirv_generator.llvm_to_spirv(
numba_dpex/spirv_generator.py:239: in llvm_to_spirv
    return mod.finalize()
numba_dpex/spirv_generator.py:178: in finalize
    self._cmd.generate(
numba_dpex/spirv_generator.py:92: in generate
    run_cmd(
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

args = ['/home/yevhenii/.miniconda3/envs/dpex-dev/lib/python3.11/site-packages/dpcpp_llvm_spirv/llvm-spirv', '-o', '/tmp/tmpmb6y1kic/1-generated-spirv', '/tmp/tmpmb6y1kic/0-llvm-friendly-spir']
error_message = 'Error during lowering LLVM IR to SPIRV'

    def run_cmd(args, error_message=None):
        try:
            check_output(
                args,
                stderr=STDOUT,
            )
        except CalledProcessError as err:
            if error_message is None:
                error_message = f"Error during call to {args[0]}"
>           raise InternalError(
                f"{error_message}:\n\t"
                + "\t".join(err.output.decode("utf-8").splitlines(True))
            )
E           numba.core.errors.InternalError: Error during lowering LLVM IR to SPIRV:
E               RequiresExtension: Feature requires the following SPIR-V extension:
E                SPV_EXT_shader_atomic_float_add
E

numba_dpex/spirv_generator.py:33: InternalError
```


- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
