### PR TITLE
Update dependent package pinning to newer versions.

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set required_compiler_version = "2023.2" %}
+{% set required_compiler_version = "2024.0" %}
 {% set excluded_compiler_version1 = "2024.0.1" %}
 {% set excluded_compiler_version2 = "2024.0.2" %}
 
@@ -28,18 +28,18 @@ requirements:
         - scikit-build >=0.15*
         - ninja # [not win]
         - cmake >=3.26*
-        - numba >=0.58*
-        - dpctl >=0.14*
-        - dpnp >=0.11*
+        - numba >=0.59*
+        - dpctl >=0.16*
+        - dpnp >=0.14*
         - dpcpp-llvm-spirv
         - wheel
     run:
         - {{ pin_compatible('dpcpp-cpp-rt', min_pin='x.x', max_pin='x') }}
         - python
-        - numba >=0.58*
-        - dpctl >=0.14*
+        - numba >=0.59*
+        - dpctl >=0.16*
         - dpcpp-llvm-spirv
-        - dpnp >=0.11*
+        - dpnp >=0.14*
         - packaging
 
 test:

--- a/environment/coverage.yml
+++ b/environment/coverage.yml
@@ -8,7 +8,7 @@ channels:
 dependencies:
   - libffi
   - gxx_linux-64
-  - dpcpp_linux-64>=2023.2,!=2024.0.1,!=2024.0.2
+  - dpcpp_linux-64>=2024.0,!=2024.0.1,!=2024.0.2
   - numba==0.58*
   - dpctl
   - dpnp

--- a/environment/docs.yml
+++ b/environment/docs.yml
@@ -8,12 +8,12 @@ channels:
 dependencies:
   - libffi
   - gxx_linux-64
-  - dpcpp_linux-64>=2023.2,!=2024.0.1,!=2024.0.2
-  - numba==0.58*
+  - dpcpp_linux-64>=2024.0,!=2024.0.1,!=2024.0.2
+  - numba==0.59*
   - scikit-build>=0.15*
   - cmake>=3.26*
-  - dpctl
-  - dpnp
+  - dpctl>=0.16*
+  - dpnp>=0.14*
   - dpcpp-llvm-spirv
   - opencl_rt
   - pip

--- a/environment/pre-commit.yml
+++ b/environment/pre-commit.yml
@@ -7,9 +7,9 @@ channels:
   - nodefaults
 dependencies:
   - libffi
-  - numba==0.58*
-  - dpctl
-  - dpnp
+  - numba==0.59*
+  - dpctl>=0.16*
+  - dpnp>=0.14*
   - dpcpp-llvm-spirv
   - opencl_rt
   - coverage


### PR DESCRIPTION
- [X] Have you provided a meaningful PR description?
Bumps the minimum version requirements for `dpcpp`, `dpctl`, `numba`, `dpnp` in meta.yaml and all environment files.