### PR TITLE
Fix/private array

### DIFF
--- a/numba_dpex/experimental/_kernel_dpcpp_spirv_overloads/_private_array_overloads.py
+++ b/numba_dpex/experimental/_kernel_dpcpp_spirv_overloads/_private_array_overloads.py
@@ -9,6 +9,7 @@ Implements the SPIR-V overloads for the kernel_api.PrivateArray class.
 
 import llvmlite.ir as llvmir
 from llvmlite.ir.builder import IRBuilder
+from numba.core import cgutils
 from numba.core.typing.npydecl import parse_dtype as _ty_parse_dtype
 from numba.core.typing.npydecl import parse_shape as _ty_parse_shape
 from numba.core.typing.templates import Signature
@@ -28,9 +29,13 @@ from ..target import DPEX_KERNEL_EXP_TARGET_NAME
 
 @intrinsic(target=DPEX_KERNEL_EXP_TARGET_NAME)
 def _intrinsic_private_array_ctor(
-    ty_context, ty_shape, ty_dtype  # pylint: disable=unused-argument
+    ty_context,  # pylint: disable=unused-argument
+    ty_shape,
+    ty_dtype,
+    ty_fill_zeros,
 ):
     require_literal(ty_shape)
+    require_literal(ty_fill_zeros)
 
     ty_array = USMNdArray(
         dtype=_ty_parse_dtype(ty_dtype),
@@ -39,7 +44,7 @@ def _intrinsic_private_array_ctor(
         addrspace=AddressSpace.PRIVATE,
     )
 
-    sig = ty_array(ty_shape, ty_dtype)
+    sig = ty_array(ty_shape, ty_dtype, ty_fill_zeros)
 
     def codegen(
         context: DpexExpKernelTypingContext,
@@ -49,11 +54,18 @@ def _intrinsic_private_array_ctor(
     ):
         shape = args[0]
         ty_shape = sig.args[0]
+        ty_fill_zeros = sig.args[-1]
         ty_array = sig.return_type
 
         ary = make_spirv_generic_array_on_stack(
             context, builder, ty_array, ty_shape, shape
         )
+
+        if ty_fill_zeros.literal_value:
+            cgutils.memset(
+                builder, ary.data, builder.mul(ary.itemsize, ary.nitems), 0
+            )
+
         return ary._getvalue()  # pylint: disable=protected-access
 
     return (
@@ -70,6 +82,7 @@ def _intrinsic_private_array_ctor(
 def ol_private_array_ctor(
     shape,
     dtype,
+    fill_zeros=False,
 ):
     """Overload of the constructor for the class
     class:`numba_dpex.kernel_api.PrivateArray`.
@@ -84,8 +97,9 @@ def ol_private_array_ctor(
     def ol_private_array_ctor_impl(
         shape,
         dtype,
+        fill_zeros=False,
     ):
         # pylint: disable=no-value-for-parameter
-        return _intrinsic_private_array_ctor(shape, dtype)
+        return _intrinsic_private_array_ctor(shape, dtype, fill_zeros)
 
     return ol_private_array_ctor_impl

--- a/numba_dpex/experimental/_kernel_dpcpp_spirv_overloads/_private_array_overloads.py
+++ b/numba_dpex/experimental/_kernel_dpcpp_spirv_overloads/_private_array_overloads.py
@@ -9,11 +9,11 @@ Implements the SPIR-V overloads for the kernel_api.PrivateArray class.
 
 import llvmlite.ir as llvmir
 from llvmlite.ir.builder import IRBuilder
-from numba.core import cgutils
+from numba.core import cgutils, types
 from numba.core.typing.npydecl import parse_dtype as _ty_parse_dtype
 from numba.core.typing.npydecl import parse_shape as _ty_parse_shape
 from numba.core.typing.templates import Signature
-from numba.extending import intrinsic, overload
+from numba.extending import type_callable
 
 from numba_dpex.core.types import USMNdArray
 from numba_dpex.experimental.target import DpexExpKernelTypingContext
@@ -24,67 +24,12 @@ from numba_dpex.kernel_api_impl.spirv.arrayobj import (
 )
 from numba_dpex.utils import address_space as AddressSpace
 
-from ..target import DPEX_KERNEL_EXP_TARGET_NAME
+from ._registry import lower
 
 
-@intrinsic(target=DPEX_KERNEL_EXP_TARGET_NAME)
-def _intrinsic_private_array_ctor(
-    ty_context,  # pylint: disable=unused-argument
-    ty_shape,
-    ty_dtype,
-    ty_fill_zeros,
-):
-    require_literal(ty_shape)
-    require_literal(ty_fill_zeros)
-
-    ty_array = USMNdArray(
-        dtype=_ty_parse_dtype(ty_dtype),
-        ndim=_ty_parse_shape(ty_shape),
-        layout="C",
-        addrspace=AddressSpace.PRIVATE,
-    )
-
-    sig = ty_array(ty_shape, ty_dtype, ty_fill_zeros)
-
-    def codegen(
-        context: DpexExpKernelTypingContext,
-        builder: IRBuilder,
-        sig: Signature,
-        args: list[llvmir.Value],
-    ):
-        shape = args[0]
-        ty_shape = sig.args[0]
-        ty_fill_zeros = sig.args[-1]
-        ty_array = sig.return_type
-
-        ary = make_spirv_generic_array_on_stack(
-            context, builder, ty_array, ty_shape, shape
-        )
-
-        if ty_fill_zeros.literal_value:
-            cgutils.memset(
-                builder, ary.data, builder.mul(ary.itemsize, ary.nitems), 0
-            )
-
-        return ary._getvalue()  # pylint: disable=protected-access
-
-    return (
-        sig,
-        codegen,
-    )
-
-
-@overload(
-    PrivateArray,
-    prefer_literal=True,
-    target=DPEX_KERNEL_EXP_TARGET_NAME,
-)
-def ol_private_array_ctor(
-    shape,
-    dtype,
-    fill_zeros=False,
-):
-    """Overload of the constructor for the class
+@type_callable(PrivateArray)
+def type_interval(context):  # pylint: disable=unused-argument
+    """Sets type of the constructor for the class
     class:`numba_dpex.kernel_api.PrivateArray`.
 
     Raises:
@@ -94,12 +39,48 @@ def ol_private_array_ctor(
             type.
     """
 
-    def ol_private_array_ctor_impl(
-        shape,
-        dtype,
-        fill_zeros=False,
-    ):
-        # pylint: disable=no-value-for-parameter
-        return _intrinsic_private_array_ctor(shape, dtype, fill_zeros)
+    def typer(shape, dtype, fill_zeros=types.BooleanLiteral(False)):
+        require_literal(shape)
+        require_literal(fill_zeros)
 
-    return ol_private_array_ctor_impl
+        return USMNdArray(
+            dtype=_ty_parse_dtype(dtype),
+            ndim=_ty_parse_shape(shape),
+            layout="C",
+            addrspace=AddressSpace.PRIVATE,
+        )
+
+    return typer
+
+
+@lower(PrivateArray, types.IntegerLiteral, types.Any, types.BooleanLiteral)
+@lower(PrivateArray, types.Tuple, types.Any, types.BooleanLiteral)
+@lower(PrivateArray, types.UniTuple, types.Any, types.BooleanLiteral)
+@lower(PrivateArray, types.IntegerLiteral, types.Any)
+@lower(PrivateArray, types.Tuple, types.Any)
+@lower(PrivateArray, types.UniTuple, types.Any)
+def dpex_private_array_lower(
+    context: DpexExpKernelTypingContext,
+    builder: IRBuilder,
+    sig: Signature,
+    args: list[llvmir.Value],
+):
+    """Implements lower for the class:`numba_dpex.kernel_api.PrivateArray`"""
+    shape = args[0]
+    ty_shape = sig.args[0]
+    if len(sig.args) == 3:
+        fill_zeros = sig.args[-1].literal_value
+    else:
+        fill_zeros = False
+    ty_array = sig.return_type
+
+    ary = make_spirv_generic_array_on_stack(
+        context, builder, ty_array, ty_shape, shape
+    )
+
+    if fill_zeros:
+        cgutils.memset(
+            builder, ary.data, builder.mul(ary.itemsize, ary.nitems), 0
+        )
+
+    return ary._getvalue()  # pylint: disable=protected-access

--- a/numba_dpex/experimental/_kernel_dpcpp_spirv_overloads/_registry.py
+++ b/numba_dpex/experimental/_kernel_dpcpp_spirv_overloads/_registry.py
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2024 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Implements the SPIR-V overloads for the kernel_api.PrivateArray class.
+"""
+
+from numba.core.imputils import Registry
+
+registry = Registry()
+lower = registry.lower

--- a/numba_dpex/kernel_api/private_array.py
+++ b/numba_dpex/kernel_api/private_array.py
@@ -7,7 +7,7 @@ Implementation is intended to be used in pure Python code when prototyping a
 kernel function.
 """
 
-from numpy import ndarray
+import numpy as np
 
 
 class PrivateArray:
@@ -16,10 +16,13 @@ class PrivateArray:
     inside kernel work item.
     """
 
-    def __init__(self, shape, dtype) -> None:
+    def __init__(self, shape, dtype, fill_zeros=False) -> None:
         """Creates a new PrivateArray instance of the given shape and dtype."""
 
-        self._data = ndarray(shape=shape, dtype=dtype)
+        if fill_zeros:
+            self._data = np.zeros(shape=shape, dtype=dtype)
+        else:
+            self._data = np.empty(shape=shape, dtype=dtype)
 
     def __getitem__(self, idx_obj):
         """Returns the value stored at the position represented by idx_obj in

--- a/numba_dpex/kernel_api_impl/spirv/arrayobj.py
+++ b/numba_dpex/kernel_api_impl/spirv/arrayobj.py
@@ -41,7 +41,9 @@ def require_literal(literal_type: types.Type):
 
     for i, _ in enumerate(literal_type):
         if not isinstance(literal_type[i], types.Literal):
-            raise errors.TypingError("requires literal type")
+            raise errors.TypingError(
+                "requires each element of tuple literal type"
+            )
 
 
 def make_spirv_array(  # pylint: disable=too-many-arguments

--- a/numba_dpex/kernel_api_impl/spirv/spirv_generator.py
+++ b/numba_dpex/kernel_api_impl/spirv/spirv_generator.py
@@ -123,6 +123,7 @@ class Module:
         llvm_spirv_args = [
             "--spirv-ext=+SPV_EXT_shader_atomic_float_add",
             "--spirv-ext=+SPV_EXT_shader_atomic_float_min_max",
+            "--spirv-ext=+SPV_INTEL_arbitrary_precision_integers",
         ]
         for key in list(self.context.extra_compile_options.keys()):
             if key == LLVM_SPIRV_ARGS:

--- a/numba_dpex/kernel_api_impl/spirv/target.py
+++ b/numba_dpex/kernel_api_impl/spirv/target.py
@@ -383,12 +383,16 @@ class SPIRVTargetContext(BaseContext):
         # pylint: disable=import-outside-toplevel
         from numba_dpex import printimpl
         from numba_dpex.dpnp_iface import dpnpimpl
+        from numba_dpex.experimental._kernel_dpcpp_spirv_overloads._registry import (
+            registry as spirv_registry,
+        )
         from numba_dpex.ocl import mathimpl, oclimpl
 
         self.insert_func_defn(oclimpl.registry.functions)
         self.insert_func_defn(mathimpl.registry.functions)
         self.insert_func_defn(dpnpimpl.registry.functions)
         self.install_registry(printimpl.registry)
+        self.install_registry(spirv_registry)
         # Replace dpnp math functions with their OpenCL versions.
         self.replace_dpnp_ufunc_with_ocl_intrinsics()
 

--- a/numba_dpex/tests/experimental/test_private_array.py
+++ b/numba_dpex/tests/experimental/test_private_array.py
@@ -23,6 +23,30 @@ def private_array_kernel(item: Item, a):
         a[i] += p[j]
 
 
+def private_array_kernel_fill_true(item: Item, a):
+    i = item.get_linear_id()
+    p = PrivateArray(10, a.dtype, fill_zeros=True)
+
+    for j in range(10):
+        p[j] = j * j
+
+    a[i] = 0
+    for j in range(10):
+        a[i] += p[j]
+
+
+def private_array_kernel_fill_false(item: Item, a):
+    i = item.get_linear_id()
+    p = PrivateArray(10, a.dtype, fill_zeros=False)
+
+    for j in range(10):
+        p[j] = j * j
+
+    a[i] = 0
+    for j in range(10):
+        a[i] += p[j]
+
+
 def private_2d_array_kernel(item: Item, a):
     i = item.get_linear_id()
     p = PrivateArray(shape=(5, 2), dtype=a.dtype)
@@ -36,7 +60,13 @@ def private_2d_array_kernel(item: Item, a):
 
 
 @pytest.mark.parametrize(
-    "kernel", [private_array_kernel, private_2d_array_kernel]
+    "kernel",
+    [
+        private_array_kernel,
+        private_array_kernel_fill_true,
+        private_array_kernel_fill_false,
+        private_2d_array_kernel,
+    ],
 )
 @pytest.mark.parametrize(
     "call_kernel, decorator",


### PR DESCRIPTION
Use lower instead of overload, since we are allocating memory on the stack. Also adds optional argument `fill_zeros` cause previous implementation was doing so, but it is not essential and overkill for the performance.

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
