### PR TITLE
Add dpctl tensor support

### DIFF
--- a/numba_dpex/core/datamodel/models.py
+++ b/numba_dpex/core/datamodel/models.py
@@ -55,12 +55,23 @@ class GenericPointerModel(PrimitiveModel):
         super(GenericPointerModel, self).__init__(dmm, fe_type, be_type)
 
 
-class USMArrayModel(StructModel):
-    """A data model to represent a Dpex's array types in LLVM IR.
+class USMArrayDeviceModel(StructModel):
+    """A data model to represent a usm array type in the LLVM IR generated for a
+    device-only kernel function.
 
-    Dpex's ArrayModel is based on Numba's ArrayModel for NumPy arrays. The
-    dpex model adds an extra address space attribute to all pointer members
-    in the array.
+    The USMArrayDeviceModel adds an extra address space attribute to the data
+    member. The extra attribute is needed when passing usm_ndarray array
+    arguments to kernels that are compiled for certain OpenCL GPU devices. Note
+    that the address space attribute is applied only to the data member and not
+    other members of USMArrayDeviceModel that are pointers. It is done this way
+    as other pointer members such as meminfo are not used inside a kernel and
+    these members maybe removed from the USMArrayDeviceModel in
+    future (refer #929).
+
+    We use separate data models for host (USMArrayHostModel) and device
+    (USMArrayDeviceModel) as the address space attribute is only required for
+    kernel functions and not needed for functions that are compiled for a host
+    memory space.
     """
 
     # TODO: Evaluate the need to pass meminfo and parent attributes of an array
@@ -84,26 +95,28 @@ class USMArrayModel(StructModel):
             ("shape", types.UniTuple(types.intp, ndim)),
             ("strides", types.UniTuple(types.intp, ndim)),
         ]
-        super(USMArrayModel, self).__init__(dmm, fe_type, members)
+        super(USMArrayDeviceModel, self).__init__(dmm, fe_type, members)
 
     @property
     def flattened_field_count(self):
-        """Return the number of fields in an instance of a USMArrayModel."""
+        """
+        Return the number of fields in an instance of a USMArrayDeviceModel.
+        """
         return _get_flattened_member_count(self)
 
 
-class DpnpNdArrayModel(StructModel):
-    """Data model for the DpnpNdArray type.
+class USMArrayHostModel(StructModel):
+    """Data model for the USMNdArray type when used in a host-only function.
 
-    DpnpNdArrayModel is used by the numba_dpex.types.DpnpNdArray type and
-    abstracts the usmarystruct_t C type defined in
-    numba_dpex.core.runtime._usmarraystruct.h.
+    USMArrayHostModel is used by the numba_dpex.types.USMNdArray and
+    numba_dpex.types.DpnpNdArray type and abstracts the usmarystruct_t C type
+    defined in numba_dpex.core.runtime._usmarraystruct.h.
 
-    The DpnpNdArrayModel differs from numba's ArrayModel by including an extra
-    member sycl_queue that maps to _usmarraystruct.sycl_queue pointer. The
+    The USMArrayDeviceModel differs from numba's ArrayModel by including an
+    extra member sycl_queue that maps to _usmarraystruct.sycl_queue pointer. The
     _usmarraystruct.sycl_queue pointer stores the C++ sycl::queue pointer that
-    was used to allocate the data for the dpnp.ndarray represented by an
-    instance of _usmarraystruct.
+    was used to allocate the data for the dpctl.tensor.usm_ndarray or
+    dpnp.ndarray represented by an instance of _usmarraystruct.
     """
 
     def __init__(self, dmm, fe_type):
@@ -118,11 +131,11 @@ class DpnpNdArrayModel(StructModel):
             ("shape", types.UniTuple(types.intp, ndim)),
             ("strides", types.UniTuple(types.intp, ndim)),
         ]
-        super(DpnpNdArrayModel, self).__init__(dmm, fe_type, members)
+        super(USMArrayHostModel, self).__init__(dmm, fe_type, members)
 
     @property
     def flattened_field_count(self):
-        """Return the number of fields in an instance of a DpnpNdArrayModel."""
+        """Return the number of fields in an instance of a USMArrayHostModel."""
         return _get_flattened_member_count(self)
 
 
@@ -239,12 +252,12 @@ def _init_data_model_manager() -> datamodel.DataModelManager:
     devices, defining a kernel function (spir_kernel calling convention) with
     pointer arguments that have no address space qualifier causes a run time
     crash. For this reason, numba-dpex defines two separate data
-    models: USMArrayModel and DpnpNdArrayModel. When a dpnp.ndarray object is
-    passed as an argument to a ``numba_dpex.kernel`` decorated function it uses
-    the USMArrayModel and when passed to a ``numba_dpex.dpjit`` decorated
-    function it uses the DpnpNdArrayModel. The difference is due to the fact
-    that inside a ``dpjit`` decorated function a dpnp.ndarray object can be
-    passed to any other regular function.
+    models: USMArrayDeviceModel and USMArrayHostModel. When a dpnp.ndarray
+    object is passed as an argument to a ``numba_dpex.kernel`` decorated
+    function it uses the USMArrayDeviceModel and when passed to a
+    ``numba_dpex.dpjit`` decorated function it uses the USMArrayHostModel.
+    The difference is due to the fact that inside a ``dpjit`` decorated function
+    a dpnp.ndarray object can be passed to any other regular function.
 
     Returns:
         DataModelManager: A numba-dpex DpexKernelTarget-specific data model
@@ -252,15 +265,15 @@ def _init_data_model_manager() -> datamodel.DataModelManager:
     """
     dmm = datamodel.default_manager.copy()
     dmm.register(types.CPointer, GenericPointerModel)
-    dmm.register(Array, USMArrayModel)
+    dmm.register(Array, USMArrayDeviceModel)
 
-    # Register the USMNdArray type to USMArrayModel in numba_dpex's data model
-    # manager. The dpex_data_model_manager is used by the DpexKernelTarget
-    dmm.register(USMNdArray, USMArrayModel)
+    # Register the USMNdArray type to USMArrayDeviceModel in numba_dpex's data
+    # model manager. The dpex_data_model_manager is used by the DpexKernelTarget
+    dmm.register(USMNdArray, USMArrayDeviceModel)
 
-    # Register the DpnpNdArray type to USMArrayModel in numba_dpex's data model
-    # manager. The dpex_data_model_manager is used by the DpexKernelTarget
-    dmm.register(DpnpNdArray, USMArrayModel)
+    # Register the DpnpNdArray type to USMArrayDeviceModel in numba_dpex's data
+    # model manager. The dpex_data_model_manager is used by the DpexKernelTarget
+    dmm.register(DpnpNdArray, USMArrayDeviceModel)
 
     # Register the DpctlSyclQueue type to SyclQueueModel in numba_dpex's data
     # model manager. The dpex_data_model_manager is used by the DpexKernelTarget
@@ -272,13 +285,13 @@ def _init_data_model_manager() -> datamodel.DataModelManager:
 dpex_data_model_manager = _init_data_model_manager()
 
 
-# Register the USMNdArray type to USMArrayModel in numba's default data model
-# manager
-register_model(USMNdArray)(USMArrayModel)
-
-# Register the DpnpNdArray type to DpnpNdArrayModel in numba's default data
+# Register the USMNdArray type to USMArrayDeviceModel in numba's default data
 # model manager
-register_model(DpnpNdArray)(DpnpNdArrayModel)
+register_model(USMNdArray)(USMArrayDeviceModel)
+
+# Register the DpnpNdArray type to USMArrayHostModel in numba's default data
+# model manager
+register_model(DpnpNdArray)(USMArrayHostModel)
 
 # Register the DpctlSyclQueue type
 register_model(DpctlSyclQueue)(SyclQueueModel)

--- a/numba_dpex/core/datamodel/models.py
+++ b/numba_dpex/core/datamodel/models.py
@@ -287,7 +287,7 @@ dpex_data_model_manager = _init_data_model_manager()
 
 # Register the USMNdArray type to USMArrayDeviceModel in numba's default data
 # model manager
-register_model(USMNdArray)(USMArrayDeviceModel)
+register_model(USMNdArray)(USMArrayHostModel)
 
 # Register the DpnpNdArray type to USMArrayHostModel in numba's default data
 # model manager

--- a/numba_dpex/core/datamodel/models.py
+++ b/numba_dpex/core/datamodel/models.py
@@ -63,27 +63,24 @@ class USMArrayModel(StructModel):
     in the array.
     """
 
+    # TODO: Evaluate the need to pass meminfo and parent attributes of an array
+    #   as kernel params: https://github.com/IntelPython/numba-dpex/issues/929
+
     def __init__(self, dmm, fe_type):
         ndim = fe_type.ndim
         members = [
-            (
-                "meminfo",
-                types.CPointer(fe_type.dtype, addrspace=fe_type.addrspace),
-            ),
-            (
-                "parent",
-                types.CPointer(types.pyobject, addrspace=fe_type.addrspace),
-            ),
+            # meminfo never used in kernel, so we don'te care about addrspace
+            ("meminfo", types.MemInfoPointer(fe_type.dtype)),
+            # parent never used in kernel, so we don'te care about addrspace
+            ("parent", types.pyobject),
             ("nitems", types.intp),
             ("itemsize", types.intp),
             (
                 "data",
                 types.CPointer(fe_type.dtype, addrspace=fe_type.addrspace),
             ),
-            (
-                "sycl_queue",
-                types.CPointer(types.void, addrspace=fe_type.addrspace),
-            ),
+            # sycl_queue never used in kernel, so we don'te care about addrspace
+            ("sycl_queue", types.voidptr),
             ("shape", types.UniTuple(types.intp, ndim)),
             ("strides", types.UniTuple(types.intp, ndim)),
         ]

--- a/numba_dpex/core/types/dpnp_ndarray_type.py
+++ b/numba_dpex/core/types/dpnp_ndarray_type.py
@@ -200,19 +200,22 @@ class DpnpNdArray(USMNdArray):
         return out
 
 
+# TODO: move this section to separate file
 # --------------- Boxing/Unboxing logic for dpnp.ndarray ----------------------#
 
 
-@unbox(DpnpNdArray)
+@unbox(USMNdArray)
 def unbox_dpnp_nd_array(typ, obj, c):
-    """Converts a dpnp.ndarray object to a Numba internal array structure.
+    """Converts a dpctl.tensor.usm_ndarray/dpnp.ndarray object to a Numba-dpex
+    internal array structure.
 
     Args:
         typ : The Numba type of the PyObject
         obj : The actual PyObject to be unboxed
         c : The unboxing context
 
-    Returns: A NativeValue object representing an unboxed dpnp.ndarray
+    Returns: A NativeValue object representing an unboxed
+        dpctl.tensor.usm_ndarray/dpnp.ndarray
     """
     # Reusing the numba.core.base.BaseContext's make_array function to get a
     # struct allocated. The same struct is used for numpy.ndarray
@@ -264,24 +267,26 @@ def unbox_dpnp_nd_array(typ, obj, c):
     with c.builder.if_then(failed, likely=False):
         c.pyapi.err_set_string(
             "PyExc_TypeError",
-            "can't unbox array from PyObject into "
+            "can't unbox usm array from PyObject into "
             "native value.  The object maybe of a "
             "different type",
         )
     return NativeValue(c.builder.load(aryptr), is_error=failed)
 
 
-@box(DpnpNdArray)
+@box(USMNdArray)
 def box_array(typ, val, c):
-    """Boxes a NativeValue representation of DpnpNdArray type into a
-    dpnp.ndarray PyObject
+    """Boxes a NativeValue representation of USMNdArray/DpnpNdArray type into a
+    dpctl.tensor.usm_ndarray/dpnp.ndarray PyObject
 
     Args:
-        typ: The representation of the DpnpNdArray type.
-        val: A native representation of a Numba DpnpNdArray type object.
+        typ: The representation of the USMNdArray/DpnpNdArray type.
+        val: A native representation of a Numba USMNdArray/DpnpNdArray type
+            object.
         c: The boxing context.
 
-    Returns: A Pyobject for a dpnp.ndarray boxed from the Numba native value.
+    Returns: A Pyobject for a dpctl.tensor.usm_ndarray/dpnp.ndarray boxed from
+        the Numba-dpex native value.
     """
     if c.context.enable_nrt:
         np_dtype = numpy_support.as_dtype(typ.dtype)

--- a/numba_dpex/experimental/kernel_dispatcher.py
+++ b/numba_dpex/experimental/kernel_dispatcher.py
@@ -38,7 +38,7 @@ from numba_dpex.core.targets.kernel_target import (
     CompilationMode,
     DpexKernelTargetContext,
 )
-from numba_dpex.core.types import DpnpNdArray, USMNdArray
+from numba_dpex.core.types import USMNdArray
 from numba_dpex.core.utils import kernel_launcher as kl
 
 from .target import DPEX_KERNEL_EXP_TARGET_NAME, dpex_exp_kernel_target
@@ -56,7 +56,7 @@ class _KernelCompiler(_FunctionCompiler):
     def check_queue_equivalence_of_args(
         self, py_func_name: str, args: [types.Type, ...]
     ):
-        """Evaluates if all DpnpNdArray arguments passed to a kernel function
+        """Evaluates if all USMNdArray arguments passed to a kernel function
         has the same DpctlSyclQueue type.
 
         Args:
@@ -65,15 +65,15 @@ class _KernelCompiler(_FunctionCompiler):
             argument passed to the kernel
 
         Raises:
-            ExecutionQueueInferenceError: If all DpnpNdArray were not allocated
+            ExecutionQueueInferenceError: If all USMNdArray were not allocated
             on the same dpctl.SyclQueue
-            ExecutionQueueInferenceError: If there were not DpnpNdArray
+            ExecutionQueueInferenceError: If there were not USMNdArray
             arguments passed to the kernel.
         """
         common_queue = None
 
         for arg in args:
-            if isinstance(arg, DpnpNdArray):
+            if isinstance(arg, USMNdArray):
                 if common_queue is None:
                     common_queue = arg.queue
                 elif common_queue != arg.queue:
@@ -143,9 +143,9 @@ class _KernelCompiler(_FunctionCompiler):
             KernelHasReturnValueError: non void return type.
             InvalidKernelSpecializationError: unsupported arguments where
                 provided.
-            ExecutionQueueInferenceError: If all DpnpNdArray were not allocated
+            ExecutionQueueInferenceError: If all USMNdArray were not allocated
                 on the same dpctl.SyclQueue
-            ExecutionQueueInferenceError: If there were not DpnpNdArray
+            ExecutionQueueInferenceError: If there were not USMNdArray
                 arguments passed to the kernel.
         """
         self.check_sig_types(py_func_name, args, None)
@@ -343,7 +343,7 @@ class KernelDispatcher(Dispatcher):
         # can save a couple µs.
         try:
             tp = typeof(val, Purpose.argument)
-            if isinstance(tp, types.Array) and not isinstance(tp, DpnpNdArray):
+            if isinstance(tp, types.Array) and not isinstance(tp, USMNdArray):
                 raise UnsupportedKernelArgumentError(
                     type=str(type(val)), value=val
                 )

--- a/numba_dpex/tests/core/types/DpnpNdArray/test_models.py
+++ b/numba_dpex/tests/core/types/DpnpNdArray/test_models.py
@@ -7,8 +7,8 @@ from numba.core.datamodel import default_manager, models
 from numba.core.registry import cpu_target
 
 from numba_dpex.core.datamodel.models import (
-    DpnpNdArrayModel,
-    USMArrayModel,
+    USMArrayDeviceModel,
+    USMArrayHostModel,
     dpex_data_model_manager,
 )
 from numba_dpex.core.descriptor import dpex_kernel_target
@@ -21,9 +21,9 @@ def test_model_for_DpnpNdArray():
     """
     dpnp_ndarray = DpnpNdArray(ndim=1, dtype=types.float64, layout="C")
     model = dpex_data_model_manager.lookup(dpnp_ndarray)
-    assert isinstance(model, USMArrayModel)
+    assert isinstance(model, USMArrayDeviceModel)
     default_model = default_manager.lookup(dpnp_ndarray)
-    assert isinstance(default_model, DpnpNdArrayModel)
+    assert isinstance(default_model, USMArrayHostModel)
 
 
 def test_dpnp_ndarray_Model():
@@ -32,7 +32,7 @@ def test_dpnp_ndarray_Model():
     It is a subclass of models.StructModel and models.ArrayModel.
     """
 
-    assert issubclass(DpnpNdArrayModel, models.StructModel)
+    assert issubclass(USMArrayHostModel, models.StructModel)
 
 
 def test_flattened_member_count():

--- a/numba_dpex/tests/core/types/test_box_unbox.py
+++ b/numba_dpex/tests/core/types/test_box_unbox.py
@@ -10,6 +10,7 @@ import functools
 import sys
 
 import dpctl
+import dpctl.tensor as dpt
 import dpnp
 import numpy
 import pytest
@@ -23,8 +24,7 @@ constructors_with_parent = [
     # doing it in the right way. Testing tests =)
     lambda: numpy.empty(10, dtype=numpy.float32),
     lambda: dpnp.empty(10, dtype=dpnp.float32),
-    # TODO: is it possible to test USMNd array same way?
-    # lambda: dpx.USMNdArray(1, queue=None, dtype=dpx.float32), # noqa: E800
+    lambda: dpt.empty(10, dtype=dpt.float32),
 ]
 
 ranges = [(10,), (10, 10), (10, 10, 10)]

--- a/numba_dpex/tests/experimental/test_supported_array_types_as_kernel_args.py
+++ b/numba_dpex/tests/experimental/test_supported_array_types_as_kernel_args.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests different input array type support for the kernel."""
+
+import dpctl.tensor as dpt
+import dpnp
+import pytest
+
+import numba_dpex as dpex
+import numba_dpex.experimental as dpex_exp
+from numba_dpex.tests._helper import get_all_dtypes
+
+list_of_dtypes = get_all_dtypes(
+    no_bool=True, no_float16=True, no_none=True, no_complex=True
+)
+
+zeros_func = (dpt.zeros, dpnp.zeros)
+
+_SIZE = 10
+
+
+@pytest.fixture(params=((a, b) for a in zeros_func for b in list_of_dtypes))
+def input_array(request):
+    zeros, dtype = request.param
+    return zeros(_SIZE, dtype=dtype)
+
+
+@dpex_exp.kernel
+def set_ones(a):
+    i = dpex.get_global_id(0)
+    a[i] = 1
+
+
+def test_fetch_add(input_array):
+    dpex_exp.call_kernel(set_ones, dpex.Range(_SIZE), input_array)
+
+    assert input_array[0] == 1


### PR DESCRIPTION
Add support for `dpctl.tensor.usm_ndarray` to dpjit and experimental kernel.

Several additional changes where made:
- Apply better naming for `USMNdArray`/`DpnpNdArray` data models.
- Fix for `USMNdArray` device data model.
- Use same data type for host and separate type for device for both `USMNdArray` and `DpnpNdArray`

Checklist
- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
