### PR TITLE
Move FlagEnum into kernel_api.

### DIFF
--- a/numba_dpex/experimental/_kernel_dpcpp_spirv_overloads/_atomic_ref_overloads.py
+++ b/numba_dpex/experimental/_kernel_dpcpp_spirv_overloads/_atomic_ref_overloads.py
@@ -14,13 +14,13 @@ from numba.extending import intrinsic, overload, overload_method
 from numba_dpex.core import itanium_mangler as ext_itanium_mangler
 from numba_dpex.core.targets.kernel_target import CC_SPIR_FUNC, LLVM_SPIRV_ARGS
 from numba_dpex.core.types import USMNdArray
-from numba_dpex.experimental.flag_enum import FlagEnum
 from numba_dpex.kernel_api import (
     AddressSpace,
     AtomicRef,
     MemoryOrder,
     MemoryScope,
 )
+from numba_dpex.kernel_api.flag_enum import FlagEnum
 
 from ..dpcpp_types import AtomicRefType
 from ..target import DPEX_KERNEL_EXP_TARGET_NAME

--- a/numba_dpex/experimental/literal_intenum_type.py
+++ b/numba_dpex/experimental/literal_intenum_type.py
@@ -13,7 +13,7 @@ from numba.core.types import Integer, Literal
 from numba.core.typing.typeof import typeof
 
 from numba_dpex.core.exceptions import IllegalIntEnumLiteralValueError
-from numba_dpex.experimental.flag_enum import FlagEnum
+from numba_dpex.kernel_api.flag_enum import FlagEnum
 
 
 class IntEnumLiteral(Literal, Integer):

--- a/numba_dpex/experimental/target.py
+++ b/numba_dpex/experimental/target.py
@@ -20,8 +20,8 @@ from numba_dpex.core.targets.kernel_target import (
     DpexKernelTypingContext,
 )
 from numba_dpex.experimental.models import exp_dmm
+from numba_dpex.kernel_api.flag_enum import FlagEnum
 
-from .flag_enum import FlagEnum
 from .literal_intenum_type import IntEnumLiteral
 
 

--- a/numba_dpex/kernel_api/flag_enum.py
+++ b/numba_dpex/kernel_api/flag_enum.py
@@ -2,7 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Provides a FlagEnum class to help distinguish IntEnum types that numba-dpex
+"""
+Provides a FlagEnum class to help distinguish IntEnum types that numba_dpex
 intends to use as Integer literal types inside the compiler type inferring
 infrastructure.
 """
@@ -10,13 +11,13 @@ from enum import IntEnum
 
 
 class FlagEnum(IntEnum):
-    """Helper class to distinguish IntEnum types that numba-dpex should consider
+    """Helper class to distinguish IntEnum types that numba_dpex should consider
     as Numba Literal types.
     """
 
     @classmethod
     def basetype(cls) -> int:
-        """Returns an dummy int object that helps numba-dpex infer the type of
+        """Returns an dummy int object that helps numba_dpex infer the type of
         an instance of a FlagEnum class.
 
         Returns:

--- a/numba_dpex/kernel_api/memory_enums.py
+++ b/numba_dpex/kernel_api/memory_enums.py
@@ -6,7 +6,7 @@
 memory enum classes.
 """
 
-from numba_dpex.experimental.flag_enum import FlagEnum
+from numba_dpex.kernel_api.flag_enum import FlagEnum
 
 
 class MemoryOrder(FlagEnum):

--- a/numba_dpex/tests/experimental/IntEnumLiteral/test_compilation.py
+++ b/numba_dpex/tests/experimental/IntEnumLiteral/test_compilation.py
@@ -6,7 +6,7 @@ import dpnp
 
 import numba_dpex.experimental as exp_dpex
 from numba_dpex import Range
-from numba_dpex.experimental.flag_enum import FlagEnum
+from numba_dpex.kernel_api.flag_enum import FlagEnum
 
 
 class MockFlags(FlagEnum):

--- a/numba_dpex/tests/experimental/IntEnumLiteral/test_type_creation.py
+++ b/numba_dpex/tests/experimental/IntEnumLiteral/test_type_creation.py
@@ -8,7 +8,7 @@ import pytest
 
 from numba_dpex.core.exceptions import IllegalIntEnumLiteralValueError
 from numba_dpex.experimental import IntEnumLiteral
-from numba_dpex.experimental.flag_enum import FlagEnum
+from numba_dpex.kernel_api.flag_enum import FlagEnum
 
 
 def test_intenumliteral_creation():

--- a/numba_dpex/tests/experimental/IntEnumLiteral/test_type_registration.py
+++ b/numba_dpex/tests/experimental/IntEnumLiteral/test_type_registration.py
@@ -7,8 +7,8 @@ from numba.core.datamodel import default_manager
 
 from numba_dpex.core.datamodel.models import dpex_data_model_manager
 from numba_dpex.experimental import IntEnumLiteral
-from numba_dpex.experimental.flag_enum import FlagEnum
 from numba_dpex.experimental.models import exp_dmm
+from numba_dpex.kernel_api.flag_enum import FlagEnum
 
 
 def test_data_model_registration():

--- a/numba_dpex/tests/experimental/codegen/test_intenum_literal_codegen.py
+++ b/numba_dpex/tests/experimental/codegen/test_intenum_literal_codegen.py
@@ -9,7 +9,7 @@ from numba.core import types
 
 import numba_dpex.experimental as exp_dpex
 from numba_dpex import DpctlSyclQueue, DpnpNdArray, int64
-from numba_dpex.experimental.flag_enum import FlagEnum
+from numba_dpex.kernel_api.flag_enum import FlagEnum
 
 
 def test_compilation_as_literal_constant():


### PR DESCRIPTION
Moves the `FlagEnum` class from `numba_dpex.experimental` to `kernel_api`.