### PR TITLE
Overloads for an AtomicRef class and fetch_add method

### DIFF
--- a/numba_dpex/core/parfors/parfor_lowerer.py
+++ b/numba_dpex/core/parfors/parfor_lowerer.py
@@ -13,15 +13,15 @@ from numba.parfors.parfor import (
 )
 
 from numba_dpex import config
+from numba_dpex.core.datamodel.models import (
+    dpex_data_model_manager as kernel_dmm,
+)
 from numba_dpex.core.parfors.reduction_helper import (
     ReductionHelper,
     ReductionKernelVariables,
 )
 from numba_dpex.core.utils.kernel_launcher import KernelLaunchIRBuilder
 from numba_dpex.dpctl_iface import libsyclinterface_bindings as sycl
-from numba_dpex.core.datamodel.models import (
-    dpex_data_model_manager as kernel_dmm,
-)
 
 from ..exceptions import UnsupportedParforError
 from ..types.dpnp_ndarray_type import DpnpNdArray
@@ -30,7 +30,6 @@ from .reduction_kernel_builder import (
     create_reduction_main_kernel_for_parfor,
     create_reduction_remainder_kernel_for_parfor,
 )
-
 
 # A global list of kernels to keep the objects alive indefinitely.
 keep_alive_kernels = []

--- a/numba_dpex/core/types/dpctl_types.py
+++ b/numba_dpex/core/types/dpctl_types.py
@@ -23,7 +23,9 @@ class DpctlSyclQueue(types.Type):
         # XXX: Storing the device filter string is a temporary workaround till
         # the compute follows data inference pass is fixed to use SyclQueue
         self._device = sycl_queue.sycl_device.filter_string
-
+        self._device_has_aspect_atomic64 = (
+            sycl_queue.sycl_device.has_aspect_atomic64
+        )
         try:
             self._unique_id = hash(sycl_queue)
         except Exception:
@@ -48,13 +50,19 @@ class DpctlSyclQueue(types.Type):
         return self._device
 
     @property
+    def device_has_aspect_atomic64(self):
+        return self._device_has_aspect_atomic64
+
+    @property
     def key(self):
         """Returns a Python object used as the key to cache an instance of
         DpctlSyclQueue.
+
         The key is constructed by hashing the actual dpctl.SyclQueue object
         encapsulated by an instance of DpctlSyclQueue. Doing so ensures, that
         different dpctl.SyclQueue instances are inferred as separate instances
         of the DpctlSyclQueue type.
+
         Returns:
             int: hash of the self._sycl_queue Python object.
         """

--- a/numba_dpex/experimental/__init__.py
+++ b/numba_dpex/experimental/__init__.py
@@ -8,6 +8,7 @@ yet production ready.
 
 from numba.core.imputils import Registry
 
+from ._kernel_dpcpp_spirv_overloads import _atomic_ref_overloads
 from .decorators import device_func, kernel
 from .kernel_dispatcher import KernelDispatcher
 from .launcher import call_kernel, call_kernel_async

--- a/numba_dpex/experimental/_kernel_dpcpp_spirv_overloads/__init__.py
+++ b/numba_dpex/experimental/_kernel_dpcpp_spirv_overloads/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/numba_dpex/experimental/_kernel_dpcpp_spirv_overloads/_atomic_ref_overloads.py
+++ b/numba_dpex/experimental/_kernel_dpcpp_spirv_overloads/_atomic_ref_overloads.py
@@ -1,0 +1,296 @@
+# SPDX-FileCopyrightText: 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Implements the SPIR-V overloads for the kernel_api.atomic_ref class methods.
+"""
+
+from llvmlite import ir as llvmir
+from numba import errors
+from numba.core import cgutils, types
+from numba.extending import intrinsic, overload, overload_method
+
+from numba_dpex.core import itanium_mangler as ext_itanium_mangler
+from numba_dpex.core.targets.kernel_target import CC_SPIR_FUNC, LLVM_SPIRV_ARGS
+from numba_dpex.core.types import USMNdArray
+from numba_dpex.experimental.flag_enum import FlagEnum
+
+from ..dpcpp_types import AtomicRefType
+from ..kernel_iface import AddressSpace, AtomicRef, MemoryOrder, MemoryScope
+from ..target import DPEX_KERNEL_EXP_TARGET_NAME
+from ._spv_atomic_inst_helper import (
+    get_atomic_inst_name,
+    get_memory_semantics_mask,
+    get_scope,
+)
+
+
+def _parse_enum_or_int_literal_(literal_int) -> int:
+    """Parse an instance of an enum class or numba.core.types.Literal to its
+    actual int value.
+
+    Returns the Python int value for the numba Literal type.
+
+    Args:
+        literal_int: Instance of IntegerLiteral wrapping a Python int scalar
+        value
+    Raises:
+        TypingError: If the literal_int is not an IntegerLiteral type.
+    Returns:
+        int: The Python int value extracted from the literal_int.
+    """
+
+    if isinstance(literal_int, types.IntegerLiteral):
+        return literal_int.literal_value
+
+    if isinstance(literal_int, FlagEnum):
+        return literal_int.value
+
+    raise errors.TypingError("Could not parse input as an IntegerLiteral")
+
+
+def _intrinsic_helper(
+    ty_context, ty_atomic_ref, ty_val, op_str  # pylint: disable=unused-argument
+):
+    sig = types.void(ty_atomic_ref, ty_val)
+
+    def gen(context, builder, sig, args):
+        atomic_ref_ty = sig.args[0]
+        atomic_ref_dtype = atomic_ref_ty.dtype
+        retty = context.get_value_type(atomic_ref_dtype)
+
+        data_attr_pos = context.data_model_manager.lookup(
+            atomic_ref_ty
+        ).get_field_position("ref")
+
+        # TODO: evaluating the llvm-spirv flags that dpcpp uses
+        context.extra_compile_options[LLVM_SPIRV_ARGS] = [
+            "--spirv-ext=+SPV_EXT_shader_atomic_float_add"
+        ]
+
+        ptr_type = retty.as_pointer()
+        ptr_type.addrspace = atomic_ref_ty.address_space
+
+        spirv_fn_arg_types = [
+            ptr_type,
+            llvmir.IntType(32),
+            llvmir.IntType(32),
+            retty,
+        ]
+
+        mangled_fn_name = ext_itanium_mangler.mangle_ext(
+            get_atomic_inst_name(op_str, atomic_ref_dtype),
+            [
+                types.CPointer(
+                    atomic_ref_dtype, addrspace=atomic_ref_ty.address_space
+                ),
+                "__spv.Scope.Flag",
+                "__spv.MemorySemanticsMask.Flag",
+                atomic_ref_dtype,
+            ],
+        )
+        fn = cgutils.get_or_insert_function(
+            builder.module,
+            llvmir.FunctionType(retty, spirv_fn_arg_types),
+            mangled_fn_name,
+        )
+        fn.calling_convention = CC_SPIR_FUNC
+        spirv_memory_semantics_mask = get_memory_semantics_mask(
+            atomic_ref_ty.memory_order
+        )
+        spirv_scope = get_scope(atomic_ref_ty.memory_scope)
+
+        fn_args = [
+            builder.extract_value(args[0], data_attr_pos),
+            context.get_constant(types.int32, spirv_scope),
+            context.get_constant(types.int32, spirv_memory_semantics_mask),
+            args[1],
+        ]
+
+        builder.call(fn, fn_args)
+
+    return sig, gen
+
+
+@intrinsic(target=DPEX_KERNEL_EXP_TARGET_NAME)
+def _intrinsic_fetch_add(ty_context, ty_atomic_ref, ty_val):
+    return _intrinsic_helper(ty_context, ty_atomic_ref, ty_val, "fetch_add")
+
+
+@intrinsic(target=DPEX_KERNEL_EXP_TARGET_NAME)
+def _intrinsic_atomic_ref_ctor(
+    ty_context, ref, ty_index, ty_retty_ref  # pylint: disable=unused-argument
+):
+    ty_retty = ty_retty_ref.instance_type
+    sig = ty_retty(ref, ty_index, ty_retty_ref)
+
+    def codegen(context, builder, sig, args):
+        ref = args[0]
+        index_pos = args[1]
+
+        dmm = context.data_model_manager
+        data_attr_pos = dmm.lookup(sig.args[0]).get_field_position("data")
+        data_attr = builder.extract_value(ref, data_attr_pos)
+
+        with builder.goto_entry_block():
+            ptr_to_data_attr = builder.alloca(data_attr.type)
+        builder.store(data_attr, ptr_to_data_attr)
+        ref_ptr_value = builder.gep(builder.load(ptr_to_data_attr), [index_pos])
+
+        atomic_ref_struct = cgutils.create_struct_proxy(ty_retty)(
+            context, builder
+        )
+        ref_attr_pos = dmm.lookup(ty_retty).get_field_position("ref")
+        atomic_ref_struct[ref_attr_pos] = ref_ptr_value
+        # pylint: disable=protected-access
+        return atomic_ref_struct._getvalue()
+
+    return (
+        sig,
+        codegen,
+    )
+
+
+def _check_if_supported_ref(ref):
+    supported = True
+
+    if not isinstance(ref, USMNdArray):
+        raise errors.TypingError(
+            f"Cannot create an AtomicRef from {ref}. "
+            "An AtomicRef can only be constructed from a 0-dimensional "
+            "dpctl.tensor.usm_ndarray or a dpnp.ndarray array."
+        )
+    if ref.dtype not in [
+        types.int32,
+        types.uint32,
+        types.float32,
+        types.int64,
+        types.uint64,
+        types.float64,
+    ]:
+        raise errors.TypingError(
+            "Cannot create an AtomicRef from a tensor with an unsupported "
+            "element type."
+        )
+    if ref.dtype in [types.int64, types.float64, types.uint64]:
+        if not ref.queue.device_has_aspect_atomic64:
+            raise errors.TypingError(
+                "Targeted device does not support 64-bit atomic operations."
+            )
+
+    return supported
+
+
+@overload(
+    AtomicRef,
+    prefer_literal=True,
+    target=DPEX_KERNEL_EXP_TARGET_NAME,
+)
+def ol_atomic_ref(
+    ref,
+    index=0,
+    memory_order=MemoryOrder.RELAXED,
+    memory_scope=MemoryScope.DEVICE,
+    address_space=AddressSpace.GLOBAL,
+):
+    """Overload of the constructor for the class
+    class:`numba_dpex.experimental.kernel_iface.AtomicRef`.
+
+    Raises:
+        errors.TypingError: If the `ref` argument is not a UsmNdArray type.
+        errors.TypingError: If the dtype of the `ref` is not supported in an
+        AtomicRef.
+        errors.TypingError: If the device does not support atomic operations on
+        the dtype of the `ref`.
+        errors.TypingError: If the `memory_order`, `address_type`, or
+        `memory_scope` arguments could not be parsed as integer literals.
+        errors.TypingError: If the `address_space` argument is different from
+        the address space attribute of the `ref` argument.
+        errors.TypingError: If the address space is PRIVATE.
+
+    """
+    _check_if_supported_ref(ref)
+
+    try:
+        _address_space = _parse_enum_or_int_literal_(address_space)
+    except errors.TypingError as exc:
+        raise errors.TypingError(
+            "Address space argument to AtomicRef constructor should "
+            "be an IntegerLiteral."
+        ) from exc
+
+    try:
+        _memory_order = _parse_enum_or_int_literal_(memory_order)
+    except errors.TypingError as exc:
+        raise errors.TypingError(
+            "Memory order argument to AtomicRef constructor should "
+            "be an IntegerLiteral."
+        ) from exc
+
+    try:
+        _memory_scope = _parse_enum_or_int_literal_(memory_scope)
+    except errors.TypingError as exc:
+        raise errors.TypingError(
+            "Memory scope argument to AtomicRef constructor should "
+            "be an IntegerLiteral."
+        ) from exc
+
+    if _address_space != ref.addrspace:
+        raise errors.TypingError(
+            "The address_space specified via the AtomicRef constructor "
+            f"{_address_space} does not match the address space "
+            f"{ref.addrspace} of the referred object for which the AtomicRef "
+            "is to be constructed."
+        )
+
+    if _address_space == AddressSpace.PRIVATE:
+        raise errors.TypingError(
+            f"Unsupported address space value {_address_space}. Supported "
+            f"address space values are: Generic ({AddressSpace.GENERIC}), "
+            f"Global ({AddressSpace.GLOBAL}), and Local ({AddressSpace.LOCAL})."
+        )
+
+    ty_retty = AtomicRefType(
+        dtype=ref.dtype,
+        memory_order=_memory_order,
+        memory_scope=_memory_scope,
+        address_space=_address_space,
+    )
+
+    def ol_atomic_ref_ctor_impl(
+        ref,
+        index=0,
+        memory_order=MemoryOrder.RELAXED,  # pylint: disable=unused-argument
+        memory_scope=MemoryScope.DEVICE,  # pylint: disable=unused-argument
+        address_space=AddressSpace.GLOBAL,  # pylint: disable=unused-argument
+    ):
+        # pylint: disable=no-value-for-parameter
+        return _intrinsic_atomic_ref_ctor(ref, index, ty_retty)
+
+    return ol_atomic_ref_ctor_impl
+
+
+@overload_method(AtomicRefType, "fetch_add", target=DPEX_KERNEL_EXP_TARGET_NAME)
+def ol_fetch_add(atomic_ref, val):
+    """SPIR-V overload for
+    :meth:`numba_dpex.experimental.kernel_iface.AtomicRef.fetch_add`.
+
+    Generates the same LLVM IR instruction as dpcpp for the
+    `atomic_ref::fetch_add` function.
+
+    Raises:
+        TypingError: When the dtype of the aggregator value does not match the
+        dtype of the AtomicRef type.
+    """
+    if atomic_ref.dtype != val:
+        raise errors.TypingError(
+            f"Type of value to add: {val} does not match the type of the "
+            f"reference: {atomic_ref.dtype} stored in the atomic ref."
+        )
+
+    def ol_fetch_add_impl(atomic_ref, val):
+        # pylint: disable=no-value-for-parameter
+        return _intrinsic_fetch_add(atomic_ref, val)
+
+    return ol_fetch_add_impl

--- a/numba_dpex/experimental/_kernel_dpcpp_spirv_overloads/_spv_atomic_inst_helper.py
+++ b/numba_dpex/experimental/_kernel_dpcpp_spirv_overloads/_spv_atomic_inst_helper.py
@@ -1,0 +1,170 @@
+# SPDX-FileCopyrightText: 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Helper module to generate LLVM IR SPIR-V intrinsic calls.
+"""
+from enum import IntEnum
+
+from numba.core import types
+
+from ..kernel_iface import MemoryOrder, MemoryScope
+
+
+class _SpvScope(IntEnum):
+    """
+    An enumeration to store the dpcpp values for SPIR-V memory scope.
+    """
+
+    CROSS_DEVICE = 0
+    DEVICE = 1
+    WORKGROUP = 2
+    SUBGROUP = 3
+    INVOCATION = 4
+
+
+class _SpvMemorySemanticsMask(IntEnum):
+    """
+    An enumeration to store the dpcpp values for SPIR-V mask.
+
+    """
+
+    NONE = 0x0
+    ACQUIRE = 0x2
+    RELEASE = 0x4
+    ACQUIRE_RELEASE = 0x8
+    SEQUENTIALLY_CONSISTENT = 0x10
+    UNIFORM_MEMORY = 0x40
+    SUBGROUP_MEMORY = 0x80
+    WORKGROUP_MEMORY = 0x100
+    CROSS_WORKGROUP_MEMORY = 0x200
+    ATOMIC_COUNTER_MEMORY = 0x400
+    IMAGE_MEMORY = 0x800
+
+
+_spv_atomic_instructions_map = {
+    "fetch_add": {
+        types.int32: "__spirv_AtomicIAdd",
+        types.int64: "__spirv_AtomicIAdd",
+        types.float32: "__spirv_AtomicFAddEXT",
+        types.float64: "__spirv_AtomicFAddEXT",
+    },
+    "fetch_sub": {
+        types.int32: "__spirv_AtomicISub",
+        types.int64: "__spirv_AtomicISub",
+        types.float32: "__spirv_AtomicFSubEXT",
+        types.float64: "__spirv_AtomicFSubEXT",
+    },
+    "fetch_min": {
+        types.int32: "__spirv_AtomicSMin",
+        types.int64: "__spirv_AtomicSMin",
+        types.float32: "__spirv_AtomicFMinEXT",
+        types.float64: "__spirv_AtomicFMinEXT",
+    },
+    "fetch_max": {
+        types.int32: "__spirv_AtomicSMax",
+        types.int64: "__spirv_AtomicSMax",
+        types.float32: "__spirv_AtomicFMaxEXT",
+        types.float64: "__spirv_AtomicFMaxEXT",
+    },
+    "fetch_and": {
+        types.int32: "__spirv_AtomicAnd",
+        types.int64: "__spirv_AtomicAnd",
+    },
+    "fetch_or": {
+        types.int32: "__spirv_AtomicOr",
+        types.int64: "__spirv_AtomicOr",
+    },
+    "fetch_xor": {
+        types.int32: "__spirv_AtomicXor",
+        types.int64: "__spirv_AtomicXor",
+    },
+}
+
+
+def get_atomic_inst_name(atomic_inst: str, atomic_ref_dtype: types.Type) -> str:
+    """Returns a string corresponding to the LLVM IR intrinsic function
+    generated for a particular atomic operation for a specific data type.
+
+    Args:
+        atomic_inst (str): The string name of an atomic operation to look up.
+        atomic_ref_dtype (numba.core.types.Type): The Numba type object
+        corresponding to the dtype of the object stored in an AtomicRef.
+
+    Raises:
+        ValueError: If the atomic operation is not found in the
+        ``_spv_atomic_instructions_map`` dictionary.
+        ValueError: If no instruction is found for a combination of the
+        atomic operation and the dtype in the ``_spv_atomic_instructions_map``
+        dictionary.
+
+    Returns:
+        str: A string corresponding to the LLVM IR intrinsic that should be
+        generated for the atomic operation for the specified dtype.
+    """
+    inst_ref_types_map = _spv_atomic_instructions_map.get(atomic_inst)
+    if inst_ref_types_map is None:
+        raise ValueError("Unsupported atomic instruction")
+
+    inst_name = inst_ref_types_map.get(atomic_ref_dtype)
+
+    if inst_name is None:
+        raise ValueError(
+            "Unsupported atomic reference type for instruction " + atomic_inst
+        )
+    return inst_name
+
+
+def get_memory_semantics_mask(memory_order):
+    """
+    Equivalent of the getMemorySemanticsMask function in dpcpp's
+    sycl/include/sycl/detail/spirv.hpp.  Translates SYCL memory order to a
+    SPIR-V  memory semantics mask.
+
+    """
+
+    spv_order = _SpvMemorySemanticsMask.NONE.value
+
+    if memory_order == MemoryOrder.RELAXED.value:
+        spv_order = _SpvMemorySemanticsMask.NONE.value
+    elif memory_order == MemoryOrder.CONSUME_UNSUPPORTED.value:
+        pass
+    elif memory_order == MemoryOrder.ACQUIRE.value:
+        spv_order = _SpvMemorySemanticsMask.ACQUIRE.value
+    elif memory_order == MemoryOrder.RELEASE.value:
+        spv_order = _SpvMemorySemanticsMask.RELEASE.value
+    elif memory_order == MemoryOrder.ACQ_REL.value:
+        spv_order = _SpvMemorySemanticsMask.ACQUIRE_RELEASE.value
+    elif memory_order == MemoryOrder.SEQ_CST.value:
+        spv_order = _SpvMemorySemanticsMask.SEQUENTIALLY_CONSISTENT.value
+    else:
+        raise ValueError("Invalid memory order provided")
+
+    return (
+        spv_order
+        | _SpvMemorySemanticsMask.SUBGROUP_MEMORY.value
+        | _SpvMemorySemanticsMask.WORKGROUP_MEMORY.value
+        | _SpvMemorySemanticsMask.CROSS_WORKGROUP_MEMORY.value
+    )
+
+
+def get_scope(memory_scope):
+    """
+    Translates a memory scope enum value to an equivalent SPIR-V memory scope
+    value.
+    """
+    retval = None
+    if memory_scope == MemoryScope.WORK_ITEM.value:
+        retval = _SpvScope.INVOCATION.value
+    elif memory_scope == MemoryScope.SUB_GROUP.value:
+        retval = _SpvScope.SUBGROUP.value
+    elif memory_scope == MemoryScope.WORK_GROUP.value:
+        retval = _SpvScope.WORKGROUP.value
+    elif memory_scope == MemoryScope.DEVICE.value:
+        retval = _SpvScope.DEVICE.value
+    elif memory_scope == MemoryScope.SYSTEM.value:
+        retval = _SpvScope.CROSS_DEVICE.value
+    else:
+        raise ValueError("Invalid memory scope provided")
+
+    return retval

--- a/numba_dpex/experimental/dpcpp_types.py
+++ b/numba_dpex/experimental/dpcpp_types.py
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Collection of numba-dpex typing classes for kernel_iface Python classes.
+"""
+
+from numba.core.types import Type
+
+
+class AtomicRefType(Type):
+    """numba-dpex internal type to represent a Python object of
+    :class:`numba_dpex.experimental.kernel_iface.AtomicRef`.
+    """
+
+    def __init__(
+        self,
+        dtype: Type,
+        memory_order: int,
+        memory_scope: int,
+        address_space: int,
+    ):
+        """Creates an instance of the AtomicRefType representing a Python
+        AtomicRef object.
+        """
+        self._dtype = dtype
+        self._memory_order = memory_order
+        self._memory_scope = memory_scope
+        self._address_space = address_space
+        name = (
+            f"AtomicRef< {self._dtype}, "
+            f"memory_order= {self._memory_order}, "
+            f"memory_scope= {self._memory_scope}, "
+            f"address_space= {self._address_space}>"
+        )
+        super().__init__(name=name)
+
+    @property
+    def memory_order(self) -> int:
+        """Returns the integer value for a memory order that corresponds to
+        kernel_iface.MemoryOrder.
+        """
+        return self._memory_order
+
+    @property
+    def memory_scope(self) -> int:
+        """Returns the integer value for a memory order that corresponds to
+        kernel_iface.MemoryScope.
+        """
+        return self._memory_scope
+
+    @property
+    def address_space(self) -> int:
+        """Returns the integer value for a memory order that corresponds to
+        kernel_iface.AddressSpace.
+        """
+        return self._address_space
+
+    @property
+    def dtype(self):
+        """Returns the Numba type of the object corresponding to the value
+        stored in an AtomicRef.
+        """
+        return self._dtype
+
+    @property
+    def key(self):
+        """
+        A property used for __eq__, __ne__ and __hash__.
+        """
+        return (
+            self.dtype,
+            self.memory_order,
+            self.memory_scope,
+            self.address_space,
+        )
+
+    def cast_python_value(self, args):
+        """The helper function is not overloaded and using it on the
+        AtomicRefType throws a NotImplementedError.
+        """
+        raise NotImplementedError

--- a/numba_dpex/experimental/kernel_iface/__init__.py
+++ b/numba_dpex/experimental/kernel_iface/__init__.py
@@ -8,6 +8,7 @@ prototyping SYCL-like kernels in pure Python before compiling them using
 numba_dpex.kernel.
 """
 
+from .atomic_ref import AtomicRef
 from .memory_enums import AddressSpace, MemoryOrder, MemoryScope
 
-__all__ = ["AddressSpace", "MemoryOrder", "MemoryScope"]
+__all__ = ["AddressSpace", "AtomicRef", "MemoryOrder", "MemoryScope"]

--- a/numba_dpex/experimental/kernel_iface/atomic_ref.py
+++ b/numba_dpex/experimental/kernel_iface/atomic_ref.py
@@ -1,0 +1,169 @@
+# SPDX-FileCopyrightText: 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Implements a mock Python class to represent ``sycl::atomic_ref`` for
+prototyping numba_dpex kernel functions before they are JIT compiled.
+"""
+
+from .memory_enums import AddressSpace, MemoryOrder, MemoryScope
+
+
+class AtomicRef:
+    """Analogue to the ``sycl::atomic_ref`` type. An atomic reference is a
+    view into a data container that can be then updated atomically using any of
+    the ``fetch_*`` member functions of the class.
+    """
+
+    def __init__(  # pylint: disable=too-many-arguments
+        self,
+        ref,
+        index=0,
+        memory_order=MemoryOrder.RELAXED,
+        memory_scope=MemoryScope.DEVICE,
+        address_space=AddressSpace.GLOBAL,
+    ):
+        """A Python stub to represent a SYCL AtomicRef class. An AtomicRef
+        object represents a single element view into a Python array-like object
+        that can be then updated using various fetch_* type functions.
+
+        To maintain analogy with SYCL's API, the AtomicRef constructor takes
+        optional ``memory_order``, ``memory_scope``, and ``address_space``
+        arguments that are ignored in Python execution.
+        """
+        self._memory_order = memory_order
+        self._memory_scope = memory_scope
+        self._address_space = address_space
+        self._ref = ref
+        self._index = index
+
+    @property
+    def ref(self):
+        """Returns the value stored in the AtomicRef._ref[_index]."""
+        return self._ref[self._index]
+
+    @property
+    def memory_order(self) -> MemoryOrder:
+        """Returns the MemoryOrder value used to define the AtomicRef."""
+        return self._memory_order
+
+    @property
+    def memory_scope(self) -> MemoryScope:
+        """Returns the MemoryScope value used to define the AtomicRef."""
+        return self._memory_scope
+
+    @property
+    def address_space(self) -> AddressSpace:
+        """Returns the AddressSpace value used to define the AtomicRef."""
+        return self._address_space
+
+    def fetch_add(self, val):
+        """Adds the operand ``val`` to the object referenced by the AtomicRef
+        and assigns the result to the value of the referenced object. Returns
+        the original value of the object.
+
+        Args:
+            val : Value to be added to the object referenced by the AtomicRef.
+
+        Returns: The original value of the object referenced by the AtomicRef.
+
+        """
+        old = self._ref[self._index]
+        self._ref[self._index] += val
+        return old
+
+    def fetch_sub(self, val):
+        """Subtracts the operand ``val`` to the object referenced by the
+        AtomicRef and assigns the result to the value of the referenced object.
+        Returns the original value of the object.
+
+        Args:
+            val : Value to be subtracted to the object referenced by the
+            AtomicRef.
+
+        Returns: The original value of the object referenced by the AtomicRef.
+
+        """
+        old = self._ref[self._index]
+        self._ref[self._index] -= val
+        return old
+
+    def fetch_min(self, val):
+        """Calculates the minimum value of the operand ``val`` and the object
+        referenced by the AtomicRef and assigns the result to the value of the
+        referenced object. Returns the original value of the object.
+
+        Args:
+            val : Value to be compared against to the object referenced by the
+            AtomicRef.
+
+        Returns: The original value of the object referenced by the AtomicRef.
+
+        """
+        old = self._ref[self._index]
+        self._ref[self._index] = min(old, val)
+        return old
+
+    def fetch_max(self, val):
+        """Calculates the maximum value of the operand ``val`` and the object
+        referenced by the AtomicRef and assigns the result to the value of the
+        referenced object. Returns the original value of the object.
+
+        Args:
+            val : Value to be compared against to the object referenced by the
+            AtomicRef.
+
+        Returns: The original value of the object referenced by the AtomicRef.
+
+        """
+        old = self._ref[self._index]
+        self._ref[self._index] = max(old, val)
+        return old
+
+    def fetch_and(self, val):
+        """Calculates the bitwise AND of the operand ``val`` and the object
+        referenced by the AtomicRef and assigns the result to the value of the
+        referenced object. Returns the original value of the object.
+
+        Args:
+            val : Value to be bitwise ANDed against to the object referenced by
+            the AtomicRef.
+
+        Returns: The original value of the object referenced by the AtomicRef.
+
+        """
+        old = self._ref[self._index]
+        self._ref[self._index] &= val
+        return old
+
+    def fetch_or(self, val):
+        """Calculates the bitwise OR of the operand ``val`` and the object
+        referenced by the AtomicRef and assigns the result to the value of the
+        referenced object. Returns the original value of the object.
+
+        Args:
+            val : Value to be bitwise ORed against to the object referenced by
+            the AtomicRef.
+
+        Returns: The original value of the object referenced by the AtomicRef.
+
+        """
+        old = self._ref[self._index]
+        self._ref[self._index] |= val
+        return old
+
+    def fetch_xor(self, val):
+        """Calculates the bitwise XOR of the operand ``val`` and the object
+        referenced by the AtomicRef and assigns the result to the value of the
+        referenced object. Returns the original value of the object.
+
+        Args:
+            val : Value to be bitwise XORed against to the object referenced by
+            the AtomicRef.
+
+        Returns: The original value of the object referenced by the AtomicRef.
+
+        """
+        old = self._ref[self._index]
+        self._ref[self._index] ^= val
+        return old

--- a/numba_dpex/experimental/launcher.py
+++ b/numba_dpex/experimental/launcher.py
@@ -22,7 +22,10 @@ from numba_dpex.core.types import DpctlSyclEvent, NdRangeType, RangeType
 from numba_dpex.core.utils import kernel_launcher as kl
 from numba_dpex.dpctl_iface import libsyclinterface_bindings as sycl
 from numba_dpex.dpctl_iface.wrappers import wrap_event_reference
-from numba_dpex.experimental.kernel_dispatcher import KernelDispatcher
+from numba_dpex.experimental.kernel_dispatcher import (
+    KernelDispatcher,
+    _KernelCompileResult,
+)
 
 
 class LLRange(NamedTuple):
@@ -130,9 +133,10 @@ def _submit_kernel(  # pylint: disable=too-many-arguments
     # directly from type and compile it. Thats why we don't need to get it in
     # codegen
     kernel_dispatcher: KernelDispatcher = ty_kernel_fn.dispatcher
-    kernel_module: kl.SPIRVKernelModule = kernel_dispatcher.get_compile_result(
+    kcres: _KernelCompileResult = kernel_dispatcher.get_compile_result(
         kernel_sig
-    ).kernel_device_ir_module
+    )
+    kernel_module: kl.SPIRVKernelModule = kcres.kernel_device_ir_module
     kernel_targetctx: DpexKernelTargetContext = kernel_dispatcher.targetctx
 
     def codegen(

--- a/numba_dpex/experimental/models.py
+++ b/numba_dpex/experimental/models.py
@@ -7,14 +7,29 @@ numba_dpex.experimental module.
 """
 
 from llvmlite import ir as llvmir
+from numba.core import types
 from numba.core.datamodel import DataModelManager, models
-from numba.core.datamodel.models import PrimitiveModel
+from numba.core.datamodel.models import PrimitiveModel, StructModel
 from numba.core.extending import register_model
 
 import numba_dpex.core.datamodel.models as dpex_core_models
 
+from .dpcpp_types import AtomicRefType
 from .literal_intenum_type import IntEnumLiteral
 from .types import KernelDispatcherType
+
+
+class AtomicRefModel(StructModel):
+    """Data model for AtomicRefType."""
+
+    def __init__(self, dmm, fe_type):
+        members = [
+            (
+                "ref",
+                types.CPointer(fe_type.dtype, addrspace=fe_type.address_space),
+            ),
+        ]
+        super().__init__(dmm, fe_type, members)
 
 
 class IntEnumLiteralModel(PrimitiveModel):
@@ -43,6 +58,7 @@ def _init_exp_data_model_manager() -> DataModelManager:
 
     # Register the types and data model in the DpexExpTargetContext
     dmm.register(IntEnumLiteral, IntEnumLiteralModel)
+    dmm.register(AtomicRefType, AtomicRefModel)
 
     return dmm
 

--- a/numba_dpex/experimental/typeof.py
+++ b/numba_dpex/experimental/typeof.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Adds typeof implementations to Numba registry for all numba-dpex experimental
+types.
+
+"""
+
+from numba.extending import typeof_impl
+
+from .dpcpp_types import AtomicRefType
+from .kernel_iface import AtomicRef
+
+
+@typeof_impl.register(AtomicRef)
+def typeof_atomic_ref(val: AtomicRef, c) -> AtomicRefType:
+    """Returns a ``numba_dpex.experimental.dpctpp_types.AtomicRefType``
+    instance for a Python AtomicRef object.
+
+    Args:
+        val (AtomicRef): Instance of the AtomicRef type.
+        c : Numba typing context used for type inference.
+
+    Returns: AtomicRefType object corresponding to the AtomicRef object.
+
+    """
+    dtype = typeof_impl(val.ref, c)
+
+    return AtomicRefType(
+        dtype=dtype,
+        memory_order=val.memory_order.value,
+        memory_scope=val.memory_scope.value,
+        address_space=val.address_space.value,
+    )

--- a/numba_dpex/spirv_generator.py
+++ b/numba_dpex/spirv_generator.py
@@ -156,7 +156,10 @@ class Module(object):
         # Generate SPIR-V from "friendly" LLVM-based SPIR 2.0
         spirv_path = self._track_temp_file("generated-spirv")
 
-        llvm_spirv_args = []
+        # TODO: find better approach to set SPIRV compiler arguments. Workaround
+        #  against caching intrinsic that sets this argument.
+        # https://github.com/IntelPython/numba-dpex/issues/1262
+        llvm_spirv_args = ["--spirv-ext=+SPV_EXT_shader_atomic_float_add"]
         for key in list(self.context.extra_compile_options.keys()):
             if key == LLVM_SPIRV_ARGS:
                 llvm_spirv_args = self.context.extra_compile_options[key]

--- a/numba_dpex/tests/experimental/kernel_iface/spv_overloads/__init__.py
+++ b/numba_dpex/tests/experimental/kernel_iface/spv_overloads/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/numba_dpex/tests/experimental/kernel_iface/spv_overloads/test_atomic_fetch_phi.py
+++ b/numba_dpex/tests/experimental/kernel_iface/spv_overloads/test_atomic_fetch_phi.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import dpnp
+import pytest
+
+import numba_dpex as dpex
+import numba_dpex.experimental as dpex_exp
+from numba_dpex.experimental.kernel_iface import AtomicRef
+from numba_dpex.tests._helper import get_all_dtypes
+
+list_of_supported_dtypes = get_all_dtypes(
+    no_bool=True, no_float16=True, no_none=True, no_complex=True
+)
+
+
+@pytest.fixture(params=list_of_supported_dtypes)
+def input_arrays(request):
+    # The size of input and out arrays to be used
+    N = 10
+    a = dpnp.ones(N, dtype=request.param)
+    b = dpnp.zeros(N, dtype=request.param)
+    return a, b
+
+
+@pytest.mark.parametrize("ref_index", [0, 5])
+def test_fetch_add(input_arrays, ref_index):
+    @dpex_exp.kernel
+    def atomic_ref_kernel(a, b, ref_index):
+        i = dpex.get_global_id(0)
+        v = AtomicRef(b, index=ref_index)
+        v.fetch_add(a[i])
+
+    a, b = input_arrays
+
+    dpex_exp.call_kernel(atomic_ref_kernel, dpex.Range(10), a, b, ref_index)
+
+    # Verify that `a` was accumulated at b[ref_index]
+    assert b[ref_index] == 10

--- a/numba_dpex/tests/experimental/kernel_iface/spv_overloads/test_atomic_ref.py
+++ b/numba_dpex/tests/experimental/kernel_iface/spv_overloads/test_atomic_ref.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import dpnp
+import pytest
+from numba.core.errors import TypingError
+
+import numba_dpex as dpex
+import numba_dpex.experimental as dpex_exp
+from numba_dpex.experimental.kernel_iface import AddressSpace, AtomicRef
+
+
+def test_atomic_ref_compilation():
+    @dpex_exp.kernel
+    def atomic_ref_kernel(a, b):
+        i = dpex.get_global_id(0)
+        v = AtomicRef(b, index=0, address_space=AddressSpace.GLOBAL)
+        v.fetch_add(a[i])
+
+    a = dpnp.ones(10)
+    b = dpnp.zeros(10)
+    try:
+        dpex_exp.call_kernel(atomic_ref_kernel, dpex.Range(10), a, b)
+    except Exception:
+        pytest.fail("Unexpected execution failure")
+
+
+def test_atomic_ref_compilation_failure():
+    """A negative test that verifies that a TypingError is raised if we try to
+    create an AtomicRef in the local address space from a global address space
+    ref.
+    """
+
+    @dpex_exp.kernel
+    def atomic_ref_kernel(a, b):
+        i = dpex.get_global_id(0)
+        v = AtomicRef(b, index=0, address_space=AddressSpace.LOCAL)
+        v.fetch_add(a[i])
+
+    a = dpnp.ones(10)
+    b = dpnp.zeros(10)
+
+    with pytest.raises(TypingError):
+        dpex_exp.call_kernel(atomic_ref_kernel, dpex.Range(10), a, b)


### PR DESCRIPTION
- [X] Have you provided a meaningful PR description?

Adds a new `AtomicRef` class to the experimental `kernel_iface` module to mimic `sycl::atomic_ref` class. The class includes Python functions to simulate the atomic `fetch_*` functions in SYCL.

The `AtomicRef` class is also overloaded and an overloaded implementation is provided for the class constructor and the `fetch_add` method was also added.

UPD: one bug was introduced/discovered along with a workaround: https://github.com/IntelPython/numba-dpex/issues/1262

- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
