### PR TITLE
A sycl::local_accessor-like API for numba-dpex kernel

### DIFF
--- a/numba_dpex/core/datamodel/models.py
+++ b/numba_dpex/core/datamodel/models.py
@@ -22,8 +22,9 @@ from ..types import (
 )
 
 
-def _get_flattened_member_count(ty):
-    """Return the number of fields in an instance of a given StructModel."""
+def get_flattened_member_count(ty):
+    """Returns the number of fields in an instance of a given StructModel."""
+
     flattened_member_count = 0
     members = ty._members
     for member in members:
@@ -109,7 +110,7 @@ class USMArrayDeviceModel(StructModel):
         """
         Return the number of fields in an instance of a USMArrayDeviceModel.
         """
-        return _get_flattened_member_count(self)
+        return get_flattened_member_count(self)
 
 
 class USMArrayHostModel(StructModel):
@@ -143,7 +144,7 @@ class USMArrayHostModel(StructModel):
     @property
     def flattened_field_count(self):
         """Return the number of fields in an instance of a USMArrayHostModel."""
-        return _get_flattened_member_count(self)
+        return get_flattened_member_count(self)
 
 
 class SyclQueueModel(StructModel):
@@ -223,7 +224,7 @@ class RangeModel(StructModel):
     @property
     def flattened_field_count(self):
         """Return the number of fields in an instance of a RangeModel."""
-        return _get_flattened_member_count(self)
+        return get_flattened_member_count(self)
 
 
 class NdRangeModel(StructModel):
@@ -246,7 +247,7 @@ class NdRangeModel(StructModel):
     @property
     def flattened_field_count(self):
         """Return the number of fields in an instance of a NdRangeModel."""
-        return _get_flattened_member_count(self)
+        return get_flattened_member_count(self)
 
 
 def _init_data_model_manager() -> datamodel.DataModelManager:

--- a/numba_dpex/core/types/kernel_api/local_accessor.py
+++ b/numba_dpex/core/types/kernel_api/local_accessor.py
@@ -10,6 +10,15 @@ from numba_dpex.core.types import USMNdArray
 from numba_dpex.utils import address_space as AddressSpace
 
 
+class DpctlMDLocalAccessorType(Type):
+    """numba-dpex internal type to represent a dpctl SyclInterface type
+    `MDLocalAccessorTy`.
+    """
+
+    def __init__(self):
+        super().__init__(name="DpctlMDLocalAccessor")
+
+
 class LocalAccessorType(USMNdArray):
     """numba-dpex internal type to represent a Python object of
     :class:`numba_dpex.experimental.kernel_iface.LocalAccessor`.

--- a/numba_dpex/core/types/kernel_api/local_accessor.py
+++ b/numba_dpex/core/types/kernel_api/local_accessor.py
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: 2024 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from numba.core.pythonapi import unbox
+from numba.core.types import Array, Type
+from numba.np import numpy_support
+
+from numba_dpex.core.types import USMNdArray
+from numba_dpex.utils import address_space as AddressSpace
+
+
+class LocalAccessorType(USMNdArray):
+    """numba-dpex internal type to represent a Python object of
+    :class:`numba_dpex.experimental.kernel_iface.LocalAccessor`.
+    """
+
+    def __init__(self, ndim, dtype):
+        try:
+            if isinstance(dtype, Type):
+                parsed_dtype = dtype
+            else:
+                parsed_dtype = numpy_support.from_dtype(dtype)
+        except NotImplementedError as exc:
+            raise ValueError(f"Unsupported array dtype: {dtype}") from exc
+
+        type_name = (
+            f"LocalAccessor(dtype={parsed_dtype}, ndim={ndim}, "
+            f"address_space={AddressSpace.LOCAL})"
+        )
+
+        super().__init__(
+            ndim=ndim,
+            layout="C",
+            dtype=parsed_dtype,
+            addrspace=AddressSpace.LOCAL,
+            name=type_name,
+        )
+
+    def cast_python_value(self, args):
+        """The helper function is not overloaded and using it on the
+        LocalAccessorType throws a NotImplementedError.
+        """
+        raise NotImplementedError
+
+
+@unbox(LocalAccessorType)
+def unbox_local_accessor(typ, obj, c):  # pylint: disable=unused-argument
+    """Unboxes a Python LocalAccessor PyObject* into a numba-dpex internal
+    representation.
+
+    A LocalAccessor object is represented internally in numba-dpex with the
+    same data model as a numpy.ndarray. It is done as a LocalAccessor object
+    serves only as a placeholder type when passed to ``call_kernel`` and the
+    data buffer should never be accessed inside a host-side compiled function
+    such as ``call_kernel``.
+
+    When a LocalAccessor object is passed as an argument to a kernel function
+    it uses the USMArrayDeviceModel. Doing so allows numba-dpex to correctly
+    generate the kernel signature passing in a pointer in the local address
+    space.
+    """
+
+    nparrobj = c.pyapi.object_getattr_string(obj, "_data")
+    nparrtype = Array(typ.dtype, typ.ndim, typ.layout, readonly=False)
+    return c.unbox(nparrtype, nparrobj)

--- a/numba_dpex/core/utils/kernel_flattened_args_builder.py
+++ b/numba_dpex/core/utils/kernel_flattened_args_builder.py
@@ -11,12 +11,15 @@ from typing import NamedTuple
 
 import dpctl
 from llvmlite import ir as llvmir
-from numba.core import types
+from numba.core import cgutils, types
 from numba.core.cpu import CPUContext
 
 from numba_dpex import utils
 from numba_dpex.core.types import USMNdArray
-from numba_dpex.core.types.kernel_api.local_accessor import LocalAccessorType
+from numba_dpex.core.types.kernel_api.local_accessor import (
+    DpctlMDLocalAccessorType,
+    LocalAccessorType,
+)
 from numba_dpex.dpctl_iface._helpers import numba_type_to_dpctl_typenum
 
 
@@ -120,40 +123,6 @@ class KernelFlattenedArgsBuilder:
         for karg in args_list:
             print(f"    {karg.llvm_val} of typeid {karg.typeid}")
 
-    def _allocate_local_accessor_metadata_struct(self):
-        """Allocates a struct into the current function to store the metadata
-        that should be passed to libsyclinterface to allocate a
-        sycl::local_accessor object. The constructor of the sycl::local_accessor
-        class is: local_accessor<Ty, Ndim>(range<Ndims> r).
-
-        For this reason, the struct is allocated as:
-
-        LOCAL_ACCESSOR_MDSTRUCT_TYPE = llvmir.LiteralStructType(
-                [
-                    llvmir.IntType(64), # Ndim (0..3]
-                    llvmir.IntType(32), # typeid
-                    llvmir.IntType(64), # Dim0 extent
-                    llvmir.IntType(64), # Dim1 extent or NULL
-                    llvmir.IntType(64), # Dim2 extent or NULL
-                ]
-            )
-        """
-        local_accessor_mdstruct_type = llvmir.LiteralStructType(
-            [
-                llvmir.IntType(64),
-                llvmir.IntType(32),
-                llvmir.IntType(64),
-                llvmir.IntType(64),
-                llvmir.IntType(64),
-            ]
-        )
-
-        struct_ref = None
-        with self._builder.goto_entry_block():
-            struct_ref = self._builder.alloca(typ=local_accessor_mdstruct_type)
-
-        return struct_ref
-
     def _build_arg(self, llvm_val, numba_type):
         """Returns a KernelArg to be passed to a DPCTLQueue_Submit call.
 
@@ -250,7 +219,7 @@ class KernelFlattenedArgsBuilder:
         )
 
     def _build_local_accessor_metadata_arg(
-        self, llvm_val, arg_type, data_attr_ty
+        self, llvm_val, arg_type: LocalAccessorType, data_attr_ty
     ):
         """Handles the special case of building the kernel argument for the data
         attribute of a kernel_api.LocalAccessor object.
@@ -267,91 +236,27 @@ class KernelFlattenedArgsBuilder:
         handle proper device memory allocation.
         """
 
-        kernel_data_model = self._kernel_dmm.lookup(arg_type)
-        host_data_model = self._context.data_model_manager.lookup(arg_type)
-        shape_member = kernel_data_model.get_member_fe_type("shape")
-        shape_member_pos = host_data_model.get_field_position("shape")
-        ndim = shape_member.count
+        ndim = arg_type.ndim
 
-        mdstruct_ref = self._allocate_local_accessor_metadata_struct()
-
-        # Store the number of dimensions in the local accessor
-        self._store_val_into_struct(
-            mdstruct_ref,
-            index=0,
-            val=self._context.get_constant(types.int64, ndim),
+        md_proxy = cgutils.create_struct_proxy(DpctlMDLocalAccessorType())(
+            self._context,
+            self._builder,
         )
-        # Get the underlying dtype of the data (a CPointer) attribute of a
-        # local_accessor object
-        self._store_val_into_struct(
-            mdstruct_ref,
-            index=1,
-            val=numba_type_to_dpctl_typenum(self._context, data_attr_ty.dtype),
-        )
-        # Extract and store the shape values from array into mdstruct
-        shape_attr = self._builder.gep(
-            llvm_val,
-            [
-                self._context.get_constant(types.int32, 0),
-                self._context.get_constant(types.int32, shape_member_pos),
-            ],
-        )
-        # Store the extent of the 1st dimension of the local accessor
-        dim0_shape_ext = self._builder.gep(
-            shape_attr,
-            [
-                self._context.get_constant(types.int32, 0),
-                self._context.get_constant(types.int32, 0),
-            ],
-        )
-        self._store_val_into_struct(
-            mdstruct_ref,
-            index=2,
-            val=self._builder.load(dim0_shape_ext),
+        la_proxy = cgutils.create_struct_proxy(arg_type)(
+            self._context, self._builder, value=self._builder.load(llvm_val)
         )
 
-        if ndim == 2:
-            dim1_shape_ext = self._builder.gep(
-                shape_attr,
-                [
-                    self._context.get_constant(types.int32, 0),
-                    self._context.get_constant(types.int32, 1),
-                ],
-            )
-            self._store_val_into_struct(
-                mdstruct_ref,
-                index=3,
-                val=self._builder.load(dim1_shape_ext),
-            )
-        else:
-            self._store_val_into_struct(
-                mdstruct_ref,
-                index=3,
-                val=self._context.get_constant(types.int64, 1),
-            )
-
-        if ndim == 3:
-            dim2_shape_ext = self._builder.gep(
-                shape_attr,
-                [
-                    self._context.get_constant(types.int32, 0),
-                    self._context.get_constant(types.int32, 2),
-                ],
-            )
-            self._store_val_into_struct(
-                mdstruct_ref,
-                index=4,
-                val=self._builder.load(dim2_shape_ext),
-            )
-        else:
-            self._store_val_into_struct(
-                mdstruct_ref,
-                index=4,
-                val=self._context.get_constant(types.int64, 1),
-            )
+        md_proxy.ndim = self._context.get_constant(types.int64, ndim)
+        md_proxy.dpctl_type_id = numba_type_to_dpctl_typenum(
+            self._context, data_attr_ty.dtype
+        )
+        for i, val in enumerate(
+            cgutils.unpack_tuple(self._builder, la_proxy.shape)
+        ):
+            setattr(md_proxy, f"dim{i}", val)
 
         return self._build_arg(
-            llvm_val=mdstruct_ref,
+            llvm_val=md_proxy._getpointer(),
             numba_type=LocalAccessorType(
                 ndim, dpctl.tensor.dtype(data_attr_ty.dtype.name)
             ),

--- a/numba_dpex/core/utils/kernel_launcher.py
+++ b/numba_dpex/core/utils/kernel_launcher.py
@@ -21,6 +21,7 @@ from numba_dpex.core import config
 from numba_dpex.core.exceptions import UnreachableError
 from numba_dpex.core.runtime.context import DpexRTContext
 from numba_dpex.core.types import USMNdArray
+from numba_dpex.core.types.kernel_api.local_accessor import LocalAccessorType
 from numba_dpex.core.types.kernel_api.ranges import NdRangeType, RangeType
 from numba_dpex.core.utils.kernel_flattened_args_builder import (
     KernelFlattenedArgsBuilder,
@@ -675,7 +676,9 @@ def get_queue_from_llvm_values(
     the queue from the first USMNdArray argument can be extracted.
     """
     for arg_num, argty in enumerate(ty_kernel_args):
-        if isinstance(argty, USMNdArray):
+        if isinstance(argty, USMNdArray) and not isinstance(
+            argty, LocalAccessorType
+        ):
             llvm_val = ll_kernel_args[arg_num]
             datamodel = ctx.data_model_manager.lookup(argty)
             sycl_queue_attr_pos = datamodel.get_field_position("sycl_queue")

--- a/numba_dpex/dpctl_iface/_helpers.py
+++ b/numba_dpex/dpctl_iface/_helpers.py
@@ -5,6 +5,7 @@
 from numba.core import types
 
 from numba_dpex import dpctl_sem_version
+from numba_dpex.core.types.kernel_api.local_accessor import LocalAccessorType
 
 
 def numba_type_to_dpctl_typenum(context, ty):
@@ -34,6 +35,10 @@ def numba_type_to_dpctl_typenum(context, ty):
             return context.get_constant(
                 types.int32, kargty.dpctl_void_ptr.value
             )
+        elif isinstance(ty, LocalAccessorType):
+            return context.get_constant(
+                types.int32, kargty.dpctl_local_accessor.value
+            )
         else:
             raise NotImplementedError
     else:
@@ -61,5 +66,9 @@ def numba_type_to_dpctl_typenum(context, ty):
         elif ty == types.voidptr or isinstance(ty, types.CPointer):
             # DPCTL_VOID_PTR
             return context.get_constant(types.int32, 15)
+        elif isinstance(ty, LocalAccessorType):
+            raise NotImplementedError(
+                "LocalAccessor args for kernels requires dpctl 0.17 or greater."
+            )
         else:
             raise NotImplementedError

--- a/numba_dpex/experimental/__init__.py
+++ b/numba_dpex/experimental/__init__.py
@@ -12,6 +12,7 @@ from numba.core.imputils import Registry
 from numba_dpex.core.boxing import *
 from numba_dpex.kernel_api_impl.spirv.dispatcher import SPIRVKernelDispatcher
 
+from . import typeof
 from ._kernel_dpcpp_spirv_overloads import (
     _atomic_fence_overloads,
     _atomic_ref_overloads,

--- a/numba_dpex/experimental/models.py
+++ b/numba_dpex/experimental/models.py
@@ -19,7 +19,10 @@ from numba_dpex.core.types.kernel_api.index_space_ids import (
 )
 
 from ..core.types.kernel_api.atomic_ref import AtomicRefType
-from ..core.types.kernel_api.local_accessor import LocalAccessorType
+from ..core.types.kernel_api.local_accessor import (
+    DpctlMDLocalAccessorType,
+    LocalAccessorType,
+)
 from .types import KernelDispatcherType
 
 
@@ -42,6 +45,26 @@ class EmptyStructModel(StructModel):
 
     def __init__(self, dmm, fe_type):
         members = []
+        super().__init__(dmm, fe_type, members)
+
+
+class DpctlMDLocalAccessorModel(StructModel):
+    """Data model to represent DpctlMDLocalAccessorType.
+
+    Must be the same structure as
+    dpctl/syclinterface/dpctl_sycl_queue_interface.h::MDLocalAccessor.
+
+    Structure intended to be used only on host side of the kernel call.
+    """
+
+    def __init__(self, dmm, fe_type):
+        members = [
+            ("ndim", types.size_t),
+            ("dpctl_type_id", types.int32),
+            ("dim0", types.size_t),
+            ("dim1", types.size_t),
+            ("dim2", types.size_t),
+        ]
         super().__init__(dmm, fe_type, members)
 
 
@@ -88,6 +111,9 @@ register_model(ItemType)(EmptyStructModel)
 
 # Register the NdItemType type
 register_model(NdItemType)(EmptyStructModel)
+
+# Register the MDLocalAccessorType type
+register_model(DpctlMDLocalAccessorType)(DpctlMDLocalAccessorModel)
 
 # The LocalAccessorType is registered with the EmptyStructModel in the default
 # data manager so that its attributes are not accessible inside dpjit.

--- a/numba_dpex/experimental/models.py
+++ b/numba_dpex/experimental/models.py
@@ -8,7 +8,7 @@ numba_dpex.experimental module.
 
 from numba.core import types
 from numba.core.datamodel import DataModelManager, models
-from numba.core.datamodel.models import StructModel
+from numba.core.datamodel.models import ArrayModel, StructModel
 from numba.core.extending import register_model
 
 import numba_dpex.core.datamodel.models as dpex_core_models
@@ -19,6 +19,7 @@ from numba_dpex.core.types.kernel_api.index_space_ids import (
 )
 
 from ..core.types.kernel_api.atomic_ref import AtomicRefType
+from ..core.types.kernel_api.local_accessor import LocalAccessorType
 from .types import KernelDispatcherType
 
 
@@ -60,6 +61,8 @@ def _init_exp_data_model_manager() -> DataModelManager:
     # Register the types and data model in the DpexExpTargetContext
     dmm.register(AtomicRefType, AtomicRefModel)
 
+    dmm.register(LocalAccessorType, dpex_core_models.USMArrayDeviceModel)
+
     # Register the GroupType type
     dmm.register(GroupType, EmptyStructModel)
 
@@ -85,3 +88,7 @@ register_model(ItemType)(EmptyStructModel)
 
 # Register the NdItemType type
 register_model(NdItemType)(EmptyStructModel)
+
+# The LocalAccessorType is registered with the EmptyStructModel in the default
+# data manager so that its attributes are not accessible inside dpjit.
+register_model(LocalAccessorType)(ArrayModel)

--- a/numba_dpex/experimental/typeof.py
+++ b/numba_dpex/experimental/typeof.py
@@ -97,4 +97,4 @@ def typeof_local_accessor(val: LocalAccessor, c) -> LocalAccessorType:
     Returns: LocalAccessorType object corresponding to the LocalAccessor object.
     """
     # pylint: disable=protected-access
-    return LocalAccessorType(ndim=val._data.ndim, dtype=val._data.dtype)
+    return LocalAccessorType(ndim=len(val._shape), dtype=val._dtype)

--- a/numba_dpex/experimental/typeof.py
+++ b/numba_dpex/experimental/typeof.py
@@ -14,7 +14,8 @@ from numba_dpex.core.types.kernel_api.index_space_ids import (
     ItemType,
     NdItemType,
 )
-from numba_dpex.kernel_api import AtomicRef, Group, Item, NdItem
+from numba_dpex.core.types.kernel_api.local_accessor import LocalAccessorType
+from numba_dpex.kernel_api import AtomicRef, Group, Item, LocalAccessor, NdItem
 
 from ..core.types.kernel_api.atomic_ref import AtomicRefType
 
@@ -84,3 +85,16 @@ def typeof_nditem(val: NdItem, c):
         instance.
     """
     return NdItemType(val.dimensions)
+
+
+@typeof_impl.register(LocalAccessor)
+def typeof_local_accessor(val: LocalAccessor, c) -> LocalAccessorType:
+    """Returns a ``numba_dpex.experimental.dpctpp_types.LocalAccessorType``
+    instance for a Python LocalAccessor object.
+    Args:
+        val (LocalAccessor): Instance of the LocalAccessor type.
+        c : Numba typing context used for type inference.
+    Returns: LocalAccessorType object corresponding to the LocalAccessor object.
+    """
+    # pylint: disable=protected-access
+    return LocalAccessorType(ndim=val._data.ndim, dtype=val._data.dtype)

--- a/numba_dpex/kernel_api/__init__.py
+++ b/numba_dpex/kernel_api/__init__.py
@@ -14,21 +14,25 @@ from .atomic_ref import AtomicRef
 from .barrier import group_barrier
 from .index_space_ids import Group, Item, NdItem
 from .launcher import call_kernel
+from .local_accessor import LocalAccessor
 from .memory_enums import AddressSpace, MemoryOrder, MemoryScope
 from .private_array import PrivateArray
 from .ranges import NdRange, Range
 
 __all__ = [
+    "call_kernel",
+    "group_barrier",
     "AddressSpace",
     "atomic_fence",
     "AtomicRef",
+    "Group",
+    "Item",
+    "LocalAccessor",
     "MemoryOrder",
     "MemoryScope",
+    "NdItem",
     "NdRange",
     "Range",
-    "Group",
-    "NdItem",
-    "Item",
     "PrivateArray",
     "group_barrier",
     "call_kernel",

--- a/numba_dpex/kernel_api/local_accessor.py
+++ b/numba_dpex/kernel_api/local_accessor.py
@@ -35,19 +35,17 @@ class LocalAccessor:
             if hasattr(shape, "tolist"):
                 fn = getattr(shape, "tolist")
                 if callable(fn):
-                    self._shape = shape.tolist()
+                    self._shape = tuple(shape.tolist())
             else:
                 try:
-                    self._shape = [
-                        shape,
-                    ]
+                    self._shape = (shape,)
                 except Exception as e:
                     raise TypeError(
                         "Argument shape must a non-negative integer, "
                         "or a list/tuple of such integers."
                     ) from e
         else:
-            self._shape = list(shape)
+            self._shape = tuple(shape)
 
         # Make sure shape is made up a supported types
         if not self._verify_positive_integral_list(self._shape):
@@ -118,7 +116,9 @@ class _LocalAccessorMock:
     """
 
     def __init__(self, local_accessor: LocalAccessor):
-        self._data = local_accessor._data
+        self._data = numpy.empty(
+            local_accessor._shape, dtype=local_accessor._dtype
+        )
 
     def __getitem__(self, idx_obj):
         """Returns the value stored at the position represented by idx_obj in

--- a/numba_dpex/kernel_api/local_accessor.py
+++ b/numba_dpex/kernel_api/local_accessor.py
@@ -1,0 +1,135 @@
+# SPDX-FileCopyrightText: 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Implements a Python analogue to SYCL's local_accessor class. The class is
+intended to be used in pure Python code when prototyping a kernel function
+and to be passed to an actual kernel function for local memory allocation.
+"""
+import numpy
+
+
+class LocalAccessor:
+    """
+    The ``LocalAccessor`` class is analogous to SYCL's ``local_accessor``
+    class. The class acts a s proxy to allocating device local memory and
+    accessing that memory from within a :func:`numba_dpex.kernel` decorated
+    function.
+    """
+
+    def _verify_positive_integral_list(self, ls):
+        """Checks if all members of a list are positive integers."""
+
+        ret = False
+        try:
+            ret = all(int(val) > 0 for val in ls)
+        except ValueError:
+            pass
+
+        return ret
+
+    def __init__(self, shape, dtype) -> None:
+        """Creates a new LocalAccessor instance of the given shape and dtype."""
+
+        if not isinstance(shape, (list, tuple)):
+            if hasattr(shape, "tolist"):
+                fn = getattr(shape, "tolist")
+                if callable(fn):
+                    self._shape = shape.tolist()
+            else:
+                try:
+                    self._shape = [
+                        shape,
+                    ]
+                except Exception as e:
+                    raise TypeError(
+                        "Argument shape must a non-negative integer, "
+                        "or a list/tuple of such integers."
+                    ) from e
+        else:
+            self._shape = list(shape)
+
+        # Make sure shape is made up a supported types
+        if not self._verify_positive_integral_list(self._shape):
+            raise TypeError(
+                "Argument shape must a non-negative integer, "
+                "or a list/tuple of such integers."
+            )
+
+        # Make sure shape has a rank between (1..3)
+        if len(self._shape) < 1 or len(self._shape) > 3:
+            raise TypeError("LocalAccessor can only have up to 3 dimensions.")
+
+        self._dtype = dtype
+
+        if self._dtype not in [
+            numpy.float32,
+            numpy.float64,
+            numpy.int32,
+            numpy.int64,
+            numpy.int16,
+            numpy.int8,
+            numpy.uint32,
+            numpy.uint64,
+            numpy.uint16,
+            numpy.uint8,
+        ]:
+            raise TypeError(
+                f"Argument dtype {dtype} is not supported. numpy.float32, "
+                "numpy.float64, numpy.[u]int8, numpy.[u]int16, numpy.[u]int32, "
+                "numpy.[u]int64 are the currently supported dtypes."
+            )
+
+        self._data = numpy.empty(self._shape, dtype=self._dtype)
+
+    def __getitem__(self, idx_obj):
+        """Returns the value stored at the position represented by idx_obj in
+        the self._data ndarray.
+        """
+
+        raise NotImplementedError(
+            "The data of a LocalAccessor object can only be accessed "
+            "inside a kernel."
+        )
+
+    def __setitem__(self, idx_obj, val):
+        """Assigns a new value to the position represented by idx_obj in
+        the self._data ndarray.
+        """
+
+        raise NotImplementedError(
+            "The data of a LocalAccessor object can only be accessed "
+            "inside a kernel."
+        )
+
+
+class _LocalAccessorMock:
+    """Mock class that is used to represent a local accessor inside a "kernel".
+
+    A LocalAccessor represents a device-only memory allocation and the
+    class is designed in a way to not have any data container backing up the
+    actual memory storage. Instead, the _LocalAccessorMock class is used to
+    represent a local_accessor that has an actual numpy ndarray backing it up.
+    Whenever, a LocalAccessor object is passed to `func`:kernel_api.call_kernel`
+    it is converted to a _LocalAccessor internally. That way the data and
+    access function on the data only works inside a kernel to simulate
+    device-only memory allocation and outside the kernel the data for a
+    LocalAccessor is not accessible.
+    """
+
+    def __init__(self, local_accessor: LocalAccessor):
+        self._data = local_accessor._data
+
+    def __getitem__(self, idx_obj):
+        """Returns the value stored at the position represented by idx_obj in
+        the self._data ndarray.
+        """
+
+        return self._data[idx_obj]
+
+    def __setitem__(self, idx_obj, val):
+        """Assigns a new value to the position represented by idx_obj in
+        the self._data ndarray.
+        """
+
+        self._data[idx_obj] = val

--- a/numba_dpex/tests/experimental/codegen/test_local_accessor_kernel_arg.py
+++ b/numba_dpex/tests/experimental/codegen/test_local_accessor_kernel_arg.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: 2023 - 2024 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import dpctl
+from llvmlite import ir as llvmir
+from numba.core import types
+
+from numba_dpex import DpctlSyclQueue, DpnpNdArray
+from numba_dpex import experimental as dpex_exp
+from numba_dpex import int64
+from numba_dpex.core.types.kernel_api.index_space_ids import NdItemType
+from numba_dpex.core.types.kernel_api.local_accessor import LocalAccessorType
+from numba_dpex.kernel_api import (
+    AddressSpace,
+    MemoryScope,
+    NdItem,
+    group_barrier,
+)
+
+
+def kernel_func(nd_item: NdItem, a, slm):
+    i = nd_item.get_global_linear_id()
+    j = nd_item.get_local_linear_id()
+
+    slm[j] = 100
+    group_barrier(nd_item.get_group(), MemoryScope.WORK_GROUP)
+
+    a[i] += slm[j]
+
+
+def test_codegen_local_accessor_kernel_arg():
+    """Tests if a kernel with a local accessor argument is generated with
+    expected local address space pointer argument.
+    """
+
+    queue_ty = DpctlSyclQueue(dpctl.SyclQueue())
+    i64arr_ty = DpnpNdArray(ndim=1, dtype=int64, layout="C", queue=queue_ty)
+    slm_ty = LocalAccessorType(ndim=1, dtype=int64)
+    disp = dpex_exp.kernel(inline_threshold=3)(kernel_func)
+    dmm = disp.targetctx.data_model_manager
+
+    i64arr_ty_flattened_arg_count = dmm.lookup(i64arr_ty).flattened_field_count
+    slm_ty_model = dmm.lookup(slm_ty)
+    slm_ty_flattened_arg_count = slm_ty_model.flattened_field_count
+    slm_ptr_pos = slm_ty_model.get_field_position("data")
+
+    llargtys = disp.targetctx.get_arg_packer([i64arr_ty, slm_ty]).argument_types
+
+    # Go over all the arguments to the spir_kernel_func and assert two things:
+    # a) Number of arguments == i64arr_ty_flattened_arg_count
+    #    + slm_ty_flattened_arg_count
+    # b) The argument corresponding to the data attribute of the local accessor
+    # argument is a pointer in address space local address space
+
+    num_kernel_args = 0
+    slm_data_ptr_arg = None
+    for kernel_arg in llargtys:
+        if num_kernel_args == i64arr_ty_flattened_arg_count + slm_ptr_pos:
+            slm_data_ptr_arg = kernel_arg
+        num_kernel_args += 1
+    assert (
+        num_kernel_args
+        == i64arr_ty_flattened_arg_count + slm_ty_flattened_arg_count
+    )
+    assert isinstance(slm_data_ptr_arg, llvmir.PointerType)
+    assert slm_data_ptr_arg.addrspace == AddressSpace.LOCAL

--- a/numba_dpex/tests/experimental/kernel_api_overloads/spv_overloads/test_local_accessors.py
+++ b/numba_dpex/tests/experimental/kernel_api_overloads/spv_overloads/test_local_accessors.py
@@ -23,9 +23,49 @@ list_of_supported_dtypes = get_all_dtypes(
 
 
 @dpex_exp.kernel
-def _kernel(nd_item: NdItem, a, slm):
+def _kernel1(nd_item: NdItem, a, slm):
     i = nd_item.get_global_linear_id()
-    j = nd_item.get_local_linear_id()
+
+    # TODO: overload nd_item.get_local_id()
+    j = (nd_item.get_local_id(0),)
+
+    slm[j] = 0
+    group_barrier(nd_item.get_group(), MemoryScope.WORK_GROUP)
+
+    for m in range(100):
+        slm[j] += i * m
+        group_barrier(nd_item.get_group(), MemoryScope.WORK_GROUP)
+
+    a[i] = slm[j]
+
+
+@dpex_exp.kernel
+def _kernel2(nd_item: NdItem, a, slm):
+    i = nd_item.get_global_linear_id()
+
+    # TODO: overload nd_item.get_local_id()
+    j = (nd_item.get_local_id(0), nd_item.get_local_id(1))
+
+    slm[j] = 0
+    group_barrier(nd_item.get_group(), MemoryScope.WORK_GROUP)
+
+    for m in range(100):
+        slm[j] += i * m
+        group_barrier(nd_item.get_group(), MemoryScope.WORK_GROUP)
+
+    a[i] = slm[j]
+
+
+@dpex_exp.kernel
+def _kernel3(nd_item: NdItem, a, slm):
+    i = nd_item.get_global_linear_id()
+
+    # TODO: overload nd_item.get_local_id()
+    j = (
+        nd_item.get_local_id(0),
+        nd_item.get_local_id(1),
+        nd_item.get_local_id(2),
+    )
 
     slm[j] = 0
     group_barrier(nd_item.get_group(), MemoryScope.WORK_GROUP)
@@ -38,19 +78,27 @@ def _kernel(nd_item: NdItem, a, slm):
 
 
 @pytest.mark.parametrize("supported_dtype", list_of_supported_dtypes)
-def test_local_accessor(supported_dtype):
+@pytest.mark.parametrize(
+    "nd_range, _kernel",
+    [
+        (dpex.NdRange((32,), (32,)), _kernel1),
+        (dpex.NdRange((32, 1), (32, 1)), _kernel2),
+        (dpex.NdRange((1, 32, 1), (1, 32, 1)), _kernel3),
+    ],
+)
+def test_local_accessor(supported_dtype, nd_range: dpex.NdRange, _kernel):
     """A test for passing a LocalAccessor object as a kernel argument."""
 
     N = 32
     a = dpnp.empty(N, dtype=supported_dtype)
-    slm = LocalAccessor((32 * 64), dtype=a.dtype)
+    slm = LocalAccessor(nd_range.local_range, dtype=a.dtype)
 
     # A single work group with 32 work items is launched. Each work item
     # computes the sum of (0..99) * its get_global_linear_id i.e.,
     # `4950 * get_global_linear_id` and stores it into the work groups local
     # memory. The local memory is of size 32*64 elements of the requested dtype.
     # The result is then stored into `a` in global memory
-    dpex_exp.call_kernel(_kernel, dpex.NdRange((N,), (32,)), a, slm)
+    dpex_exp.call_kernel(_kernel, nd_range, a, slm)
 
     for idx in range(N):
         assert a[idx] == 4950 * idx
@@ -68,4 +116,4 @@ def test_local_accessor_argument_to_range_kernel():
     # A TypeError is raised if NUMBA_CAPTURED_ERROR=new_style and a
     # numba.TypingError is raised if NUMBA_CAPTURED_ERROR=old_style
     with pytest.raises((TypeError, TypingError)):
-        dpex_exp.call_kernel(_kernel, dpex.Range(N), a, slm)
+        dpex_exp.call_kernel(_kernel1, dpex.Range(N), a, slm)

--- a/numba_dpex/tests/experimental/kernel_api_overloads/spv_overloads/test_local_accessors.py
+++ b/numba_dpex/tests/experimental/kernel_api_overloads/spv_overloads/test_local_accessors.py
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: 2023 - 2024 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+
+import dpnp
+import pytest
+
+import numba_dpex as dpex
+import numba_dpex.experimental as dpex_exp
+from numba_dpex.kernel_api import (
+    LocalAccessor,
+    MemoryScope,
+    NdItem,
+    group_barrier,
+)
+from numba_dpex.tests._helper import get_all_dtypes
+
+list_of_supported_dtypes = get_all_dtypes(
+    no_bool=True, no_float16=True, no_none=True, no_complex=True
+)
+
+
+@pytest.mark.parametrize("supported_dtype", list_of_supported_dtypes)
+def test_local_accessor(supported_dtype):
+    """A test for passing a LocalAccessor object as a kernel argument."""
+
+    @dpex_exp.kernel
+    def _kernel(nd_item: NdItem, a, slm):
+        i = nd_item.get_global_linear_id()
+        j = nd_item.get_local_linear_id()
+
+        slm[j] = 0
+        group_barrier(nd_item.get_group(), MemoryScope.WORK_GROUP)
+
+        for m in range(100):
+            slm[j] += i * m
+            group_barrier(nd_item.get_group(), MemoryScope.WORK_GROUP)
+
+        a[i] = slm[j]
+
+    N = 32
+    a = dpnp.empty(N, dtype=supported_dtype)
+    slm = LocalAccessor((32 * 64), dtype=a.dtype)
+
+    # A single work group with 32 work items is launched. Each work item
+    # computes the sum of (0..99) * its get_global_linear_id i.e.,
+    # `4950 * get_global_linear_id` and stores it into the work groups local
+    # memory. The local memory is of size 32*64 elements of the requested dtype.
+    # The result is then stored into `a` in global memory
+    dpex_exp.call_kernel(_kernel, dpex.NdRange((N,), (32,)), a, slm)
+
+    for idx in range(N):
+        assert a[idx] == 4950 * idx

--- a/numba_dpex/tests/kernel_api/test_local_accessor.py
+++ b/numba_dpex/tests/kernel_api/test_local_accessor.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: 2024 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import numpy
+import pytest
+
+from numba_dpex import kernel_api as kapi
+
+
+def _slm_kernel(nd_item: kapi.NdItem, a, slm):
+    i = nd_item.get_global_linear_id()
+    j = nd_item.get_local_linear_id()
+
+    slm[j] = 100
+    a[i] = slm[i]
+
+
+def test_local_accessor_data_inaccessible_outside_kernel():
+    la = kapi.LocalAccessor((100,), dtype=numpy.float32)
+
+    with pytest.raises(NotImplementedError):
+        print(la[0])
+
+    with pytest.raises(NotImplementedError):
+        la[0] = 10
+
+
+def test_local_accessor_use_inside_kernel():
+
+    a = numpy.empty(32)
+    slm = kapi.LocalAccessor(32, dtype=a.dtype)
+
+    # launches one work group with 32 work item. Each work item initializes its
+    # position in the SLM to 100 and then writes it to the global array `a`.
+    kapi.call_kernel(_slm_kernel, kapi.NdRange((32,), (32,)), a, slm)
+
+    assert numpy.all(a == 100)
+
+
+def test_local_accessor_usage_not_allowed_with_range_kernel():
+
+    a = numpy.empty(32)
+    slm = kapi.LocalAccessor(32, dtype=a.dtype)
+
+    with pytest.raises(TypeError):
+        kapi.call_kernel(_slm_kernel, kapi.Range((32,)), a, slm)


### PR DESCRIPTION
- [X] Have you provided a meaningful PR description?

The PR adds a `sycl::local_accessor` like API to numba-dpex's kernel API.

- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?

TODOs
- [x] All existing test cases pass
- [x] New test case to verify that the kernel function argument for a local_accessor is correctly generated
- [x] dpctl PR merged with new changes [IntelPython/dpctl/pull/1558]
- [x] Remove hard-coding for typeid (after adding a new enum in dpctl) [#1379]
- [x] Add end-to-end tests
- [ ] Example
- [ ] Tutorial
- [x] According to section 4.7.6.11. of the SYCL specification, a local_accessor must not be used in a SYCL kernel function that is invoked via single_task or via the simple form of parallel_for that takes a range parameter.
