### PR TITLE
Adds all fetch_* SPIR-V overload to experimental

### DIFF
--- a/numba_dpex/spirv_generator.py
+++ b/numba_dpex/spirv_generator.py
@@ -159,7 +159,10 @@ class Module(object):
         # TODO: find better approach to set SPIRV compiler arguments. Workaround
         #  against caching intrinsic that sets this argument.
         # https://github.com/IntelPython/numba-dpex/issues/1262
-        llvm_spirv_args = ["--spirv-ext=+SPV_EXT_shader_atomic_float_add"]
+        llvm_spirv_args = [
+            "--spirv-ext=+SPV_EXT_shader_atomic_float_add",
+            "--spirv-ext=+SPV_EXT_shader_atomic_float_min_max",
+        ]
         for key in list(self.context.extra_compile_options.keys()):
             if key == LLVM_SPIRV_ARGS:
                 llvm_spirv_args = self.context.extra_compile_options[key]

--- a/numba_dpex/tests/experimental/kernel_iface/spv_overloads/test_atomic_fetch_phi.py
+++ b/numba_dpex/tests/experimental/kernel_iface/spv_overloads/test_atomic_fetch_phi.py
@@ -4,6 +4,7 @@
 
 import dpnp
 import pytest
+from numba.core.errors import TypingError
 
 import numba_dpex as dpex
 import numba_dpex.experimental as dpex_exp
@@ -14,30 +15,80 @@ list_of_supported_dtypes = get_all_dtypes(
     no_bool=True, no_float16=True, no_none=True, no_complex=True
 )
 
+list_of_fetch_phi_funcs = [
+    "fetch_add",
+    "fetch_sub",
+    "fetch_min",
+    "fetch_max",
+    "fetch_and",
+    "fetch_or",
+    "fetch_xor",
+]
+
+
+@pytest.fixture(params=list_of_fetch_phi_funcs)
+def fetch_phi_fn(request):
+    return request.param
+
 
 @pytest.fixture(params=list_of_supported_dtypes)
 def input_arrays(request):
     # The size of input and out arrays to be used
     N = 10
-    a = dpnp.ones(N, dtype=request.param)
-    b = dpnp.zeros(N, dtype=request.param)
+    a = dpnp.arange(N, dtype=request.param)
+    b = dpnp.ones(N, dtype=request.param)
     return a, b
 
 
 @pytest.mark.parametrize("ref_index", [0, 5])
-def test_fetch_add(input_arrays, ref_index):
+def test_fetch_phi_fn(input_arrays, ref_index, fetch_phi_fn):
+    """A test for all fetch_phi atomic functions."""
+
     @dpex_exp.kernel
-    def atomic_ref_kernel(a, b, ref_index):
+    def _kernel(a, b, ref_index):
         i = dpex.get_global_id(0)
         v = AtomicRef(b, index=ref_index)
-        v.fetch_add(a[i])
+        getattr(v, fetch_phi_fn)(a[i])
 
     a, b = input_arrays
 
-    dpex_exp.call_kernel(atomic_ref_kernel, dpex.Range(10), a, b, ref_index)
+    if (
+        fetch_phi_fn in ["fetch_and", "fetch_or", "fetch_xor"]
+        and issubclass(a.dtype.type, dpnp.floating)
+        and issubclass(b.dtype.type, dpnp.floating)
+    ):
+        # fetch_and, fetch_or, fetch_xor accept only int arguments.
+        # test for TypingError when float arguments are passed.
+        with pytest.raises(TypingError):
+            dpex_exp.call_kernel(_kernel, dpex.Range(10), a, b, ref_index)
+    else:
+        dpex_exp.call_kernel(_kernel, dpex.Range(10), a, b, ref_index)
+        # Verify that `a` accumulated at b[ref_index] by kernel
+        # matches the `a` accumulated at  b[ref_index+1] using Python
+        for i in range(a.size):
+            v = AtomicRef(b, index=ref_index + 1)
+            getattr(v, fetch_phi_fn)(a[i])
 
-    # Verify that `a` was accumulated at b[ref_index]
-    assert b[ref_index] == 10
+        assert b[ref_index] == b[ref_index + 1]
+
+
+def test_fetch_phi_diff_types(fetch_phi_fn):
+    """A negative test that verifies that a TypingError is raised if
+    AtomicRef type and value to be added are of different types.
+    """
+
+    @dpex_exp.kernel
+    def _kernel(a, b):
+        i = dpex.get_global_id(0)
+        v = AtomicRef(b, index=0)
+        getattr(v, fetch_phi_fn)(a[i])
+
+    N = 10
+    a = dpnp.ones(N, dtype=dpnp.float32)
+    b = dpnp.zeros(N, dtype=dpnp.int32)
+
+    with pytest.raises(TypingError):
+        dpex_exp.call_kernel(_kernel, dpex.Range(10), a, b)
 
 
 @dpex_exp.kernel
@@ -54,7 +105,7 @@ def atomic_ref_1(a):
     v.fetch_add(a[i + 2])
 
 
-def test_spirv_compiler_flags():
+def test_spirv_compiler_flags_add():
     """Check if float atomic flag is being populated from intrinsic for the
     second call.
 
@@ -68,3 +119,36 @@ def test_spirv_compiler_flags():
 
     assert a[0] == N - 1
     assert a[1] == N - 1
+
+
+@dpex_exp.kernel
+def atomic_max_0(a):
+    i = dpex.get_global_id(0)
+    v = AtomicRef(a, index=0)
+    if i != 0:
+        v.fetch_max(a[i])
+
+
+@dpex_exp.kernel
+def atomic_max_1(a):
+    i = dpex.get_global_id(0)
+    v = AtomicRef(a, index=0)
+    if i != 0:
+        v.fetch_max(a[i])
+
+
+def test_spirv_compiler_flags_max():
+    """Check if float atomic flag is being populated from intrinsic for the
+    second call.
+
+    https://github.com/IntelPython/numba-dpex/issues/1262
+    """
+    N = 10
+    a = dpnp.arange(N, dtype=dpnp.float32)
+    b = dpnp.arange(N, dtype=dpnp.float32)
+
+    dpex_exp.call_kernel(atomic_max_0, dpex.Range(N), a)
+    dpex_exp.call_kernel(atomic_max_1, dpex.Range(N), b)
+
+    assert a[0] == N - 1
+    assert b[0] == N - 1


### PR DESCRIPTION
- [X] Have you provided a meaningful PR description?
Adds the remaining overloads for `fetch_*` functions to the `_atomic_ref_overloads` module. These include - fetch_sub, fetch_min, fetch_max, fetch_and, fetch_or, and fetch_xor.
This PR also contains positive and negative test cases for testing out each of the atomic functions
 
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
