### PR TITLE
Fix for atomic load, store, exchange failure on ocl

### DIFF
--- a/numba_dpex/experimental/_kernel_dpcpp_spirv_overloads/_group_barrier_overloads.py
+++ b/numba_dpex/experimental/_kernel_dpcpp_spirv_overloads/_group_barrier_overloads.py
@@ -6,7 +6,6 @@
 Provides overloads for functions included in kernel_iface.barrier that
 generate dpcpp SPIR-V LLVM IR intrinsic function calls.
 """
-import warnings
 
 from llvmlite import ir as llvmir
 from numba.core import cgutils, types
@@ -20,18 +19,7 @@ from numba_dpex.kernel_api import group_barrier
 from numba_dpex.kernel_api.memory_enums import MemoryOrder, MemoryScope
 
 from ._spv_atomic_inst_helper import get_memory_semantics_mask, get_scope
-
-_SUPPORT_CONVERGENT = True
-
-try:
-    llvmir.FunctionAttributes("convergent")
-except ValueError:
-    warnings.warn(
-        "convergent attribute is supported only starting llvmlite "
-        + "0.42. Not setting this attribute may result in unexpected behavior"
-        + "when using group_barrier"
-    )
-    _SUPPORT_CONVERGENT = False
+from .spv_atomic_fn_declarations import _SUPPORT_CONVERGENT
 
 
 def _get_memory_scope(fence_scope):


### PR DESCRIPTION
- [x] Have you provided a meaningful PR description?

This PR fixes the failure that was occurring `opencl:cpu` when atomic load, store and exchange operations were being used. Spirv expects arguments to be of integer types always. This PR introduces a `bitcast` to integer types when the argument are of floating point types.
This PR also added additional function attributes to these atomic function declarations, keeping it the same as the declaration generated for DPC++.
It further updates the test cases to remove expected failure on `opencl:cpu` executions. 

- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
