### PR TITLE
Adds overloads for group indexing functions

### DIFF
--- a/numba_dpex/experimental/_kernel_dpcpp_spirv_overloads/_index_space_id_overloads.py
+++ b/numba_dpex/experimental/_kernel_dpcpp_spirv_overloads/_index_space_id_overloads.py
@@ -123,6 +123,26 @@ def _intrinsic_spirv_workgroup_size(
     )
 
 
+@intrinsic(target=DPEX_KERNEL_EXP_TARGET_NAME)
+def _intrinsic_spirv_workgroup_id(
+    ty_context, ty_dim  # pylint: disable=unused-argument
+):
+    """Generates instruction to get index from BuiltInWorkgroupId."""
+    return _intrinsic_spirv_global_index_const(
+        ty_context, ty_dim, "BuiltInWorkgroupId"
+    )
+
+
+@intrinsic(target=DPEX_KERNEL_EXP_TARGET_NAME)
+def _intrinsic_spirv_numworkgroups(
+    ty_context, ty_dim  # pylint: disable=unused-argument
+):
+    """Generates instruction to get index from BuiltInNumWorkgroups."""
+    return _intrinsic_spirv_global_index_const(
+        ty_context, ty_dim, "BuiltInNumWorkgroups"
+    )
+
+
 def generate_index_overload(_type, _intrinsic):
     """Generates overload for the index method that generates specific IR from
     provided intrinsic."""
@@ -167,6 +187,9 @@ _index_const_overload_methods = [
     (NdItemType, "get_local_id", _intrinsic_spirv_local_invocation_id),
     (NdItemType, "get_global_range", _intrinsic_spirv_global_size),
     (NdItemType, "get_local_range", _intrinsic_spirv_workgroup_size),
+    (GroupType, "get_group_id", _intrinsic_spirv_workgroup_id),
+    (GroupType, "get_group_range", _intrinsic_spirv_numworkgroups),
+    (GroupType, "get_local_range", _intrinsic_spirv_workgroup_size),
 ]
 
 for index_overload in _index_const_overload_methods:

--- a/numba_dpex/kernel_api/index_space_ids.py
+++ b/numba_dpex/kernel_api/index_space_ids.py
@@ -52,9 +52,11 @@ class Group:
             + (self._index[2])
         )
 
-    def get_group_range(self):
-        """Returns a range representing the number of groups in the nd-range."""
-        return self._group_range
+    def get_group_range(self, dim):
+        """Returns a the extent of the range representing the number of groups
+        in the nd-range for a specified dimension.
+        """
+        return self._group_range[dim]
 
     def get_group_linear_range(self):
         """Return the total number of work-groups in the nd_range."""
@@ -64,12 +66,12 @@ class Group:
 
         return num_wg
 
-    def get_local_range(self):
-        """Returns a SYCL range representing all dimensions of the local
-        range. This local range may have been provided by the programmer, or
-        chosen by the SYCL runtime.
+    def get_local_range(self, dim):
+        """Returns the extent of the SYCL range representing all dimensions
+        of the local range for a specified dimension. This local range may
+        have been provided by the programmer, or chosen by the SYCL runtime.
         """
-        return self._local_range
+        return self._local_range[dim]
 
     def get_local_linear_range(self):
         """Return the total number of work-items in the work-group."""

--- a/numba_dpex/tests/experimental/test_index_space_ids.py
+++ b/numba_dpex/tests/experimental/test_index_space_ids.py
@@ -174,8 +174,9 @@ def test_no_item():
     )
 
 
+# TODO: https://github.com/IntelPython/numba-dpex/issues/1308
+@skip_windows
 def test_get_group_id():
-
     global_size = 100
     group_size = 20
     num_groups = global_size // group_size
@@ -195,8 +196,9 @@ def test_get_group_id():
     assert np.array_equal(ka.asnumpy(), expected)
 
 
+# TODO: https://github.com/IntelPython/numba-dpex/issues/1308
+@skip_windows
 def test_get_group_range():
-
     global_size = 100
     group_size = 20
     num_groups = global_size // group_size
@@ -216,8 +218,9 @@ def test_get_group_range():
     assert np.array_equal(ka.asnumpy(), expected)
 
 
+# TODO: https://github.com/IntelPython/numba-dpex/issues/1308
+@skip_windows
 def test_get_group_local_range():
-
     global_size = 100
     group_size = 20
     num_groups = global_size // group_size


### PR DESCRIPTION
- [X] Have you provided a meaningful PR description?
Enables the following group indexing functions inside a kernel:
`get_group_id`
`get_group_range`
`get_local_range`
- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
