### PR TITLE
Use enum values for kernel arg types if dpctl >= 0.17

### DIFF
--- a/numba_dpex/dpctl_iface/_helpers.py
+++ b/numba_dpex/dpctl_iface/_helpers.py
@@ -4,6 +4,8 @@
 
 from numba.core import types
 
+from numba_dpex import dpctl_sem_version
+
 
 def numba_type_to_dpctl_typenum(context, ty):
     """
@@ -11,32 +13,52 @@ def numba_type_to_dpctl_typenum(context, ty):
     ``DPCTLKernelArgType``.
     """
 
-    val = None
-    if ty == types.int32 or isinstance(ty, types.scalars.IntegerLiteral):
-        # DPCTL_LONG_LONG
-        val = context.get_constant(types.int32, 9)
-    elif ty == types.uint32:
-        # DPCTL_UNSIGNED_LONG_LONG
-        val = context.get_constant(types.int32, 10)
-    elif ty == types.boolean:
-        # DPCTL_UNSIGNED_INT
-        val = context.get_constant(types.int32, 5)
-    elif ty == types.int64:
-        # DPCTL_LONG_LONG
-        val = context.get_constant(types.int32, 9)
-    elif ty == types.uint64:
-        # DPCTL_SIZE_T
-        val = context.get_constant(types.int32, 11)
-    elif ty == types.float32:
-        # DPCTL_FLOAT
-        val = context.get_constant(types.int32, 12)
-    elif ty == types.float64:
-        # DPCTL_DOUBLE
-        val = context.get_constant(types.int32, 13)
-    elif ty == types.voidptr or isinstance(ty, types.CPointer):
-        # DPCTL_VOID_PTR
-        val = context.get_constant(types.int32, 15)
-    else:
-        raise NotImplementedError
+    if dpctl_sem_version >= (0, 17, 0):
+        # FIXME change to imports from a dpctl enum/class rather than
+        # hard coding these numbers.
 
-    return val
+        if ty == types.boolean:
+            return context.get_constant(types.int32, 1)
+        elif ty == types.int32 or isinstance(ty, types.scalars.IntegerLiteral):
+            return context.get_constant(types.int32, 4)
+        elif ty == types.uint32:
+            return context.get_constant(types.int32, 5)
+        elif ty == types.int64:
+            return context.get_constant(types.int32, 6)
+        elif ty == types.uint64:
+            return context.get_constant(types.int32, 7)
+        elif ty == types.float32:
+            return context.get_constant(types.int32, 8)
+        elif ty == types.float64:
+            return context.get_constant(types.int32, 9)
+        elif ty == types.voidptr or isinstance(ty, types.CPointer):
+            return context.get_constant(types.int32, 10)
+        else:
+            raise NotImplementedError
+    else:
+        if ty == types.int32 or isinstance(ty, types.scalars.IntegerLiteral):
+            # DPCTL_LONG_LONG
+            return context.get_constant(types.int32, 9)
+        elif ty == types.uint32:
+            # DPCTL_UNSIGNED_LONG_LONG
+            return context.get_constant(types.int32, 10)
+        elif ty == types.boolean:
+            # DPCTL_UNSIGNED_INT
+            return context.get_constant(types.int32, 5)
+        elif ty == types.int64:
+            # DPCTL_LONG_LONG
+            return context.get_constant(types.int32, 9)
+        elif ty == types.uint64:
+            # DPCTL_SIZE_T
+            return context.get_constant(types.int32, 11)
+        elif ty == types.float32:
+            # DPCTL_FLOAT
+            return context.get_constant(types.int32, 12)
+        elif ty == types.float64:
+            # DPCTL_DOUBLE
+            return context.get_constant(types.int32, 13)
+        elif ty == types.voidptr or isinstance(ty, types.CPointer):
+            # DPCTL_VOID_PTR
+            return context.get_constant(types.int32, 15)
+        else:
+            raise NotImplementedError


### PR DESCRIPTION
- [X] Have you provided a meaningful PR description?
https://github.com/IntelPython/dpctl/pull/1581 updated the enum values for DPCTLSyclKernelArgTy and also introduced a Python enum to track the libsyclinterface values. The current numba-dpex PR uses the latest API and enum from dpctl if the semantic version of dpctl is 0.17 or greater. Old behavior is retained for backward compatibility.

- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
