### PR TITLE
Refactor all tests for strided dpnp arrays in kernel with different layouts

### DIFF
--- a/numba_dpex/tests/experimental/test_strided_dpnp_array_in_kernel.py
+++ b/numba_dpex/tests/experimental/test_strided_dpnp_array_in_kernel.py
@@ -2,23 +2,72 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import math
+
 import dpnp
+import numpy as np
+import pytest
 
 import numba_dpex
 import numba_dpex.experimental as exp_dpex
-from numba_dpex import NdRange, Range
+from numba_dpex import Range
+
+
+def get_order(a):
+    """Get order of an array.
+
+    Args:
+        a (numpy.ndarray, dpnp.ndarray): Input array.
+
+    Raises:
+        Exception: _description_
+
+    Returns:
+        str: 'C' if c-contiguous, 'F' if f-contiguous or 'A' if aligned.
+    """
+    if a.flags.c_contiguous and not a.flags.f_contiguous:
+        return "C"
+    elif not a.flags.c_contiguous and a.flags.f_contiguous:
+        return "F"
+    elif a.flags.c_contiguous and a.flags.f_contiguous:
+        return "A"
+    else:
+        raise Exception("Unknown order/layout")
 
 
 @exp_dpex.kernel
 def change_values_1d(x, v):
+    """Assign values in a 1d dpnp.ndarray
+
+    Args:
+        x (dpnp.ndarray): Input array.
+        v (int): Value to be assigned.
+    """
     i = numba_dpex.get_global_id(0)
     p = x[i]  # getitem
     p = v
     x[i] = p  # setitem
 
 
+def change_values_1d_func(a, p):
+    """Assign values in a 1d numpy.ndarray
+
+    Args:
+        a (numpy.ndarray): Input array.
+        p (int): Value to be assigned.
+    """
+    for i in range(a.shape[0]):
+        a[i] = p
+
+
 @exp_dpex.kernel
 def change_values_2d(x, v):
+    """Assign values in a 2d dpnp.ndarray
+
+    Args:
+        x (dpnp.ndarray): Input array.
+        v (int): Value to be assigned.
+    """
     i = numba_dpex.get_global_id(0)
     j = numba_dpex.get_global_id(1)
     p = x[i, j]  # getitem
@@ -26,8 +75,26 @@ def change_values_2d(x, v):
     x[i, j] = p  # setitem
 
 
+def change_values_2d_func(a, p):
+    """Assign values in a 2d numpy.ndarray
+
+    Args:
+        a (numpy.ndarray): Input array.
+        p (int): Value to be assigned.
+    """
+    for i in range(a.shape[0]):
+        for j in range(a.shape[1]):
+            a[i, j] = p
+
+
 @exp_dpex.kernel
 def change_values_3d(x, v):
+    """Assign values in a 3d dpnp.ndarray
+
+    Args:
+        x (dpnp.ndarray): Input array.
+        v (int): Value to be assigned.
+    """
     i = numba_dpex.get_global_id(0)
     j = numba_dpex.get_global_id(1)
     k = numba_dpex.get_global_id(2)
@@ -36,74 +103,192 @@ def change_values_3d(x, v):
     x[i, j, k] = p  # setitem
 
 
-def test_strided_dpnp_array_in_kernel():
+def change_values_3d_func(a, p):
+    """Assign values in a 3d numpy.ndarray
+
+    Args:
+        a (numpy.ndarray): Input array.
+        p (int): Value to be assigned.
+    """
+    for i in range(a.shape[0]):
+        for j in range(a.shape[1]):
+            for k in range(a.shape[2]):
+                a[i, j, k] = p
+
+
+@pytest.mark.parametrize("N", [8, 16, 32, 64, 128, 256, 512])
+@pytest.mark.parametrize("s", [1, 2, 3, 4, 5, 6, 7])
+def test_1d_strided_dpnp_array_in_kernel(N, s):
     """
     Tests if we can correctly handle a strided 1d dpnp array
     inside dpex kernel.
     """
-    N = 1024
-    out = dpnp.arange(0, N * 2, dtype=dpnp.int64)
-    b = out[::2]
+    k = -3
 
-    r = Range(N)
-    v = -3
-    exp_dpex.call_kernel(change_values_1d, r, b, v)
+    t = np.arange(0, N, dtype=dpnp.int64)
+    u = dpnp.asarray(t)
 
-    assert (dpnp.asnumpy(b) == v).all()
+    v = u[::s]
+    exp_dpex.call_kernel(change_values_1d, Range(v.shape[0]), v, k)
+
+    x = t[::s]
+    change_values_1d_func(x, k)
+
+    # check the value of the array view
+    assert np.all(dpnp.asnumpy(v) == x)
+    # check the value of the original arrays
+    assert np.all(dpnp.asnumpy(u) == t)
 
 
-def test_multievel_strided_dpnp_array_in_kernel():
+@pytest.mark.parametrize("N", [8, 16, 32, 64, 128])
+@pytest.mark.parametrize("s", [2, 3, 4, 5])
+def test_multievel_1d_strided_dpnp_array_in_kernel(N, s):
     """
     Tests if we can correctly handle a multilevel strided 1d dpnp array
     inside dpex kernel.
     """
-    N = 128
-    out = dpnp.arange(0, N * 2, dtype=dpnp.int64)
-    v = -3
+    k = -3
 
-    b = out
-    n = N
-    K = 7
-    for _ in range(K):
-        b = b[::2]
-        exp_dpex.call_kernel(change_values_1d, Range(n), b, v)
-        assert (dpnp.asnumpy(b) == v).all()
-        n = int(n / 2)
+    t = dpnp.arange(0, N, dtype=dpnp.int64)
+    u = dpnp.asarray(t)
+
+    v, x = u, t
+    while v.shape[0] > 1:
+        v = v[::s]
+        exp_dpex.call_kernel(change_values_1d, Range(v.shape[0]), v, k)
+
+        x = x[::s]
+        change_values_1d_func(x, k)
+
+        # check the value of the array view
+        assert np.all(dpnp.asnumpy(v) == x)
+        # check the value of the original arrays
+        assert np.all(dpnp.asnumpy(u) == t)
 
 
-def test_multilevel_2d_strided_dpnp_array_in_kernel():
+@pytest.mark.parametrize("M", [3, 5, 7, 9])
+@pytest.mark.parametrize("N", [2, 4, 6, 8])
+@pytest.mark.parametrize("s1", [2, 4, 6])
+@pytest.mark.parametrize("s2", [1, 3, 5])
+@pytest.mark.parametrize("order", ["C", "F"])
+def test_2d_strided_dpnp_array_in_kernel(M, N, s1, s2, order):
+    """
+    Tests if we can correctly handle a strided 2d dpnp array
+    inside dpex kernel.
+    """
+    k = -3
+
+    t = np.arange(0, M * N, dtype=np.int64).reshape(M, N, order=order)
+    u = dpnp.asarray(t)
+
+    # check order, sanity check
+    assert get_order(u) == order
+
+    v = u[::s1, ::s2]
+    exp_dpex.call_kernel(change_values_2d, Range(*v.shape), v, k)
+
+    x = t[::s1, ::s2]
+    change_values_2d_func(x, k)
+
+    # check the value of the array view
+    assert np.all(dpnp.asnumpy(v) == x)
+    # check the value of the original arrays
+    assert np.all(dpnp.asnumpy(u) == t)
+
+
+@pytest.mark.parametrize("M", [5, 7, 9, 11])
+@pytest.mark.parametrize("N", [4, 6, 8, 10])
+@pytest.mark.parametrize("s1", [2, 4, 6])
+@pytest.mark.parametrize("s2", [3, 5, 7])
+@pytest.mark.parametrize("order", ["C", "F"])
+def test_multilevel_2d_strided_dpnp_array_in_kernel(M, N, s1, s2, order):
     """
     Tests if we can correctly handle a multilevel strided 2d dpnp array
     inside dpex kernel.
     """
-    N = 128
-    out, _ = dpnp.mgrid[0 : N * 2, 0 : N * 2]  # noqa: E203
-    v = -3
+    k = -3
 
-    b = out
-    n = N
-    K = 7
-    for _ in range(K):
-        b = b[::2, ::2]
-        exp_dpex.call_kernel(change_values_2d, Range(n, n), b, v)
-        assert (dpnp.asnumpy(b) == v).all()
-        n = int(n / 2)
+    t = np.arange(0, M * N, dtype=np.int64).reshape(M, N, order=order)
+    u = dpnp.asarray(t)
+
+    # check order, sanity check
+    assert get_order(u) == order
+
+    v, x = u, t
+    while v.shape[0] > 1 and v.shape[1] > 1:
+        v = v[::s1, ::s2]
+        exp_dpex.call_kernel(change_values_2d, Range(*v.shape), v, k)
+
+        x = x[::s1, ::s2]
+        change_values_2d_func(x, k)
+
+        # check the value of the array view
+        assert np.all(dpnp.asnumpy(v) == x)
+        # check the value of the original arrays
+        assert np.all(dpnp.asnumpy(u) == t)
 
 
-def test_multilevel_3d_strided_dpnp_array_in_kernel():
+@pytest.mark.parametrize("M", [2, 3, 4])
+@pytest.mark.parametrize("N", [5, 6, 7])
+@pytest.mark.parametrize("K", [8, 9, 10])
+@pytest.mark.parametrize("s1", [1, 2, 3])
+@pytest.mark.parametrize("s2", [2, 3, 4])
+@pytest.mark.parametrize("s3", [3, 4, 5])
+@pytest.mark.parametrize("order", ["C", "F"])
+def test_3d_strided_dpnp_array_in_kernel(M, N, K, s1, s2, s3, order):
+    """
+    Tests if we can correctly handle a strided 3d dpnp array
+    inside dpex kernel.
+    """
+    k = -3
+
+    t = np.arange(0, M * N * K, dtype=np.int64).reshape((M, N, K), order=order)
+    u = dpnp.asarray(t)
+
+    # check order, sanity check
+    assert get_order(u) == order
+
+    v = u[::s1, ::s2, ::s3]
+    exp_dpex.call_kernel(change_values_3d, Range(*v.shape), v, k)
+
+    x = t[::s1, ::s2, ::s3]
+    change_values_3d_func(x, k)
+
+    # check the value of the array view
+    assert np.all(dpnp.asnumpy(v) == x)
+    # check the value of the original arrays
+    assert np.all(dpnp.asnumpy(u) == t)
+
+
+@pytest.mark.parametrize("M", [5, 6, 7])
+@pytest.mark.parametrize("N", [8, 9, 10])
+@pytest.mark.parametrize("K", [11, 12, 13])
+@pytest.mark.parametrize("s1", [2, 3, 4])
+@pytest.mark.parametrize("s2", [3, 4, 5])
+@pytest.mark.parametrize("s3", [4, 5, 6])
+@pytest.mark.parametrize("order", ["C", "F"])
+def test_multilevel_3d_strided_dpnp_array_in_kernel(M, N, K, s1, s2, s3, order):
     """
     Tests if we can correctly handle a multilevel strided 3d dpnp array
     inside dpex kernel.
     """
-    N = 128
-    out, _, _ = dpnp.mgrid[0 : N * 2, 0 : N * 2, 0 : N * 2]  # noqa: E203
-    v = -3
+    k = -3
 
-    b = out
-    n = N
-    K = 7
-    for _ in range(K):
-        b = b[::2, ::2, ::2]
-        exp_dpex.call_kernel(change_values_3d, Range(n, n, n), b, v)
-        assert (dpnp.asnumpy(b) == v).all()
-        n = int(n / 2)
+    t = np.arange(0, M * N * K, dtype=np.int64).reshape((M, N, K), order=order)
+    u = dpnp.asarray(t)
+
+    # check order, sanity check
+    assert get_order(u) == order
+
+    v, x = u, t
+    while v.shape[0] > 1 and v.shape[1] > 1 and v.shape[2] > 1:
+        v = v[::s1, ::s2, ::s3]
+        exp_dpex.call_kernel(change_values_3d, Range(*v.shape), v, k)
+
+        x = x[::s1, ::s2, ::s3]
+        change_values_3d_func(x, k)
+
+        # check the value of the array view
+        assert np.all(dpnp.asnumpy(v) == x)
+        # check the value of the original arrays
+        assert np.all(dpnp.asnumpy(u) == t)

--- a/numba_dpex/tests/experimental/test_strided_dpnp_array_in_kernel.py
+++ b/numba_dpex/tests/experimental/test_strided_dpnp_array_in_kernel.py
@@ -70,9 +70,7 @@ def change_values_2d(x, v):
     """
     i = numba_dpex.get_global_id(0)
     j = numba_dpex.get_global_id(1)
-    p = x[i, j]  # getitem
-    p = v
-    x[i, j] = p  # setitem
+    x[i, j] = v
 
 
 def change_values_2d_func(a, p):
@@ -98,9 +96,7 @@ def change_values_3d(x, v):
     i = numba_dpex.get_global_id(0)
     j = numba_dpex.get_global_id(1)
     k = numba_dpex.get_global_id(2)
-    p = x[i, j, k]  # getitem
-    p = v
-    x[i, j, k] = p  # setitem
+    x[i, j, k] = v
 
 
 def change_values_3d_func(a, p):
@@ -116,13 +112,13 @@ def change_values_3d_func(a, p):
                 a[i, j, k] = p
 
 
-@pytest.mark.parametrize("N", [8, 16, 32, 64, 128, 256, 512])
 @pytest.mark.parametrize("s", [1, 2, 3, 4, 5, 6, 7])
-def test_1d_strided_dpnp_array_in_kernel(N, s):
+def test_1d_strided_dpnp_array_in_kernel(s):
     """
     Tests if we can correctly handle a strided 1d dpnp array
     inside dpex kernel.
     """
+    N = 256
     k = -3
 
     t = np.arange(0, N, dtype=dpnp.int64)
@@ -140,13 +136,13 @@ def test_1d_strided_dpnp_array_in_kernel(N, s):
     assert np.all(dpnp.asnumpy(u) == t)
 
 
-@pytest.mark.parametrize("N", [8, 16, 32, 64, 128])
 @pytest.mark.parametrize("s", [2, 3, 4, 5])
-def test_multievel_1d_strided_dpnp_array_in_kernel(N, s):
+def test_multievel_1d_strided_dpnp_array_in_kernel(s):
     """
     Tests if we can correctly handle a multilevel strided 1d dpnp array
     inside dpex kernel.
     """
+    N = 256
     k = -3
 
     t = dpnp.arange(0, N, dtype=dpnp.int64)
@@ -166,16 +162,15 @@ def test_multievel_1d_strided_dpnp_array_in_kernel(N, s):
         assert np.all(dpnp.asnumpy(u) == t)
 
 
-@pytest.mark.parametrize("M", [3, 5, 7, 9])
-@pytest.mark.parametrize("N", [2, 4, 6, 8])
-@pytest.mark.parametrize("s1", [2, 4, 6])
-@pytest.mark.parametrize("s2", [1, 3, 5])
+@pytest.mark.parametrize("s1", [2, 4, 6, 8])
+@pytest.mark.parametrize("s2", [1, 3, 5, 7])
 @pytest.mark.parametrize("order", ["C", "F"])
-def test_2d_strided_dpnp_array_in_kernel(M, N, s1, s2, order):
+def test_2d_strided_dpnp_array_in_kernel(s1, s2, order):
     """
     Tests if we can correctly handle a strided 2d dpnp array
     inside dpex kernel.
     """
+    M, N = 13, 31
     k = -3
 
     t = np.arange(0, M * N, dtype=np.int64).reshape(M, N, order=order)
@@ -196,16 +191,15 @@ def test_2d_strided_dpnp_array_in_kernel(M, N, s1, s2, order):
     assert np.all(dpnp.asnumpy(u) == t)
 
 
-@pytest.mark.parametrize("M", [5, 7, 9, 11])
-@pytest.mark.parametrize("N", [4, 6, 8, 10])
-@pytest.mark.parametrize("s1", [2, 4, 6])
-@pytest.mark.parametrize("s2", [3, 5, 7])
+@pytest.mark.parametrize("s1", [2, 4, 6, 8])
+@pytest.mark.parametrize("s2", [3, 5, 7, 9])
 @pytest.mark.parametrize("order", ["C", "F"])
-def test_multilevel_2d_strided_dpnp_array_in_kernel(M, N, s1, s2, order):
+def test_multilevel_2d_strided_dpnp_array_in_kernel(s1, s2, order):
     """
     Tests if we can correctly handle a multilevel strided 2d dpnp array
     inside dpex kernel.
     """
+    M, N = 13, 31
     k = -3
 
     t = np.arange(0, M * N, dtype=np.int64).reshape(M, N, order=order)
@@ -228,18 +222,16 @@ def test_multilevel_2d_strided_dpnp_array_in_kernel(M, N, s1, s2, order):
         assert np.all(dpnp.asnumpy(u) == t)
 
 
-@pytest.mark.parametrize("M", [2, 3, 4])
-@pytest.mark.parametrize("N", [5, 6, 7])
-@pytest.mark.parametrize("K", [8, 9, 10])
 @pytest.mark.parametrize("s1", [1, 2, 3])
 @pytest.mark.parametrize("s2", [2, 3, 4])
 @pytest.mark.parametrize("s3", [3, 4, 5])
 @pytest.mark.parametrize("order", ["C", "F"])
-def test_3d_strided_dpnp_array_in_kernel(M, N, K, s1, s2, s3, order):
+def test_3d_strided_dpnp_array_in_kernel(s1, s2, s3, order):
     """
     Tests if we can correctly handle a strided 3d dpnp array
     inside dpex kernel.
     """
+    M, N, K = 13, 31, 11
     k = -3
 
     t = np.arange(0, M * N * K, dtype=np.int64).reshape((M, N, K), order=order)
@@ -260,18 +252,16 @@ def test_3d_strided_dpnp_array_in_kernel(M, N, K, s1, s2, s3, order):
     assert np.all(dpnp.asnumpy(u) == t)
 
 
-@pytest.mark.parametrize("M", [5, 6, 7])
-@pytest.mark.parametrize("N", [8, 9, 10])
-@pytest.mark.parametrize("K", [11, 12, 13])
 @pytest.mark.parametrize("s1", [2, 3, 4])
 @pytest.mark.parametrize("s2", [3, 4, 5])
 @pytest.mark.parametrize("s3", [4, 5, 6])
 @pytest.mark.parametrize("order", ["C", "F"])
-def test_multilevel_3d_strided_dpnp_array_in_kernel(M, N, K, s1, s2, s3, order):
+def test_multilevel_3d_strided_dpnp_array_in_kernel(s1, s2, s3, order):
     """
     Tests if we can correctly handle a multilevel strided 3d dpnp array
     inside dpex kernel.
     """
+    M, N, K = 13, 31, 11
     k = -3
 
     t = np.arange(0, M * N * K, dtype=np.int64).reshape((M, N, K), order=order)

--- a/numba_dpex/tests/experimental/test_strided_dpnp_array_in_kernel.py
+++ b/numba_dpex/tests/experimental/test_strided_dpnp_array_in_kernel.py
@@ -44,9 +44,7 @@ def change_values_1d(x, v):
         v (int): Value to be assigned.
     """
     i = numba_dpex.get_global_id(0)
-    p = x[i]  # getitem
-    p = v
-    x[i] = p  # setitem
+    x[i] = v
 
 
 def change_values_1d_func(a, p):


### PR DESCRIPTION
1. Strided array correctly works with the current code.
2. This PR performs unit test for all situations (differing dimensions, shape, strides, view-of-views etc.)
3. This PR performs unit test for both `C` and `F` contiguous arrays.
4. This is relevant to the experimental kernel, will not work with the old kernel code.

This PR finally resolves #572 and supersedes #1268 and #1271

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?

Fixes #572, #363
