### PR TITLE
Pin pytest to 8.0.1

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -176,8 +176,10 @@ jobs:
 
       # We want to make sure that all dependecies install automatically.
       # intel::intel-opencl-rt is needed for set-intel-ocl-icd-registry.ps1
+      # TODO: remove pytest dependency directly, once resolved:
+      # https://github.com/pytest-dev/pytest/issues/12036
       - name: Install builded package
-        run: mamba install ${{ env.PACKAGE_NAME }}=${{ env.PACKAGE_VERSION }} intel::intel-opencl-rt pytest-cov conda-tree -c ${{ env.CHANNEL_PATH }}
+        run: mamba install ${{ env.PACKAGE_NAME }}=${{ env.PACKAGE_VERSION }} intel::intel-opencl-rt pytest-cov pytest=8.0.1 conda-tree -c ${{ env.CHANNEL_PATH }}
 
       - name: Install numba-mlir
         if: matrix.use_mlir


### PR DESCRIPTION
Windows tests started failing since `8.0.2` pytest release. Use previous version

Pytest issue to track the status: https://github.com/pytest-dev/pytest/issues/12036

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
