### PR TITLE
Feature/add linear indexing overload

### DIFF
--- a/numba_dpex/experimental/_kernel_dpcpp_spirv_overloads/_index_space_id_overloads.py
+++ b/numba_dpex/experimental/_kernel_dpcpp_spirv_overloads/_index_space_id_overloads.py
@@ -16,7 +16,7 @@ from numba_dpex.core.types.kernel_api.index_space_ids import (
     ItemType,
     NdItemType,
 )
-from numba_dpex.kernel_api import Item, NdItem
+from numba_dpex.kernel_api import Group, Item, NdItem
 from numba_dpex.kernel_api_impl.spirv.target import SPIRVTargetContext
 
 from ..target import DPEX_KERNEL_EXP_TARGET_NAME
@@ -303,3 +303,4 @@ def register_jitable_method(type_, method):
 register_jitable_method(ItemType, Item.get_linear_id)
 register_jitable_method(NdItemType, NdItem.get_global_linear_id)
 register_jitable_method(NdItemType, NdItem.get_local_linear_id)
+register_jitable_method(GroupType, Group.get_group_linear_id)

--- a/numba_dpex/experimental/_kernel_dpcpp_spirv_overloads/_index_space_id_overloads.py
+++ b/numba_dpex/experimental/_kernel_dpcpp_spirv_overloads/_index_space_id_overloads.py
@@ -301,6 +301,11 @@ def register_jitable_method(type_, method):
 
 
 register_jitable_method(ItemType, Item.get_linear_id)
+register_jitable_method(ItemType, Item.get_linear_range)
 register_jitable_method(NdItemType, NdItem.get_global_linear_id)
+register_jitable_method(NdItemType, NdItem.get_global_linear_range)
+register_jitable_method(NdItemType, NdItem.get_local_linear_range)
 register_jitable_method(NdItemType, NdItem.get_local_linear_id)
 register_jitable_method(GroupType, Group.get_group_linear_id)
+register_jitable_method(GroupType, Group.get_group_linear_range)
+register_jitable_method(GroupType, Group.get_local_linear_range)

--- a/numba_dpex/experimental/_kernel_dpcpp_spirv_overloads/_index_space_id_overloads.py
+++ b/numba_dpex/experimental/_kernel_dpcpp_spirv_overloads/_index_space_id_overloads.py
@@ -180,26 +180,31 @@ def generate_index_overload(_type, _intrinsic):
     return ol_item_gen_index
 
 
-_index_const_overload_methods = [
-    (ItemType, "get_id", _intrinsic_spirv_global_invocation_id),
-    (ItemType, "get_range", _intrinsic_spirv_global_size),
-    (NdItemType, "get_global_id", _intrinsic_spirv_global_invocation_id),
-    (NdItemType, "get_local_id", _intrinsic_spirv_local_invocation_id),
-    (NdItemType, "get_global_range", _intrinsic_spirv_global_size),
-    (NdItemType, "get_local_range", _intrinsic_spirv_workgroup_size),
-    (GroupType, "get_group_id", _intrinsic_spirv_workgroup_id),
-    (GroupType, "get_group_range", _intrinsic_spirv_numworkgroups),
-    (GroupType, "get_local_range", _intrinsic_spirv_workgroup_size),
-]
+def register_index_const_methods():
+    """Register indexing related methods that can be defined as spirv const."""
+    _index_const_overload_methods = [
+        (ItemType, "get_id", _intrinsic_spirv_global_invocation_id),
+        (ItemType, "get_range", _intrinsic_spirv_global_size),
+        (NdItemType, "get_global_id", _intrinsic_spirv_global_invocation_id),
+        (NdItemType, "get_local_id", _intrinsic_spirv_local_invocation_id),
+        (NdItemType, "get_global_range", _intrinsic_spirv_global_size),
+        (NdItemType, "get_local_range", _intrinsic_spirv_workgroup_size),
+        (GroupType, "get_group_id", _intrinsic_spirv_workgroup_id),
+        (GroupType, "get_group_range", _intrinsic_spirv_numworkgroups),
+        (GroupType, "get_local_range", _intrinsic_spirv_workgroup_size),
+    ]
 
-for index_overload in _index_const_overload_methods:
-    _type, method, _intrinsic = index_overload
+    for index_overload in _index_const_overload_methods:
+        _type, method, _intrinsic = index_overload
 
-    ol_index_func = generate_index_overload(_type, _intrinsic)
+        ol_index_func = generate_index_overload(_type, _intrinsic)
 
-    overload_method(_type, method, target=DPEX_KERNEL_EXP_TARGET_NAME)(
-        ol_index_func
-    )
+        overload_method(_type, method, target=DPEX_KERNEL_EXP_TARGET_NAME)(
+            ol_index_func
+        )
+
+
+register_index_const_methods()
 
 
 @intrinsic(target=DPEX_KERNEL_EXP_TARGET_NAME)

--- a/numba_dpex/kernel_api/index_space_ids.py
+++ b/numba_dpex/kernel_api/index_space_ids.py
@@ -128,14 +128,14 @@ class Item:
         Returns:
             int: The linear id.
         """
-        if len(self._extent) == 1:
-            return self._index[0]
-        if len(self._extent) == 2:
-            return self._index[0] * self._extent[1] + self._index[1]
+        if self.dimensions == 1:
+            return self.get_id(0)
+        if self.dimensions == 2:
+            return self.get_id(0) * self.get_range(1) + self.get_id(1)
         return (
-            (self._index[0] * self._extent[1] * self._extent[2])
-            + (self._index[1] * self._extent[2])
-            + (self._index[2])
+            (self.get_id(0) * self.get_range(1) * self.get_range(2))
+            + (self.get_id(1) * self.get_range(2))
+            + (self.get_id(2))
         )
 
     def get_id(self, idx):
@@ -193,7 +193,24 @@ class NdItem:
         Returns:
             int: The global linear id.
         """
-        return self._global_item.get_linear_id()
+        # Instead of calling self._global_item.get_linear_id(), the linearization
+        # logic is duplicated here so that the method can be JIT compiled by
+        # numba-dpex and works in both Python and Numba nopython modes.
+        if self.dimensions == 1:
+            return self.get_global_id(0)
+        if self.dimensions == 2:
+            return self.get_global_id(0) * self.get_global_range(
+                1
+            ) + self.get_global_id(1)
+        return (
+            (
+                self.get_global_id(0)
+                * self.get_global_range(1)
+                * self.get_global_range(2)
+            )
+            + (self.get_global_id(1) * self.get_global_range(2))
+            + (self.get_global_id(2))
+        )
 
     def get_local_id(self, idx):
         """Get the local id for a specific dimension.
@@ -210,7 +227,24 @@ class NdItem:
         Returns:
             int: The local linear id.
         """
-        return self._local_item.get_linear_id()
+        # Instead of calling self._local_item.get_linear_id(), the linearization
+        # logic is duplicated here so that the method can be JIT compiled by
+        # numba-dpex and works in both Python and Numba nopython modes.
+        if self.dimensions == 1:
+            return self.get_local_id(0)
+        if self.dimensions == 2:
+            return self.get_local_id(0) * self.get_local_range(
+                1
+            ) + self.get_local_id(1)
+        return (
+            (
+                self.get_local_id(0)
+                * self.get_local_range(1)
+                * self.get_local_range(2)
+            )
+            + (self.get_local_id(1) * self.get_local_range(2))
+            + (self.get_local_id(2))
+        )
 
     def get_global_range(self, idx):
         """Get the global range size for a specific dimension.

--- a/numba_dpex/kernel_api/index_space_ids.py
+++ b/numba_dpex/kernel_api/index_space_ids.py
@@ -67,8 +67,8 @@ class Group:
     def get_group_linear_range(self):
         """Return the total number of work-groups in the nd_range."""
         num_wg = 1
-        for ext in self._group_range:
-            num_wg *= ext
+        for i in range(self.dimensions):
+            num_wg *= self.get_group_range(i)
 
         return num_wg
 
@@ -82,8 +82,8 @@ class Group:
     def get_local_linear_range(self):
         """Return the total number of work-items in the work-group."""
         num_wi = 1
-        for ext in self._local_range:
-            num_wi *= ext
+        for i in range(self.dimensions):
+            num_wi *= self.get_local_range(i)
 
         return num_wi
 
@@ -151,6 +151,14 @@ class Item:
             int: The id
         """
         return self._index[idx]
+
+    def get_linear_range(self):
+        """Return the total number of work-items in the work-group."""
+        num_wi = 1
+        for i in range(self.dimensions):
+            num_wi *= self.get_range(i)
+
+        return num_wi
 
     def get_range(self, idx):
         """Get the range size for a specific dimension.
@@ -267,6 +275,22 @@ class NdItem:
             int: The size
         """
         return self._local_item.get_range(idx)
+
+    def get_local_linear_range(self):
+        """Return the total number of work-items in the work-group."""
+        num_wi = 1
+        for i in range(self.dimensions):
+            num_wi *= self.get_local_range(i)
+
+        return num_wi
+
+    def get_global_linear_range(self):
+        """Return the total number of work-items in the work-group."""
+        num_wi = 1
+        for i in range(self.dimensions):
+            num_wi *= self.get_global_range(i)
+
+        return num_wi
 
     def get_group(self):
         """Returns the group.

--- a/numba_dpex/kernel_api/index_space_ids.py
+++ b/numba_dpex/kernel_api/index_space_ids.py
@@ -42,14 +42,20 @@ class Group:
 
     def get_group_linear_id(self):
         """Returns a linearized version of the work-group index."""
-        if len(self._index) == 1:
-            return self._index[0]
-        if len(self._index) == 2:
-            return self._index[0] * self._group_range[1] + self._index[1]
+        if self.dimensions == 1:
+            return self.get_group_id(0)
+        if self.dimensions == 2:
+            return self.get_group_id(0) * self.get_group_range(
+                1
+            ) + self.get_group_id(1)
         return (
-            (self._index[0] * self._group_range[1] * self._group_range[2])
-            + (self._index[1] * self._group_range[2])
-            + (self._index[2])
+            (
+                self.get_group_id(0)
+                * self.get_group_range(1)
+                * self.get_group_range(2)
+            )
+            + (self.get_group_id(1) * self.get_group_range(2))
+            + (self.get_group_id(2))
         )
 
     def get_group_range(self, dim):

--- a/numba_dpex/tests/experimental/test_index_space_ids.py
+++ b/numba_dpex/tests/experimental/test_index_space_ids.py
@@ -36,11 +36,38 @@ def set_last_one_item(item: Item, a):
 
 
 @dpex_exp.kernel
+def set_last_one_linear_item(item: Item, a):
+    i = item.get_linear_range() - 1
+    a[i] = 1
+
+
+@dpex_exp.kernel
+def set_last_one_linear_nd_item(nd_item: NdItem, a):
+    i = nd_item.get_global_linear_range() - 1
+    a[0] = i
+    a[i] = 1
+
+
+@dpex_exp.kernel
 def set_last_one_nd_item(item: NdItem, a):
     if item.get_global_id(0) == 0:
         i = item.get_global_range(0) - 1
         a[0] = i
         a[i] = 1
+
+
+@dpex_exp.kernel
+def set_last_group_one_linear_nd_item(nd_item: NdItem, a):
+    i = nd_item.get_local_linear_range() - 1
+    a[0] = i
+    a[i] = 1
+
+
+@dpex_exp.kernel
+def set_last_group_one_group_linear_nd_item(nd_item: NdItem, a):
+    i = nd_item.get_group().get_local_linear_range() - 1
+    a[0] = i
+    a[i] = 1
 
 
 @dpex_exp.kernel
@@ -99,6 +126,12 @@ def _get_group_range_driver(nditem: NdItem, a):
     a[i] = g.get_group_range(0)
 
 
+def _get_group_linear_range_driver(nditem: NdItem, a):
+    i = nditem.get_global_linear_id()
+    g = nditem.get_group()
+    a[i] = g.get_group_linear_range()
+
+
 def _get_group_local_range_driver(nditem: NdItem, a):
     i = nditem.get_global_id(0)
     g = nditem.get_group()
@@ -122,11 +155,34 @@ def test_item_get_range():
     assert np.array_equal(a.asnumpy(), want)
 
 
-def test_nd_item_get_global_range():
+@pytest.mark.parametrize(
+    "rng",
+    [dpex.Range(_SIZE), dpex.Range(1, _GROUP_SIZE, int(_SIZE / _GROUP_SIZE))],
+)
+def test_item_get_linear_range(rng):
     a = dpnp.zeros(_SIZE, dtype=dpnp.float32)
-    dpex_exp.call_kernel(
-        set_last_one_nd_item, dpex.NdRange((a.size,), (_GROUP_SIZE,)), a
-    )
+    dpex_exp.call_kernel(set_last_one_linear_item, rng, a)
+
+    want = np.zeros(a.size, dtype=np.float32)
+    want[-1] = 1
+
+    assert np.array_equal(a.asnumpy(), want)
+
+
+@pytest.mark.parametrize(
+    "kernel,rng",
+    [
+        (set_last_one_nd_item, dpex.NdRange((_SIZE,), (_GROUP_SIZE,))),
+        (set_last_one_linear_nd_item, dpex.NdRange((_SIZE,), (_GROUP_SIZE,))),
+        (
+            set_last_one_linear_nd_item,
+            dpex.NdRange((1, 1, _SIZE), (1, 1, _GROUP_SIZE)),
+        ),
+    ],
+)
+def test_nd_item_get_global_range(kernel, rng):
+    a = dpnp.zeros(_SIZE, dtype=dpnp.float32)
+    dpex_exp.call_kernel(kernel, rng, a)
 
     want = np.zeros(a.size, dtype=np.float32)
     want[-1] = 1
@@ -135,11 +191,31 @@ def test_nd_item_get_global_range():
     assert np.array_equal(a.asnumpy(), want)
 
 
-def test_nd_item_get_local_range():
+@pytest.mark.parametrize(
+    "kernel,rng",
+    [
+        (set_last_group_one_nd_item, dpex.NdRange((_SIZE,), (_GROUP_SIZE,))),
+        (
+            set_last_group_one_linear_nd_item,
+            dpex.NdRange((_SIZE,), (_GROUP_SIZE,)),
+        ),
+        (
+            set_last_group_one_linear_nd_item,
+            dpex.NdRange((1, 1, _SIZE), (1, 1, _GROUP_SIZE)),
+        ),
+        (
+            set_last_group_one_group_linear_nd_item,
+            dpex.NdRange((_SIZE,), (_GROUP_SIZE,)),
+        ),
+        (
+            set_last_group_one_group_linear_nd_item,
+            dpex.NdRange((1, 1, _SIZE), (1, 1, _GROUP_SIZE)),
+        ),
+    ],
+)
+def test_nd_item_get_local_range(kernel, rng):
     a = dpnp.zeros(_SIZE, dtype=dpnp.float32)
-    dpex_exp.call_kernel(
-        set_last_group_one_nd_item, dpex.NdRange((a.size,), (_GROUP_SIZE,)), a
-    )
+    dpex_exp.call_kernel(kernel, rng, a)
 
     want = np.zeros(a.size, dtype=np.float32)
     want[_GROUP_SIZE - 1] = 1
@@ -240,21 +316,32 @@ def test_get_group_id(driver, rng):
     assert np.array_equal(ka.asnumpy(), expected)
 
 
-def test_get_group_range():
-    global_size = 100
-    group_size = 20
-    num_groups = global_size // group_size
+@pytest.mark.parametrize(
+    "driver,rng",
+    [
+        (_get_group_range_driver, dpex.NdRange((_SIZE,), (_GROUP_SIZE,))),
+        (
+            _get_group_linear_range_driver,
+            dpex.NdRange((_SIZE,), (_GROUP_SIZE,)),
+        ),
+        (
+            _get_group_linear_range_driver,
+            dpex.NdRange((1, 1, _SIZE), (1, 1, _GROUP_SIZE)),
+        ),
+    ],
+)
+def test_get_group_range(driver, rng):
+    num_groups = _SIZE // _GROUP_SIZE
 
-    a = dpnp.empty(global_size, dtype=dpnp.int32)
-    ka = dpnp.empty(global_size, dtype=dpnp.int32)
-    expected = np.empty(global_size, dtype=np.int32)
-    ndrange = NdRange((global_size,), (group_size,))
-    dpex_exp.call_kernel(dpex_exp.kernel(_get_group_range_driver), ndrange, a)
-    kapi_call_kernel(_get_group_range_driver, ndrange, ka)
+    a = dpnp.empty(_SIZE, dtype=dpnp.int32)
+    ka = dpnp.empty(_SIZE, dtype=dpnp.int32)
+    expected = np.empty(_SIZE, dtype=np.int32)
+    dpex_exp.call_kernel(dpex_exp.kernel(driver), rng, a)
+    kapi_call_kernel(driver, rng, ka)
 
     for gid in range(num_groups):
-        for lid in range(group_size):
-            expected[gid * group_size + lid] = num_groups
+        for lid in range(_GROUP_SIZE):
+            expected[gid * _GROUP_SIZE + lid] = num_groups
 
     assert np.array_equal(a.asnumpy(), expected)
     assert np.array_equal(ka.asnumpy(), expected)


### PR DESCRIPTION
Reimplement linear indexing functions so they can be used both in python and numba_jit and add those as an overload. Ideal way would be to use `numba_dpex.extending.register_jitable` but it does not support methods, so I had write some kind of workaround

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?

Fixes #199 (satisfied by `get_global_linear_id` or `get_linear_id`)
