### PR TITLE
Add eager experimental kernel compilation

### DIFF
--- a/numba_dpex/experimental/launcher.py
+++ b/numba_dpex/experimental/launcher.py
@@ -130,8 +130,7 @@ def _submit_kernel(  # pylint: disable=too-many-arguments
     # directly from type and compile it. Thats why we don't need to get it in
     # codegen
     kernel_dispatcher: KernelDispatcher = ty_kernel_fn.dispatcher
-    kernel_dispatcher.compile(kernel_sig)
-    kernel_module: kl.SPIRVKernelModule = kernel_dispatcher.get_overload_kcres(
+    kernel_module: kl.SPIRVKernelModule = kernel_dispatcher.get_compile_result(
         kernel_sig
     ).kernel_device_ir_module
     kernel_targetctx: DpexKernelTargetContext = kernel_dispatcher.targetctx

--- a/numba_dpex/tests/experimental/test_kernel_specialization.py
+++ b/numba_dpex/tests/experimental/test_kernel_specialization.py
@@ -1,0 +1,101 @@
+# SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import dpctl.tensor as dpt
+import dpnp
+import pytest
+from numba.core.errors import TypingError
+
+import numba_dpex as dpex
+import numba_dpex.experimental as dpex_exp
+from numba_dpex import DpnpNdArray, float32, int64
+from numba_dpex.core.exceptions import InvalidKernelSpecializationError
+from numba_dpex.core.kernel_interface.indexers import Range
+
+i64arrty = DpnpNdArray(ndim=1, dtype=int64, layout="C")
+f32arrty = DpnpNdArray(ndim=1, dtype=float32, layout="C")
+
+specialized_kernel1 = dpex_exp.kernel((i64arrty, i64arrty, i64arrty))
+specialized_kernel2 = dpex_exp.kernel(
+    [(i64arrty, i64arrty, i64arrty), (f32arrty, f32arrty, f32arrty)]
+)
+
+
+def data_parallel_sum(a, b, c):
+    """
+    Vector addition using the ``kernel`` decorator.
+    """
+    i = dpex.get_global_id(0)
+    c[i] = a[i] + b[i]
+
+
+def test_single_specialization():
+    """Test if a kernel can be specialized with a single signature."""
+    jitkernel = specialized_kernel1(data_parallel_sum)
+    assert len(jitkernel.overloads) == 1
+
+
+def test_multiple_specialization():
+    """Test if a kernel can be specialized with multiple signatures."""
+    jitkernel = specialized_kernel2(data_parallel_sum)
+    assert len(jitkernel.overloads) == 2
+
+
+def test_invalid_specialization_error():
+    """Test if an InvalidKernelSpecializationError is raised when attempting to
+    specialize with NumPy arrays.
+    """
+    specialized_kernel3 = dpex_exp.kernel((int64[::1], int64[::1], int64[::1]))
+    with pytest.raises(InvalidKernelSpecializationError):
+        specialized_kernel3(data_parallel_sum)
+
+
+def test_missing_specialization_error():
+    """Test if a MissingSpecializationError is raised when calling a
+    specialized kernel with unsupported arguments.
+    """
+    SIZE = 16
+    a = dpnp.ones(SIZE, dtype=dpt.int32)
+    b = dpnp.ones(SIZE, dtype=dpt.int32)
+    c = dpnp.zeros(SIZE, dtype=dpt.int32)
+
+    with pytest.raises(TypingError):
+        data_parallel_sum_specialized = specialized_kernel1(data_parallel_sum)
+        dpex_exp.call_kernel(
+            data_parallel_sum_specialized, Range(SIZE), a, b, c
+        )
+
+
+def test_execution_of_specialized_kernel():
+    """Test if the specialized kernel is correctly executed."""
+    SIZE = 16
+
+    a = dpnp.ones(SIZE, dtype=dpt.int64)
+    b = dpnp.ones(SIZE, dtype=dpt.int64)
+    c = dpnp.zeros(SIZE, dtype=dpt.int64)
+
+    data_parallel_sum_specialized = specialized_kernel1(data_parallel_sum)
+
+    dpex_exp.call_kernel(data_parallel_sum_specialized, Range(SIZE), a, b, c)
+
+    npc = dpnp.asnumpy(c)
+    import numpy as np
+
+    npc_expected = np.full(SIZE, 2, dtype=np.int64)
+    assert np.array_equal(npc, npc_expected)
+
+
+def test_string_specialization():
+    """Test if NotImplementedError is raised when signature is a string"""
+
+    with pytest.raises(NotImplementedError):
+        dpex_exp.kernel("(i64arrty, i64arrty, i64arrty)")
+
+    with pytest.raises(NotImplementedError):
+        dpex_exp.kernel(
+            ["(i64arrty, i64arrty, i64arrty)", "(f32arrty, f32arrty, f32arrty)"]
+        )
+
+    with pytest.raises(ValueError):
+        dpex_exp.kernel((i64arrty))


### PR DESCRIPTION
- Add support for eager compilation for experimental kernel by providing type signature.
- Test cases where taken from kernel and adopted for experimental kernel style call. During this process it was discovered that experimental kernel can't work with dpctl tensors as arguments.
- Some code from kernel was adopted to experimental kernel

Checklist
- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
