### PR TITLE
Update/copyright 2024

### DIFF
--- a/numba_dpex/__init__.py
+++ b/numba_dpex/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/_version.py
+++ b/numba_dpex/_version.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2023 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/config.py
+++ b/numba_dpex/config.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/core/__init__.py
+++ b/numba_dpex/core/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/core/caching.py
+++ b/numba_dpex/core/caching.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/core/codegen.py
+++ b/numba_dpex/core/codegen.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/core/compiler.py
+++ b/numba_dpex/core/compiler.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2022 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/core/datamodel/__init__.py
+++ b/numba_dpex/core/datamodel/__init__.py
@@ -1,3 +1,3 @@
-# SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2022 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/numba_dpex/core/datamodel/models.py
+++ b/numba_dpex/core/datamodel/models.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2022 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/core/descriptor.py
+++ b/numba_dpex/core/descriptor.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/core/dpjit_dispatcher.py
+++ b/numba_dpex/core/dpjit_dispatcher.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/core/exceptions.py
+++ b/numba_dpex/core/exceptions.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/core/itanium_mangler.py
+++ b/numba_dpex/core/itanium_mangler.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/core/kernel_interface/__init__.py
+++ b/numba_dpex/core/kernel_interface/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/core/kernel_interface/arg_pack_unpacker.py
+++ b/numba_dpex/core/kernel_interface/arg_pack_unpacker.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2022 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/core/kernel_interface/dispatcher.py
+++ b/numba_dpex/core/kernel_interface/dispatcher.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2022 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/core/kernel_interface/func.py
+++ b/numba_dpex/core/kernel_interface/func.py
@@ -1,7 +1,6 @@
-# SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2022 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
-
 
 from numba.core import sigutils, types
 from numba.core.typing.templates import AbstractTemplate, ConcreteTemplate

--- a/numba_dpex/core/kernel_interface/indexers.py
+++ b/numba_dpex/core/kernel_interface/indexers.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2023 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/core/kernel_interface/kernel_base.py
+++ b/numba_dpex/core/kernel_interface/kernel_base.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2022 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/core/kernel_interface/launcher.py
+++ b/numba_dpex/core/kernel_interface/launcher.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Launcher package to provide the same way of calling kernel as experimental
 one."""
 

--- a/numba_dpex/core/kernel_interface/spirv_kernel.py
+++ b/numba_dpex/core/kernel_interface/spirv_kernel.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2022 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/core/kernel_interface/utils.py
+++ b/numba_dpex/core/kernel_interface/utils.py
@@ -1,7 +1,6 @@
-# SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2022 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
-
 
 from numba_dpex.core.exceptions import ExecutionQueueInferenceError
 from numba_dpex.core.types import USMNdArray

--- a/numba_dpex/core/parfors/__init__.py
+++ b/numba_dpex/core/parfors/__init__.py
@@ -1,3 +1,3 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/numba_dpex/core/parfors/kernel_builder.py
+++ b/numba_dpex/core/parfors/kernel_builder.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/core/parfors/parfor_lowerer.py
+++ b/numba_dpex/core/parfors/parfor_lowerer.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2022 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/core/parfors/reduction_helper.py
+++ b/numba_dpex/core/parfors/reduction_helper.py
@@ -1,6 +1,7 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
+
 import copy
 import operator
 

--- a/numba_dpex/core/parfors/reduction_kernel_builder.py
+++ b/numba_dpex/core/parfors/reduction_kernel_builder.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/core/passes/__init__.py
+++ b/numba_dpex/core/passes/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/core/passes/dufunc_inliner.py
+++ b/numba_dpex/core/passes/dufunc_inliner.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/core/passes/parfor_legalize_cfd_pass.py
+++ b/numba_dpex/core/passes/parfor_legalize_cfd_pass.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/core/passes/passes.py
+++ b/numba_dpex/core/passes/passes.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/core/pipelines/__init__.py
+++ b/numba_dpex/core/pipelines/__init__.py
@@ -1,3 +1,3 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/numba_dpex/core/pipelines/dpjit_compiler.py
+++ b/numba_dpex/core/pipelines/dpjit_compiler.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2022 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/core/pipelines/kernel_compiler.py
+++ b/numba_dpex/core/pipelines/kernel_compiler.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2022 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/core/runtime/__init__.py
+++ b/numba_dpex/core/runtime/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2021 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/core/runtime/_dbg_printer.h
+++ b/numba_dpex/core/runtime/_dbg_printer.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 Intel Corporation
+// SPDX-FileCopyrightText: 2023 - 2024 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/core/runtime/_dpexrt_python.c
+++ b/numba_dpex/core/runtime/_dpexrt_python.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+// SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/core/runtime/_eventstruct.c
+++ b/numba_dpex/core/runtime/_eventstruct.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+// SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/core/runtime/_eventstruct.h
+++ b/numba_dpex/core/runtime/_eventstruct.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+// SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/core/runtime/_meminfo_helper.h
+++ b/numba_dpex/core/runtime/_meminfo_helper.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+// SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/core/runtime/_nrt_helper.c
+++ b/numba_dpex/core/runtime/_nrt_helper.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+// SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/core/runtime/_nrt_helper.h
+++ b/numba_dpex/core/runtime/_nrt_helper.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+// SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/core/runtime/_nrt_python_helper.c
+++ b/numba_dpex/core/runtime/_nrt_python_helper.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+// SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/core/runtime/_nrt_python_helper.h
+++ b/numba_dpex/core/runtime/_nrt_python_helper.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+// SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/core/runtime/_queuestruct.h
+++ b/numba_dpex/core/runtime/_queuestruct.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+// SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/core/runtime/_usmarraystruct.h
+++ b/numba_dpex/core/runtime/_usmarraystruct.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+// SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/core/runtime/context.py
+++ b/numba_dpex/core/runtime/context.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/core/runtime/experimental/kernel_caching.cpp
+++ b/numba_dpex/core/runtime/experimental/kernel_caching.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+// SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/core/runtime/experimental/kernel_caching.h
+++ b/numba_dpex/core/runtime/experimental/kernel_caching.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 Intel Corporation
+// SPDX-FileCopyrightText: 2023 - 2024 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/core/runtime/experimental/nrt_reserve_meminfo.cpp
+++ b/numba_dpex/core/runtime/experimental/nrt_reserve_meminfo.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 Intel Corporation
+// SPDX-FileCopyrightText: 2023 - 2024 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/core/runtime/experimental/nrt_reserve_meminfo.h
+++ b/numba_dpex/core/runtime/experimental/nrt_reserve_meminfo.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 Intel Corporation
+// SPDX-FileCopyrightText: 2023 - 2024 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/core/runtime/experimental/tools/dpctl.cpp
+++ b/numba_dpex/core/runtime/experimental/tools/dpctl.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+// SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/core/targets/__init__.py
+++ b/numba_dpex/core/targets/__init__.py
@@ -1,3 +1,3 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/numba_dpex/core/targets/dpjit_target.py
+++ b/numba_dpex/core/targets/dpjit_target.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/core/targets/kernel_target.py
+++ b/numba_dpex/core/targets/kernel_target.py
@@ -1,7 +1,6 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
-
 
 from enum import IntEnum
 from functools import cached_property

--- a/numba_dpex/core/typeconv/__init__.py
+++ b/numba_dpex/core/typeconv/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/core/typeconv/array_conversion.py
+++ b/numba_dpex/core/typeconv/array_conversion.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/core/types/__init__.py
+++ b/numba_dpex/core/types/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/core/types/array_type.py
+++ b/numba_dpex/core/types/array_type.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/core/types/dpctl_types.py
+++ b/numba_dpex/core/types/dpctl_types.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/core/types/dpnp_ndarray_type.py
+++ b/numba_dpex/core/types/dpnp_ndarray_type.py
@@ -1,7 +1,6 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
-
 
 import dpnp
 from numba.core import cgutils, ir, types

--- a/numba_dpex/core/types/numba_types_short_names.py
+++ b/numba_dpex/core/types/numba_types_short_names.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/core/types/range_types.py
+++ b/numba_dpex/core/types/range_types.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2023 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/core/types/usm_ndarray_type.py
+++ b/numba_dpex/core/types/usm_ndarray_type.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2022 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/core/typing/__init__.py
+++ b/numba_dpex/core/typing/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2022 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/core/typing/dpnpdecl.py
+++ b/numba_dpex/core/typing/dpnpdecl.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2022 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/core/typing/typeof.py
+++ b/numba_dpex/core/typing/typeof.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2022 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/core/utils/__init__.py
+++ b/numba_dpex/core/utils/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/core/utils/caching_utils.py
+++ b/numba_dpex/core/utils/caching_utils.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/core/utils/kernel_launcher.py
+++ b/numba_dpex/core/utils/kernel_launcher.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/core/utils/kernel_templates/__init__.py
+++ b/numba_dpex/core/utils/kernel_templates/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2023 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/core/utils/kernel_templates/kernel_template_iface.py
+++ b/numba_dpex/core/utils/kernel_templates/kernel_template_iface.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2023 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/core/utils/kernel_templates/range_kernel_template.py
+++ b/numba_dpex/core/utils/kernel_templates/range_kernel_template.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2023 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/core/utils/kernel_templates/reduction_template.py
+++ b/numba_dpex/core/utils/kernel_templates/reduction_template.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2023 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/core/utils/suai_helper.py
+++ b/numba_dpex/core/utils/suai_helper.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/debuginfo.py
+++ b/numba_dpex/debuginfo.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/decorators.py
+++ b/numba_dpex/decorators.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/dpctl_iface/__init__.py
+++ b/numba_dpex/dpctl_iface/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/dpctl_iface/_helpers.py
+++ b/numba_dpex/dpctl_iface/_helpers.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/dpctl_iface/_intrinsic.py
+++ b/numba_dpex/dpctl_iface/_intrinsic.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/dpctl_iface/libsyclinterface_bindings.py
+++ b/numba_dpex/dpctl_iface/libsyclinterface_bindings.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2023 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/dpctl_iface/wrappers.py
+++ b/numba_dpex/dpctl_iface/wrappers.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2023 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/dpnp_iface/__init__.py
+++ b/numba_dpex/dpnp_iface/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/dpnp_iface/_intrinsic.py
+++ b/numba_dpex/dpnp_iface/_intrinsic.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/dpnp_iface/arrayobj.py
+++ b/numba_dpex/dpnp_iface/arrayobj.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/dpnp_iface/dpnp_ufunc_db.py
+++ b/numba_dpex/dpnp_iface/dpnp_ufunc_db.py
@@ -1,7 +1,6 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
-
 
 import copy
 

--- a/numba_dpex/dpnp_iface/dpnpimpl.py
+++ b/numba_dpex/dpnp_iface/dpnpimpl.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/examples/_helper.py
+++ b/numba_dpex/examples/_helper.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/examples/blacksholes_njit.py
+++ b/numba_dpex/examples/blacksholes_njit.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/examples/debug/dpex_func.py
+++ b/numba_dpex/examples/debug/dpex_func.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/examples/debug/njit_basic.py
+++ b/numba_dpex/examples/debug/njit_basic.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/examples/debug/side-by-side-2.py
+++ b/numba_dpex/examples/debug/side-by-side-2.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/examples/debug/side-by-side.py
+++ b/numba_dpex/examples/debug/side-by-side.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/examples/debug/simple_dpex_func.py
+++ b/numba_dpex/examples/debug/simple_dpex_func.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/examples/debug/simple_sum.py
+++ b/numba_dpex/examples/debug/simple_sum.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/examples/debug/sum.py
+++ b/numba_dpex/examples/debug/sum.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/examples/debug/sum_local_vars.py
+++ b/numba_dpex/examples/debug/sum_local_vars.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/examples/debug/sum_local_vars_revive.py
+++ b/numba_dpex/examples/debug/sum_local_vars_revive.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/examples/dpjit/vector_sum.py
+++ b/numba_dpex/examples/dpjit/vector_sum.py
@@ -1,4 +1,4 @@
-# Copyright 2020 - 2023 Intel Corporation
+# Copyright 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/examples/dpjit/vector_sum2D.py
+++ b/numba_dpex/examples/dpjit/vector_sum2D.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/examples/kernel/atomic_op.py
+++ b/numba_dpex/examples/kernel/atomic_op.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/examples/kernel/black_scholes.py
+++ b/numba_dpex/examples/kernel/black_scholes.py
@@ -1,6 +1,7 @@
-# SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2022 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache 2.0
+# SPDX-License-Identifier: Apache-2.0
 
 from math import erf, exp, log, sqrt
 

--- a/numba_dpex/examples/kernel/device_func.py
+++ b/numba_dpex/examples/kernel/device_func.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/examples/kernel/interpolation.py
+++ b/numba_dpex/examples/kernel/interpolation.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/examples/kernel/kernel_private_memory.py
+++ b/numba_dpex/examples/kernel/kernel_private_memory.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/examples/kernel/kernel_specialization.py
+++ b/numba_dpex/examples/kernel/kernel_specialization.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/examples/kernel/matmul.py
+++ b/numba_dpex/examples/kernel/matmul.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/examples/kernel/pairwise_distance.py
+++ b/numba_dpex/examples/kernel/pairwise_distance.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/examples/kernel/pipelining.py
+++ b/numba_dpex/examples/kernel/pipelining.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/examples/kernel/scan.py
+++ b/numba_dpex/examples/kernel/scan.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/examples/kernel/sum_reduction_ocl.py
+++ b/numba_dpex/examples/kernel/sum_reduction_ocl.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/examples/kernel/sum_reduction_recursive_ocl.py
+++ b/numba_dpex/examples/kernel/sum_reduction_recursive_ocl.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/examples/kernel/vector_sum.py
+++ b/numba_dpex/examples/kernel/vector_sum.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/examples/kernel/vector_sum2D.py
+++ b/numba_dpex/examples/kernel/vector_sum2D.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/examples/sum_reduction.py
+++ b/numba_dpex/examples/sum_reduction.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/examples/vectorize.py
+++ b/numba_dpex/examples/vectorize.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/experimental/__init__.py
+++ b/numba_dpex/experimental/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2023 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/experimental/_kernel_dpcpp_spirv_overloads/__init__.py
+++ b/numba_dpex/experimental/_kernel_dpcpp_spirv_overloads/__init__.py
@@ -1,3 +1,3 @@
-# SPDX-FileCopyrightText: 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2023 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/numba_dpex/experimental/_kernel_dpcpp_spirv_overloads/_atomic_ref_overloads.py
+++ b/numba_dpex/experimental/_kernel_dpcpp_spirv_overloads/_atomic_ref_overloads.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2023 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/experimental/_kernel_dpcpp_spirv_overloads/_spv_atomic_inst_helper.py
+++ b/numba_dpex/experimental/_kernel_dpcpp_spirv_overloads/_spv_atomic_inst_helper.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2023 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/experimental/decorators.py
+++ b/numba_dpex/experimental/decorators.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2023 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/experimental/dpcpp_types.py
+++ b/numba_dpex/experimental/dpcpp_types.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2023 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/experimental/flag_enum.py
+++ b/numba_dpex/experimental/flag_enum.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2023 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/experimental/kernel_dispatcher.py
+++ b/numba_dpex/experimental/kernel_dispatcher.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2023 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/experimental/kernel_iface/__init__.py
+++ b/numba_dpex/experimental/kernel_iface/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2023 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/experimental/kernel_iface/atomic_ref.py
+++ b/numba_dpex/experimental/kernel_iface/atomic_ref.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2023 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/experimental/kernel_iface/memory_enums.py
+++ b/numba_dpex/experimental/kernel_iface/memory_enums.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2023 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/experimental/launcher.py
+++ b/numba_dpex/experimental/launcher.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2023 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/experimental/literal_intenum_type.py
+++ b/numba_dpex/experimental/literal_intenum_type.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2023 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/experimental/models.py
+++ b/numba_dpex/experimental/models.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2023 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/experimental/target.py
+++ b/numba_dpex/experimental/target.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2023 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/experimental/testing.py
+++ b/numba_dpex/experimental/testing.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2023 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/experimental/typeof.py
+++ b/numba_dpex/experimental/typeof.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2023 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/experimental/types.py
+++ b/numba_dpex/experimental/types.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2023 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/numba_patches/__init__.py
+++ b/numba_dpex/numba_patches/__init__.py
@@ -1,3 +1,3 @@
-# SPDX-FileCopyrightText: 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2023 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/numba_dpex/numba_patches/patch_arrayexpr_tree_to_ir.py
+++ b/numba_dpex/numba_patches/patch_arrayexpr_tree_to_ir.py
@@ -1,7 +1,6 @@
-# SPDX-FileCopyrightText: 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2023 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
-
 
 def patch():
     """

--- a/numba_dpex/numba_patches/patch_arrayexpr_tree_to_ir.py
+++ b/numba_dpex/numba_patches/patch_arrayexpr_tree_to_ir.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+
 def patch():
     """
     Patches the _arrayexpr_tree_to_ir function in numba.parfor.parfor.py to

--- a/numba_dpex/numba_patches/patch_is_ufunc.py
+++ b/numba_dpex/numba_patches/patch_is_ufunc.py
@@ -1,7 +1,6 @@
-# SPDX-FileCopyrightText: 2020 - 2022 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
-
 
 def patch():
     """Patches the numba.np.ufunc.array_exprs._is_ufunc function to make it

--- a/numba_dpex/numba_patches/patch_is_ufunc.py
+++ b/numba_dpex/numba_patches/patch_is_ufunc.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+
 def patch():
     """Patches the numba.np.ufunc.array_exprs._is_ufunc function to make it
     possible to support dpnp universal functions (ufuncs).

--- a/numba_dpex/numba_patches/patch_mk_alloc.py
+++ b/numba_dpex/numba_patches/patch_mk_alloc.py
@@ -1,7 +1,6 @@
-# SPDX-FileCopyrightText: 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2023 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
-
 
 def patch():
     """

--- a/numba_dpex/numba_patches/patch_mk_alloc.py
+++ b/numba_dpex/numba_patches/patch_mk_alloc.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+
 def patch():
     """
     Patches the numba.core.ir_utils.mk_alloc function to support non-NumPy array

--- a/numba_dpex/ocl/__init__.py
+++ b/numba_dpex/ocl/__init__.py
@@ -1,3 +1,3 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/numba_dpex/ocl/_declare_function.py
+++ b/numba_dpex/ocl/_declare_function.py
@@ -1,7 +1,6 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
-
 
 from llvmlite import ir as llvmir
 from numba.core import cgutils, types

--- a/numba_dpex/ocl/atomics/__init__.py
+++ b/numba_dpex/ocl/atomics/__init__.py
@@ -1,3 +1,3 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/numba_dpex/ocl/atomics/atomic_helper.py
+++ b/numba_dpex/ocl/atomics/atomic_helper.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/ocl/mathdecl.py
+++ b/numba_dpex/ocl/mathdecl.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/ocl/mathimpl.py
+++ b/numba_dpex/ocl/mathimpl.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/ocl/ocldecl.py
+++ b/numba_dpex/ocl/ocldecl.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/ocl/oclimpl.py
+++ b/numba_dpex/ocl/oclimpl.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/ocl/stubs.py
+++ b/numba_dpex/ocl/stubs.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/parfor_diagnostics.py
+++ b/numba_dpex/parfor_diagnostics.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/printimpl.py
+++ b/numba_dpex/printimpl.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/spirv_generator.py
+++ b/numba_dpex/spirv_generator.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/__init__.py
+++ b/numba_dpex/tests/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/_helper.py
+++ b/numba_dpex/tests/_helper.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/conftest.py
+++ b/numba_dpex/tests/conftest.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/core/__init__.py
+++ b/numba_dpex/tests/core/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/core/passes/__init__.py
+++ b/numba_dpex/tests/core/passes/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/core/passes/test_parfor_legalize_cfd_pass.py
+++ b/numba_dpex/tests/core/passes/test_parfor_legalize_cfd_pass.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/core/runtime/__init__.py
+++ b/numba_dpex/tests/core/runtime/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/core/runtime/test_llvm_registration.py
+++ b/numba_dpex/tests/core/runtime/test_llvm_registration.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/core/test_dpjit_target.py
+++ b/numba_dpex/tests/core/test_dpjit_target.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/core/test_itanium_mangler_extension.py
+++ b/numba_dpex/tests/core/test_itanium_mangler_extension.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/core/types/DpctlSyclEvent/__init__.py
+++ b/numba_dpex/tests/core/types/DpctlSyclEvent/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/core/types/DpctlSyclEvent/test_box.py
+++ b/numba_dpex/tests/core/types/DpctlSyclEvent/test_box.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/core/types/DpctlSyclEvent/test_models.py
+++ b/numba_dpex/tests/core/types/DpctlSyclEvent/test_models.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/core/types/DpctlSyclEvent/test_overloads.py
+++ b/numba_dpex/tests/core/types/DpctlSyclEvent/test_overloads.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import dpctl
 
 from numba_dpex import dpjit

--- a/numba_dpex/tests/core/types/DpctlSyclQueue/__init__.py
+++ b/numba_dpex/tests/core/types/DpctlSyclQueue/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/core/types/DpctlSyclQueue/test_box.py
+++ b/numba_dpex/tests/core/types/DpctlSyclQueue/test_box.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/core/types/DpctlSyclQueue/test_queue_ref_attr.py
+++ b/numba_dpex/tests/core/types/DpctlSyclQueue/test_queue_ref_attr.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/core/types/DpnpNdArray/__init__.py
+++ b/numba_dpex/tests/core/types/DpnpNdArray/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/core/types/DpnpNdArray/test_boxing_unboxing.py
+++ b/numba_dpex/tests/core/types/DpnpNdArray/test_boxing_unboxing.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/core/types/DpnpNdArray/test_bugs.py
+++ b/numba_dpex/tests/core/types/DpnpNdArray/test_bugs.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/core/types/DpnpNdArray/test_dpnp_ndarray_type.py
+++ b/numba_dpex/tests/core/types/DpnpNdArray/test_dpnp_ndarray_type.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/core/types/DpnpNdArray/test_models.py
+++ b/numba_dpex/tests/core/types/DpnpNdArray/test_models.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/core/types/USMNdArray/__init__.py
+++ b/numba_dpex/tests/core/types/USMNdArray/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/core/types/USMNdArray/test_array_creation_errors.py
+++ b/numba_dpex/tests/core/types/USMNdArray/test_array_creation_errors.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import dpctl
 import pytest
 

--- a/numba_dpex/tests/core/types/USMNdArray/test_models.py
+++ b/numba_dpex/tests/core/types/USMNdArray/test_models.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2023 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/core/types/USMNdArray/test_usm_ndarray_creation.py
+++ b/numba_dpex/tests/core/types/USMNdArray/test_usm_ndarray_creation.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import dpctl
 import pytest
 

--- a/numba_dpex/tests/core/types/USMNdArray/test_usm_ndarray_type.py
+++ b/numba_dpex/tests/core/types/USMNdArray/test_usm_ndarray_type.py
@@ -1,4 +1,4 @@
-# Copyright 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/core/types/__init__.py
+++ b/numba_dpex/tests/core/types/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/core/types/range_types/__init__.py
+++ b/numba_dpex/tests/core/types/range_types/__init__.py
@@ -1,3 +1,3 @@
-# SPDX-FileCopyrightText: 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2023 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/numba_dpex/tests/core/types/range_types/test_constructor_overloads.py
+++ b/numba_dpex/tests/core/types/range_types/test_constructor_overloads.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2023 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/core/types/range_types/test_data_model.py
+++ b/numba_dpex/tests/core/types/range_types/test_data_model.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2023 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/core/types/test_box_unbox.py
+++ b/numba_dpex/tests/core/types/test_box_unbox.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/debugging/__init__.py
+++ b/numba_dpex/tests/debugging/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/debugging/common.py
+++ b/numba_dpex/tests/debugging/common.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/debugging/conftest.py
+++ b/numba_dpex/tests/debugging/conftest.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/debugging/gdb.py
+++ b/numba_dpex/tests/debugging/gdb.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/debugging/test_backtraces.py
+++ b/numba_dpex/tests/debugging/test_backtraces.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/debugging/test_breakpoints.py
+++ b/numba_dpex/tests/debugging/test_breakpoints.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/debugging/test_common.py
+++ b/numba_dpex/tests/debugging/test_common.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/debugging/test_info.py
+++ b/numba_dpex/tests/debugging/test_info.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/debugging/test_side_by_side.py
+++ b/numba_dpex/tests/debugging/test_side_by_side.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/debugging/test_stepping.py
+++ b/numba_dpex/tests/debugging/test_stepping.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/dpjit_tests/__init__.py
+++ b/numba_dpex/tests/dpjit_tests/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/dpjit_tests/dpnp/__init__.py
+++ b/numba_dpex/tests/dpjit_tests/dpnp/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/dpjit_tests/dpnp/test_dpnp_empty.py
+++ b/numba_dpex/tests/dpjit_tests/dpnp/test_dpnp_empty.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/dpjit_tests/dpnp/test_dpnp_empty_like.py
+++ b/numba_dpex/tests/dpjit_tests/dpnp/test_dpnp_empty_like.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/dpjit_tests/dpnp/test_dpnp_full.py
+++ b/numba_dpex/tests/dpjit_tests/dpnp/test_dpnp_full.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/dpjit_tests/dpnp/test_dpnp_full_like.py
+++ b/numba_dpex/tests/dpjit_tests/dpnp/test_dpnp_full_like.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/dpjit_tests/dpnp/test_dpnp_ones.py
+++ b/numba_dpex/tests/dpjit_tests/dpnp/test_dpnp_ones.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/dpjit_tests/dpnp/test_dpnp_ones_like.py
+++ b/numba_dpex/tests/dpjit_tests/dpnp/test_dpnp_ones_like.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/dpjit_tests/dpnp/test_dpnp_zeros.py
+++ b/numba_dpex/tests/dpjit_tests/dpnp/test_dpnp_zeros.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/dpjit_tests/dpnp/test_dpnp_zeros_like.py
+++ b/numba_dpex/tests/dpjit_tests/dpnp/test_dpnp_zeros_like.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/dpjit_tests/parfors/__init__.py
+++ b/numba_dpex/tests/dpjit_tests/parfors/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/dpjit_tests/parfors/prange/__init__.py
+++ b/numba_dpex/tests/dpjit_tests/parfors/prange/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2024 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/numba_dpex/tests/dpjit_tests/parfors/prange/test_pairwise_distance.py
+++ b/numba_dpex/tests/dpjit_tests/parfors/prange/test_pairwise_distance.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/dpjit_tests/parfors/test_builtin_ops.py
+++ b/numba_dpex/tests/dpjit_tests/parfors/test_builtin_ops.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/dpjit_tests/parfors/test_dpnp_bitwise_ops.py
+++ b/numba_dpex/tests/dpjit_tests/parfors/test_dpnp_bitwise_ops.py
@@ -1,7 +1,6 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
-
 
 import dpctl.tensor as dpt
 import dpnp

--- a/numba_dpex/tests/dpjit_tests/parfors/test_dpnp_logic_ops.py
+++ b/numba_dpex/tests/dpjit_tests/parfors/test_dpnp_logic_ops.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/dpjit_tests/parfors/test_dpnp_transcedental_functions.py
+++ b/numba_dpex/tests/dpjit_tests/parfors/test_dpnp_transcedental_functions.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/dpjit_tests/parfors/test_dpnp_trigonometric_functions.py
+++ b/numba_dpex/tests/dpjit_tests/parfors/test_dpnp_trigonometric_functions.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/dpjit_tests/test_dpjit_complex_arg_types.py
+++ b/numba_dpex/tests/dpjit_tests/test_dpjit_complex_arg_types.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/dpjit_tests/test_dpjit_reduction.py
+++ b/numba_dpex/tests/dpjit_tests/test_dpjit_reduction.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/dpjit_tests/test_slicing.py
+++ b/numba_dpex/tests/dpjit_tests/test_slicing.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/experimental/IntEnumLiteral/__init__.py
+++ b/numba_dpex/tests/experimental/IntEnumLiteral/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2024 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/numba_dpex/tests/experimental/IntEnumLiteral/test_compilation.py
+++ b/numba_dpex/tests/experimental/IntEnumLiteral/test_compilation.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2023 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/experimental/IntEnumLiteral/test_type_creation.py
+++ b/numba_dpex/tests/experimental/IntEnumLiteral/test_type_creation.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2023 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/experimental/IntEnumLiteral/test_type_registration.py
+++ b/numba_dpex/tests/experimental/IntEnumLiteral/test_type_registration.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2023 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/experimental/__init__.py
+++ b/numba_dpex/tests/experimental/__init__.py
@@ -1,3 +1,3 @@
-# SPDX-FileCopyrightText: 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2023 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/numba_dpex/tests/experimental/codegen/__init__.py
+++ b/numba_dpex/tests/experimental/codegen/__init__.py
@@ -1,3 +1,3 @@
-# SPDX-FileCopyrightText: 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2023 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/numba_dpex/tests/experimental/codegen/test_inline_threshold_codegen.py
+++ b/numba_dpex/tests/experimental/codegen/test_inline_threshold_codegen.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2023 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/experimental/codegen/test_intenum_literal_codegen.py
+++ b/numba_dpex/tests/experimental/codegen/test_intenum_literal_codegen.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2023 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/experimental/kernel_iface/__init__.py
+++ b/numba_dpex/tests/experimental/kernel_iface/__init__.py
@@ -1,3 +1,3 @@
-# SPDX-FileCopyrightText: 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2023 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/numba_dpex/tests/experimental/kernel_iface/spv_overloads/__init__.py
+++ b/numba_dpex/tests/experimental/kernel_iface/spv_overloads/__init__.py
@@ -1,3 +1,3 @@
-# SPDX-FileCopyrightText: 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2023 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/numba_dpex/tests/experimental/kernel_iface/spv_overloads/test_atomic_fetch_phi.py
+++ b/numba_dpex/tests/experimental/kernel_iface/spv_overloads/test_atomic_fetch_phi.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2023 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/experimental/kernel_iface/spv_overloads/test_atomic_ref.py
+++ b/numba_dpex/tests/experimental/kernel_iface/spv_overloads/test_atomic_ref.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2023 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/experimental/kernel_iface/test_memory_enum_compilation.py
+++ b/numba_dpex/tests/experimental/kernel_iface/test_memory_enum_compilation.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2023 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/experimental/test_async_kernel.py
+++ b/numba_dpex/tests/experimental/test_async_kernel.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2023 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/experimental/test_compiler_warnings.py
+++ b/numba_dpex/tests/experimental/test_compiler_warnings.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2023 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/experimental/test_exec_queue_inference.py
+++ b/numba_dpex/tests/experimental/test_exec_queue_inference.py
@@ -1,7 +1,6 @@
-# SPDX-FileCopyrightText: 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2023 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
-
 
 import dpctl
 import dpnp

--- a/numba_dpex/tests/experimental/test_inline_threshold_config.py
+++ b/numba_dpex/tests/experimental/test_inline_threshold_config.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2023 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/experimental/test_kernel_dispatcher.py
+++ b/numba_dpex/tests/experimental/test_kernel_dispatcher.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2023 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/experimental/test_kernel_specialization.py
+++ b/numba_dpex/tests/experimental/test_kernel_specialization.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2022 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/experimental/test_strided_dpnp_array_in_kernel.py
+++ b/numba_dpex/tests/experimental/test_strided_dpnp_array_in_kernel.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/experimental/test_supported_array_types_as_kernel_args.py
+++ b/numba_dpex/tests/experimental/test_supported_array_types_as_kernel_args.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2022 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/experimental/test_target_specific_overload.py
+++ b/numba_dpex/tests/experimental/test_target_specific_overload.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2023 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/kernel_tests/__init__.py
+++ b/numba_dpex/tests/kernel_tests/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/kernel_tests/test_atomic_op.py
+++ b/numba_dpex/tests/kernel_tests/test_atomic_op.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/kernel_tests/test_barrier.py
+++ b/numba_dpex/tests/kernel_tests/test_barrier.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/kernel_tests/test_caching.py
+++ b/numba_dpex/tests/kernel_tests/test_caching.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/kernel_tests/test_complex_array.py
+++ b/numba_dpex/tests/kernel_tests/test_complex_array.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/kernel_tests/test_dpnp_ndarray_args.py
+++ b/numba_dpex/tests/kernel_tests/test_dpnp_ndarray_args.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/kernel_tests/test_dump_kernel_llvm.py
+++ b/numba_dpex/tests/kernel_tests/test_dump_kernel_llvm.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/kernel_tests/test_func.py
+++ b/numba_dpex/tests/kernel_tests/test_func.py
@@ -1,7 +1,6 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
-
 
 import dpnp
 import numpy

--- a/numba_dpex/tests/kernel_tests/test_func_qualname_disambiguation.py
+++ b/numba_dpex/tests/kernel_tests/test_func_qualname_disambiguation.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2023 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/kernel_tests/test_func_specialization.py
+++ b/numba_dpex/tests/kernel_tests/test_func_specialization.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2023 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/kernel_tests/test_invalid_kernel_args.py
+++ b/numba_dpex/tests/kernel_tests/test_invalid_kernel_args.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/kernel_tests/test_kernel_has_return_value_error.py
+++ b/numba_dpex/tests/kernel_tests/test_kernel_has_return_value_error.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/kernel_tests/test_kernel_launch_params.py
+++ b/numba_dpex/tests/kernel_tests/test_kernel_launch_params.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/kernel_tests/test_kernel_specialization.py
+++ b/numba_dpex/tests/kernel_tests/test_kernel_specialization.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2022 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/kernel_tests/test_math_functions.py
+++ b/numba_dpex/tests/kernel_tests/test_math_functions.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/kernel_tests/test_ndrange_exceptions.py
+++ b/numba_dpex/tests/kernel_tests/test_ndrange_exceptions.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/kernel_tests/test_print.py
+++ b/numba_dpex/tests/kernel_tests/test_print.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/kernel_tests/test_private_memory_allocation.py
+++ b/numba_dpex/tests/kernel_tests/test_private_memory_allocation.py
@@ -1,7 +1,6 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
-
 
 import dpnp
 import numpy

--- a/numba_dpex/tests/kernel_tests/test_scalar_arg_types.py
+++ b/numba_dpex/tests/kernel_tests/test_scalar_arg_types.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/kernel_tests/test_sycl_usm_array_iface_interop.py
+++ b/numba_dpex/tests/kernel_tests/test_sycl_usm_array_iface_interop.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/kernel_tests/test_usm_ndarray_interop.py
+++ b/numba_dpex/tests/kernel_tests/test_usm_ndarray_interop.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/misc/__init__.py
+++ b/numba_dpex/tests/misc/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/misc/test_dpctl_version.py
+++ b/numba_dpex/tests/misc/test_dpctl_version.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/misc/test_parse_sem_version.py
+++ b/numba_dpex/tests/misc/test_parse_sem_version.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/misc/test_warnings.py
+++ b/numba_dpex/tests/misc/test_warnings.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import warnings
 
 import dpnp

--- a/numba_dpex/tests/test_array_utils.py
+++ b/numba_dpex/tests/test_array_utils.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/test_debuginfo.py
+++ b/numba_dpex/tests/test_debuginfo.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/test_examples.py
+++ b/numba_dpex/tests/test_examples.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/test_prange.py
+++ b/numba_dpex/tests/test_prange.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 
-# Copyright 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/tests/test_vectorize.py
+++ b/numba_dpex/tests/test_vectorize.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/utils/__init__.py
+++ b/numba_dpex/utils/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/utils/array_utils.py
+++ b/numba_dpex/utils/array_utils.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/utils/constants.py
+++ b/numba_dpex/utils/constants.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/utils/llvm_codegen_helpers.py
+++ b/numba_dpex/utils/llvm_codegen_helpers.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/numba_dpex/vectorizers.py
+++ b/numba_dpex/vectorizers.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 Intel Corporation
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/scripts/update_copyrights.py
+++ b/scripts/update_copyrights.py
@@ -30,4 +30,7 @@ def update_copyrights(root_dir, year):
 path = os.path.dirname(os.path.realpath(__file__))
 source_path = os.path.dirname(path)
 
-update_copyrights(source_path + "/numba_dpex", 2023)
+if __name__ == "__main__":
+    print("Provide new copyright year:")
+    year = input()
+    update_copyrights(source_path + "/numba_dpex", year)


### PR DESCRIPTION
Updates all copyright notices to latest year: 2024.

Also modified the update_copyright script slightly to make the year option dynamic instead of being hard coded.