### PR TITLE
Verify that AtomicRef over LocalAccessor is supported.

### DIFF
--- a/numba_dpex/kernel_api/atomic_ref.py
+++ b/numba_dpex/kernel_api/atomic_ref.py
@@ -22,7 +22,7 @@ class AtomicRef:
         index,
         memory_order=MemoryOrder.RELAXED,
         memory_scope=MemoryScope.DEVICE,
-        address_space=AddressSpace.GLOBAL,
+        address_space=None,
     ):
         """A Python stub to represent a SYCL AtomicRef class. An AtomicRef
         object represents a single element view into a Python array-like object
@@ -35,6 +35,11 @@ class AtomicRef:
         self._memory_order = memory_order
         self._memory_scope = memory_scope
         self._address_space = address_space
+
+        if not (hasattr(ref, "__getitem__") and hasattr(ref, "__setitem__")):
+            raise TypeError(
+                "Cannot create an AtomicRef from an unsupported ref type."
+            )
         self._ref = ref
         self._index = index
 


### PR DESCRIPTION
- [X] Have you provided a meaningful PR description?
    - Verifies that an AtomicRef can be constructed from a LocalAccessor object in both kernel_api and compiled modes.
    - Change the default value of the AddressSpace keyword to AtomicRef overload to None. If the value is None, it gets inferred from the ref argument. Doing this we do not have to explicitly specify AddressSpace value for AtomicRef constructed from a LocalAccessor.
    - Unit tests.
- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
