### PR TITLE
Feature/overload dimensions attribute for indexers

### DIFF
--- a/numba_dpex/experimental/_kernel_dpcpp_spirv_overloads/_index_space_id_overloads.py
+++ b/numba_dpex/experimental/_kernel_dpcpp_spirv_overloads/_index_space_id_overloads.py
@@ -9,7 +9,7 @@ Implements the SPIR-V overloads for the kernel_api.items class methods.
 import llvmlite.ir as llvmir
 from numba.core import cgutils, types
 from numba.core.errors import TypingError
-from numba.extending import intrinsic, overload_method
+from numba.extending import intrinsic, overload_attribute, overload_method
 
 from numba_dpex.core.types.kernel_api.index_space_ids import (
     GroupType,
@@ -246,5 +246,26 @@ def ol_nd_item_get_group(nd_item):
     def ol_nd_item_get_group_impl(nd_item):
         # pylint: disable=no-value-for-parameter
         return _intrinsic_get_group(nd_item)
+
+    return ol_nd_item_get_group_impl
+
+
+@overload_attribute(GroupType, "dimensions", target=DPEX_KERNEL_EXP_TARGET_NAME)
+@overload_attribute(ItemType, "dimensions", target=DPEX_KERNEL_EXP_TARGET_NAME)
+@overload_attribute(
+    NdItemType, "dimensions", target=DPEX_KERNEL_EXP_TARGET_NAME
+)
+def ol_nd_item_dimensions(item):
+    """
+    SPIR-V overload for :meth:`numba_dpex.kernel_api.<generic_item>.dimensions`.
+
+    Generates the same LLVM IR instruction as dpcpp for the
+    `sycl::<generic_item>::dimensions` attribute.
+    """
+    dimensions = item.ndim
+
+    # pylint: disable=unused-argument
+    def ol_nd_item_get_group_impl(item):
+        return dimensions
 
     return ol_nd_item_get_group_impl

--- a/numba_dpex/experimental/typeof.py
+++ b/numba_dpex/experimental/typeof.py
@@ -68,11 +68,11 @@ def typeof_item(val: Item, c):
     Returns: A numba_dpex.experimental.core.types.kernel_api.items.ItemType
         instance.
     """
-    return ItemType(val.ndim)
+    return ItemType(val.dimensions)
 
 
 @typeof_impl.register(NdItem)
-def typeof_nditem(val, c):
+def typeof_nditem(val: NdItem, c):
     """Registers the type inference implementation function for a
     numba_dpex.kernel_api.NdItem PyObject.
 
@@ -83,4 +83,4 @@ def typeof_nditem(val, c):
     Returns: A numba_dpex.experimental.core.types.kernel_api.items.NdItemType
         instance.
     """
-    return NdItemType(val.ndim)
+    return NdItemType(val.dimensions)

--- a/numba_dpex/kernel_api/index_space_ids.py
+++ b/numba_dpex/kernel_api/index_space_ids.py
@@ -147,7 +147,7 @@ class Item:
         return self._extent[idx]
 
     @property
-    def ndim(self) -> int:
+    def dimensions(self) -> int:
         """Returns the rank of a Item object.
 
         Returns:
@@ -228,10 +228,10 @@ class NdItem:
         return self._group
 
     @property
-    def ndim(self) -> int:
+    def dimensions(self) -> int:
         """Returns the rank of a NdItem object.
 
         Returns:
             int: Number of dimensions in the NdItem object
         """
-        return self._global_item.ndim
+        return self._global_item.dimensions

--- a/numba_dpex/kernel_api/index_space_ids.py
+++ b/numba_dpex/kernel_api/index_space_ids.py
@@ -98,6 +98,14 @@ class Group:
         """
         return self._leader
 
+    @property
+    def dimensions(self) -> int:
+        """Returns the rank of a Group object.
+        Returns:
+            int: Number of dimensions in the Group object
+        """
+        return self._global_range.ndim
+
     @leader.setter
     def leader(self, work_item_id):
         """Sets the leader attribute for the group."""


### PR DESCRIPTION
- Rename `ndim` to `dimensions` for `Item` and `NdItem` to follow [sycl syntax](https://github.com/intel/llvm/blob/c9b017cef0c1efb0f28cffc2ecbdd6e92c081ac9/sycl/include/sycl/nd_item.hpp#L546)
- Add `dimensions` for `Group`
- Add `dimensions` overload for `Group`, `Item` and `NdItem` 

Checklist
- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
