### PR TITLE
Allow use of latest dpcpp compiler package

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -18,6 +18,7 @@ env:
   VER_JSON_NAME: 'version.json'
   VER_SCRIPT1: "import json; f = open('version.json', 'r'); j = json.load(f); f.close(); "
   VER_SCRIPT2: "d = j['numba-dpex'][0]; print('='.join((d[s] for s in ('version', 'build'))))"
+  PYTHONIOENCODING: 'utf-8'
 
 jobs:
   build:
@@ -172,7 +173,7 @@ jobs:
       # We want to make sure that all dependecies install automatically.
       # intel::intel-opencl-rt is needed for set-intel-ocl-icd-registry.ps1
       - name: Install builded package
-        run: mamba install ${{ env.PACKAGE_NAME }}=${{ env.PACKAGE_VERSION }} intel::intel-opencl-rt pytest-cov -c ${{ env.CHANNEL_PATH }}
+        run: mamba install ${{ env.PACKAGE_NAME }}=${{ env.PACKAGE_VERSION }} intel::intel-opencl-rt pytest-cov conda-tree -c ${{ env.CHANNEL_PATH }}
 
       - name: Install numba-mlir
         if: matrix.use_mlir
@@ -198,6 +199,9 @@ jobs:
       - name: Check dpcpp-llvm-spirv
         run: |
           python -c "import dpcpp_llvm_spirv as p; print(p.get_llvm_spirv_path())"
+
+      - name: Check dependency tree
+        run: conda-tree depends -t numba-dpex
 
       - name: Smoke test
         env:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -29,6 +29,7 @@ requirements:
         - dpcpp-llvm-spirv
         - wheel
     run:
+        - {{ pin_compatible('dpcpp-cpp-rt', min_pin='x.x', max_pin='x') }}
         - python
         - numba >=0.57*
         - dpctl >=0.14*

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -13,7 +13,7 @@ build:
 requirements:
     build:
         - {{ compiler('cxx') }}
-        - {{ compiler('dpcpp') }} <2024.0.1  # [not osx]
+        - {{ compiler('dpcpp') }}  # [not osx]
     host:
         - python
         - setuptools >=63.*

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -14,6 +14,9 @@ requirements:
     build:
         - {{ compiler('cxx') }}
         - {{ compiler('dpcpp') }}  # [not osx]
+        # specific version of sysroot required by dpcpp, but 2024.0.0 package
+        # does not have it in meta data
+        - sysroot_linux-64 >=2.28  # [linux]
     host:
         - python
         - setuptools >=63.*

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,3 +1,7 @@
+{% set required_compiler_version = "2023.2" %}
+{% set excluded_compiler_version1 = "2024.0.1" %}
+{% set excluded_compiler_version2 = "2024.0.2" %}
+
 package:
     name: numba-dpex
     version: {{ GIT_DESCRIBE_TAG }}
@@ -13,11 +17,12 @@ build:
 requirements:
     build:
         - {{ compiler('cxx') }}
-        - {{ compiler('dpcpp') }}  # [not osx]
+        - {{ compiler('dpcpp') }} >={{ required_compiler_version }},!={{ excluded_compiler_version1 }},!={{ excluded_compiler_version2 }} # [not osx]
         # specific version of sysroot required by dpcpp, but 2024.0.0 package
         # does not have it in meta data
         - sysroot_linux-64 >=2.28  # [linux]
     host:
+        - dpcpp-cpp-rt >={{ required_compiler_version }},!={{ excluded_compiler_version1 }},!={{ excluded_compiler_version2 }}
         - python
         - setuptools >=63.*
         - scikit-build >=0.15*

--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ channels:
 dependencies:
   - python=3.9
   - gxx_linux-64
-  - dpcpp_linux-64
+  - dpcpp_linux-64>=2023.2,!=2024.0.1,!=2024.0.2
   - numba ==0.58*
   - dpctl >=0.14*
   - dpnp >=0.11*

--- a/environment.yml
+++ b/environment.yml
@@ -13,7 +13,7 @@ dependencies:
   - numba ==0.58*
   - dpctl >=0.14*
   - dpnp >=0.11*
-  - mkl >=2021.3.0  # for dpnp
+  - mkl >=2021.3.0 # for dpnp
   - dpcpp-llvm-spirv
   - packaging
   - scikit-build >=0.15*
@@ -21,13 +21,13 @@ dependencies:
   - pytest
   - pip
   - pip:
-    - coverage
-    - pre-commit
-    - flake8
-    - black==20.8b1
-    - pytest-cov
-    - pytest-xdist
-    - pexpect
+      - coverage
+      - pre-commit
+      - flake8
+      - black==20.8b1
+      - pytest-cov
+      - pytest-xdist
+      - pexpect
 variables:
   CHANNELS: -c defaults -c numba -c intel -c numba/label/dev -c dppy/label/dev --override-channels
   CHANNELS_DEV: -c dppy/label/dev -c defaults -c numba -c intel -c numba/label/dev --override-channels

--- a/environment.yml
+++ b/environment.yml
@@ -1,33 +1,33 @@
 name: dev
 channels:
-- defaults
-- dppy/label/dev
-- numba
-- intel
-- numba/label/dev
-- nodefaults
+  - defaults
+  - dppy/label/dev
+  - numba
+  - intel
+  - numba/label/dev
+  - nodefaults
 dependencies:
-- python=3.9
-- gxx_linux-64
-- dpcpp_linux-64==2024.0.0
-- numba ==0.58*
-- dpctl >=0.14*
-- dpnp >=0.11*
-- mkl >=2021.3.0 # for dpnp
-- dpcpp-llvm-spirv
-- packaging
-- scikit-build >=0.15*
-- cmake >=3.26*
-- pytest
-- pip
-- pip:
-  - coverage
-  - pre-commit
-  - flake8
-  - black==20.8b1
-  - pytest-cov
-  - pytest-xdist
-  - pexpect
+  - python=3.9
+  - gxx_linux-64
+  - dpcpp_linux-64
+  - numba ==0.58*
+  - dpctl >=0.14*
+  - dpnp >=0.11*
+  - mkl >=2021.3.0  # for dpnp
+  - dpcpp-llvm-spirv
+  - packaging
+  - scikit-build >=0.15*
+  - cmake >=3.26*
+  - pytest
+  - pip
+  - pip:
+    - coverage
+    - pre-commit
+    - flake8
+    - black==20.8b1
+    - pytest-cov
+    - pytest-xdist
+    - pexpect
 variables:
   CHANNELS: -c defaults -c numba -c intel -c numba/label/dev -c dppy/label/dev --override-channels
   CHANNELS_DEV: -c dppy/label/dev -c defaults -c numba -c intel -c numba/label/dev --override-channels

--- a/environment/coverage.yml
+++ b/environment/coverage.yml
@@ -8,7 +8,7 @@ channels:
 dependencies:
   - libffi
   - gxx_linux-64
-  - dpcpp_linux-64
+  - dpcpp_linux-64>=2023.2,!=2024.0.1,!=2024.0.2
   - numba==0.58*
   - dpctl
   - dpnp

--- a/environment/coverage.yml
+++ b/environment/coverage.yml
@@ -1,23 +1,23 @@
 name: dev
 channels:
-- dppy/label/dev
-- numba
-- intel
-- conda-forge
-- nodefaults
+  - dppy/label/dev
+  - numba
+  - intel
+  - conda-forge
+  - nodefaults
 dependencies:
-- libffi
-- gxx_linux-64
-- dpcpp_linux-64==2024.0.0
-- numba==0.58*
-- dpctl
-- dpnp
-- dpcpp-llvm-spirv
-- opencl_rt
-- coverage
-- pytest
-- pytest-cov
-- pytest-xdist
-- pexpect
-- scikit-build>=0.15*
-- cmake>=3.26*
+  - libffi
+  - gxx_linux-64
+  - dpcpp_linux-64
+  - numba==0.58*
+  - dpctl
+  - dpnp
+  - dpcpp-llvm-spirv
+  - opencl_rt
+  - coverage
+  - pytest
+  - pytest-cov
+  - pytest-xdist
+  - pexpect
+  - scikit-build>=0.15*
+  - cmake>=3.26*

--- a/environment/docs.yml
+++ b/environment/docs.yml
@@ -1,29 +1,29 @@
 name: dpex-docs-dev
 channels:
-- dppy/label/dev
-- numba
-- intel
-- conda-forge
-- nodefaults
+  - dppy/label/dev
+  - numba
+  - intel
+  - conda-forge
+  - nodefaults
 dependencies:
-- libffi
-- gxx_linux-64
-- dpcpp_linux-64==2024.0.0
-- numba==0.58*
-- scikit-build>=0.15*
-- cmake>=3.26*
-- dpctl
-- dpnp
-- dpcpp-llvm-spirv
-- opencl_rt
-- pip
-- pip:
-  - sphinx
-  - autodoc # there is no conda package
-  - recommonmark
-  - sphinx-rtd-theme
-  - sphinxcontrib-apidoc
-  - sphinxcontrib-googleanalytics
-  - sphinxcontrib.programoutput
-  - pydata-sphinx-theme
-  - myst-parser
+  - libffi
+  - gxx_linux-64
+  - dpcpp_linux-64
+  - numba==0.58*
+  - scikit-build>=0.15*
+  - cmake>=3.26*
+  - dpctl
+  - dpnp
+  - dpcpp-llvm-spirv
+  - opencl_rt
+  - pip
+  - pip:
+    - sphinx
+    - autodoc # there is no conda package
+    - recommonmark
+    - sphinx-rtd-theme
+    - sphinxcontrib-apidoc
+    - sphinxcontrib-googleanalytics
+    - sphinxcontrib.programoutput
+    - pydata-sphinx-theme
+    - myst-parser

--- a/environment/docs.yml
+++ b/environment/docs.yml
@@ -8,7 +8,7 @@ channels:
 dependencies:
   - libffi
   - gxx_linux-64
-  - dpcpp_linux-64
+  - dpcpp_linux-64>=2023.2,!=2024.0.1,!=2024.0.2
   - numba==0.58*
   - scikit-build>=0.15*
   - cmake>=3.26*

--- a/environment/pre-commit.yml
+++ b/environment/pre-commit.yml
@@ -1,25 +1,25 @@
 name: dev
 channels:
-- dppy/label/dev
-- numba
-- intel
-- conda-forge
-- nodefaults
+  - dppy/label/dev
+  - numba
+  - intel
+  - conda-forge
+  - nodefaults
 dependencies:
-- libffi
-- gxx_linux-64
-- dpcpp_linux-64==2024.0.0
-- numba==0.58*
-- dpctl
-- dpnp
-- dpcpp-llvm-spirv
-- opencl_rt
-- coverage
-- pytest
-- pytest-cov
-- pytest-xdist
-- pexpect
-- scikit-build>=0.15*
-- cmake>=3.26*
-- pre-commit
-- pylint
+  - libffi
+  - gxx_linux-64
+  - dpcpp_linux-64
+  - numba==0.58*
+  - dpctl
+  - dpnp
+  - dpcpp-llvm-spirv
+  - opencl_rt
+  - coverage
+  - pytest
+  - pytest-cov
+  - pytest-xdist
+  - pexpect
+  - scikit-build>=0.15*
+  - cmake>=3.26*
+  - pre-commit
+  - pylint

--- a/environment/pre-commit.yml
+++ b/environment/pre-commit.yml
@@ -7,8 +7,6 @@ channels:
   - nodefaults
 dependencies:
   - libffi
-  - gxx_linux-64
-  - dpcpp_linux-64
   - numba==0.58*
   - dpctl
   - dpnp


### PR DESCRIPTION
- [X] Have you provided a meaningful PR description?

Enable the usage of dpcpp_linux-64 2024.1 package to build numba-dpex
