### PR TITLE
Remove DEFAULT_LOCAL_SIZE completely from the code

### DIFF
--- a/docs/source/user_guide/kernel_programming/writing_kernels.rst
+++ b/docs/source/user_guide/kernel_programming/writing_kernels.rst
@@ -30,33 +30,6 @@ storing the result of vector summation:
    :name: ex_kernel_declaration_vector_sum
 
 
-.. Kernel Invocation
-.. ------------------
-
-.. When a kernel is launched you must specify the *global size* and the *local size*,
-.. which determine the hierarchy of threads, that is the order in which kernels
-.. will be invoked.
-
-.. The following syntax is used in ``numba-dpex`` for kernel invocation with
-.. specified global and local sizes:
-
-.. ``kernel_function_name[global_size, local_size](kernel arguments)``
-
-.. In the following example we invoke kernel ``kernel_vector_sum`` with global size
-.. specified via variable ``global_size``, and use ``numba_dpex.DEFAULT_LOCAL_SIZE``
-.. constant for setting local size to some default value:
-
-.. .. code-block:: python
-
-..    import numba_dpex as ndpx
-
-..    global_size = 10
-..    kernel_vector_sum[global_size, ndpx.DEFAULT_LOCAL_SIZE](a, b, c)
-
-.. .. note::
-..   Each kernel is compiled once, but it can be called multiple times with different global and local sizes settings.
-
-
 Kernel Invocation
 ------------------
 

--- a/docs/source/user_guide/programming_model.rst
+++ b/docs/source/user_guide/programming_model.rst
@@ -161,7 +161,7 @@ Specifying the execution queue is done using Python context manager:
    with dpctl.device_context(q):
        # apply the kernel to elements of X, writing value into Y,
        # while executing using given queue
-       numba_dpex_poly[X.size, numba_dpex.DEFAULT_LOCAL_SIZE](X, Y)
+       numba_dpex_poly[numba_dpex.Range(X.size)](X, Y)
 
 The argument to ``device_context`` can be a queue object, a device object for
 which a temporary queue will be created, or a filter selector string. Thus we

--- a/numba_dpex/__init__.py
+++ b/numba_dpex/__init__.py
@@ -131,7 +131,6 @@ from .ocl.stubs import (  # noqa E402
     sub_group_barrier,
 )
 
-DEFAULT_LOCAL_SIZE = []
 load_dpctl_sycl_interface()
 del load_dpctl_sycl_interface
 

--- a/numba_dpex/vectorizers.py
+++ b/numba_dpex/vectorizers.py
@@ -194,7 +194,7 @@ class UFuncMechanism(deviceufunc.UFuncMechanism):
         copy_to_numpy_from_usm_obj(devary_memview, hostary)
 
     def launch(self, func, count, queue, args):
-        func[count, dpex.DEFAULT_LOCAL_SIZE](*args)
+        func[dpex.Range(count)](*args)
 
     def device_array(self, shape, dtype, queue):
         size = np.prod(shape)


### PR DESCRIPTION
Remove the `DEFAULT_LOCAL_SIZE` from the codebase.

This fixes #1273 

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?