### PR TITLE
Tests/port existing kernel tests to experimental 

### DIFF
--- a/numba_dpex/tests/kernel_tests/test_complex_array_kernel_arg.py
+++ b/numba_dpex/tests/kernel_tests/test_complex_array_kernel_arg.py
@@ -6,21 +6,21 @@ import dpnp
 import numpy
 import pytest
 
-import numba_dpex as dpex
+import numba_dpex.experimental as dpex
 from numba_dpex.tests._helper import get_all_dtypes
 
 N = 1024
 
 
 @dpex.kernel
-def kernel_scalar(a, b, c):
-    i = dpex.get_global_id(0)
+def kernel_scalar(item, a, b, c):
+    i = item.get_id(0)
     b[i] = a[i] * c
 
 
 @dpex.kernel
-def kernel_array(a, b, c):
-    i = dpex.get_global_id(0)
+def kernel_array(item, a, b, c):
+    i = item.get_id(0)
     b[i] = a[i] * c[i]
 
 

--- a/numba_dpex/tests/kernel_tests/test_dpnp_ndarray_args.py
+++ b/numba_dpex/tests/kernel_tests/test_dpnp_ndarray_args.py
@@ -3,10 +3,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import dpnp
-from numpy.testing import assert_almost_equal
 
-import numba_dpex as ndpx
+import numba_dpex.experimental as ndpx
 from numba_dpex import float32
+from numba_dpex import kernel_api as kapi
 
 COEFFICIENTS = dpnp.asarray(
     [
@@ -64,9 +64,11 @@ COEFFICIENTS = dpnp.asarray(
 
 
 @ndpx.kernel()
-def _kernel(coefficients):
-    c = ndpx.private.array(4, dtype=float32)
-    gr_id = ndpx.get_group_id(0)
+def _kernel(nditem: kapi.NdItem, coefficients):
+    c = kapi.PrivateArray(4, dtype=float32)
+    gr: kapi.Group = nditem.get_group()
+    gr_id = gr.get_group_id(0)
+
     c[0] = coefficients[gr_id][0]
     c[1] = coefficients[gr_id][1]
     c[2] = coefficients[gr_id][2]

--- a/numba_dpex/tests/kernel_tests/test_func.py
+++ b/numba_dpex/tests/kernel_tests/test_func.py
@@ -5,17 +5,17 @@
 import dpnp
 import numpy
 
-import numba_dpex as dpex
+import numba_dpex.experimental as dpex
 
 
-@dpex.func
+@dpex.device_func
 def g(a):
     return a + dpnp.float32(1)
 
 
 @dpex.kernel
-def f(a, b):
-    i = dpex.get_global_id(0)
+def f(item, a, b):
+    i = item.get_id(0)
     b[i] = g(a[i])
 
 

--- a/numba_dpex/tests/kernel_tests/test_func_qualname_disambiguation.py
+++ b/numba_dpex/tests/kernel_tests/test_func_qualname_disambiguation.py
@@ -2,17 +2,15 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import dpctl.tensor as dpt
 import dpnp
 import numpy as np
 
-import numba_dpex as ndpx
+import numba_dpex.experimental as ndpx
 
 
 def make_write_values_kernel(n_rows):
-    """Uppermost kernel to set 1s in a certain way.
-    The uppermost kernel function invokes two levels
-    of inner functions to set 1s in an empty matrix
+    """Uppermost kernel to set 1s in a certain way. The uppermost kernel
+    function invokes two levels of inner functions to set 1s in an empty matrix
     in a certain way.
 
     Args:
@@ -20,8 +18,8 @@ def make_write_values_kernel(n_rows):
 
     Returns:
         numba_dpex.core.kernel_interface.dispatcher.JitKernel:
-            A JitKernel object that encapsulates a @kernel
-            decorated numba_dpex compiled kernel object.
+            A KernelDispatcher object that encapsulates a @kernel decorated
+            numba_dpex compiled kernel object.
     """
     write_values = make_write_values_kernel_func()
 
@@ -31,7 +29,7 @@ def make_write_values_kernel(n_rows):
             is_even = (row_idx % 2) == 0
             write_values(array_in, row_idx, is_even)
 
-    return write_values_kernel[ndpx.NdRange(ndpx.Range(1), ndpx.Range(1))]
+    return write_values_kernel
 
 
 def make_write_values_kernel_func():
@@ -47,7 +45,7 @@ def make_write_values_kernel_func():
     write_when_odd = make_write_values_kernel_func_inner(1)
     write_when_even = make_write_values_kernel_func_inner(3)
 
-    @ndpx.func
+    @ndpx.device_func
     def write_values(array_in, row_idx, is_even):
         if is_even:
             write_when_even(array_in, row_idx)
@@ -70,7 +68,7 @@ def make_write_values_kernel_func_inner(n_cols):
             numba_dpex compiled function object.
     """
 
-    @ndpx.func
+    @ndpx.device_func
     def write_values_inner(array_in, row_idx):
         for idx in range(n_cols):
             array_in[row_idx, idx] = 1
@@ -89,9 +87,9 @@ def test_qualname_basic():
         else:
             ans[i, 0] = 1
 
-    a = dpnp.zeros((10, 10), dtype=dpt.int64)
+    a = dpnp.zeros((10, 10), dtype=dpnp.int64)
 
     kernel = make_write_values_kernel(10)
-    kernel(a)
+    ndpx.call_kernel(kernel, ndpx.NdRange((1,), (1,)), a)
 
     assert np.array_equal(dpnp.asnumpy(a), ans)

--- a/numba_dpex/tests/kernel_tests/test_invalid_kernel_args.py
+++ b/numba_dpex/tests/kernel_tests/test_invalid_kernel_args.py
@@ -5,15 +5,15 @@
 import numpy
 import pytest
 
-import numba_dpex as dpex
-from numba_dpex.core.exceptions import UnsupportedKernelArgumentError
+import numba_dpex.experimental as dpex
+from numba_dpex import kernel_api as kapi
 
 N = 1024
 
 
 @dpex.kernel
-def vecadd_kernel(a, b, c):
-    i = dpex.get_global_id(0)
+def vecadd_kernel(item: kapi.Item, a, b, c):
+    i = item.get_id(0)
     c[i] = a[i] + b[i]
 
 
@@ -25,5 +25,5 @@ def test_passing_numpy_arrays_as_kernel_args():
     b = numpy.ones(N)
     c = numpy.zeros(N)
 
-    with pytest.raises(UnsupportedKernelArgumentError):
+    with pytest.raises(Exception):
         dpex.call_kernel(vecadd_kernel, dpex.Range(N), a, b, c)

--- a/numba_dpex/tests/kernel_tests/test_math_functions.py
+++ b/numba_dpex/tests/kernel_tests/test_math_functions.py
@@ -8,7 +8,7 @@ import dpnp
 import numpy
 import pytest
 
-import numba_dpex as dpex
+import numba_dpex.experimental as dpex
 from numba_dpex.tests._helper import get_all_dtypes
 
 list_of_unary_ops = ["fabs", "exp", "log", "sqrt", "sin", "cos", "tan"]
@@ -39,8 +39,8 @@ def test_binary_ops(unary_op, input_arrays):
     dpnp_uop = getattr(dpnp, unary_op)
 
     @dpex.kernel
-    def f(a, b):
-        i = dpex.get_global_id(0)
+    def f(item, a, b):
+        i = item.get_id(0)
         b[i] = uop(a[i])
 
     dpex.call_kernel(f, dpex.Range(a.size), a, b)

--- a/numba_dpex/tests/kernel_tests/test_print.py
+++ b/numba_dpex/tests/kernel_tests/test_print.py
@@ -5,9 +5,9 @@
 import dpctl
 import dpnp
 import pytest
-from numba.core.errors import LoweringError
+from numba.core.errors import TypingError
 
-import numba_dpex as dpex
+import numba_dpex.experimental as dpex
 
 list_of_dtypes = [
     dpnp.int32,
@@ -84,8 +84,10 @@ def test_print_only_str(input_arrays):
 
     a = input_arrays
 
-    with pytest.raises(LoweringError):
+    with pytest.raises(TypingError) as ex_info:
         dpex.call_kernel(print_string, dpex.Range(1), a)
+
+    assert "LoweringError" in ex_info.value.args[0]
 
 
 @skip_on_gpu
@@ -100,5 +102,7 @@ def test_print_array(input_arrays):
 
     a = input_arrays
 
-    with pytest.raises(LoweringError):
+    with pytest.raises(TypingError) as ex_info:
         dpex.call_kernel(print_string, dpex.Range(1), a)
+
+    assert "LoweringError" in ex_info.value.args[0]

--- a/numba_dpex/tests/kernel_tests/test_scalar_arg_types.py
+++ b/numba_dpex/tests/kernel_tests/test_scalar_arg_types.py
@@ -6,21 +6,21 @@ import dpnp
 import numpy
 import pytest
 
-import numba_dpex as dpex
+import numba_dpex.experimental as dpex
 from numba_dpex.tests._helper import get_all_dtypes
 
 N = 1024
 
 
 @dpex.kernel
-def scaling_kernel(a, b, c):
-    i = dpex.get_global_id(0)
+def scaling_kernel(item, a, b, c):
+    i = item.get_id(0)
     b[i] = a[i] * c
 
 
 @dpex.kernel
-def kernel_with_bool_arg(a, b, test):
-    i = dpex.get_global_id(0)
+def kernel_with_bool_arg(item, a, b, test):
+    i = item.get_id(0)
     if test:
         b[i] = a[i] + a[i]
     else:

--- a/numba_dpex/tests/kernel_tests/test_usm_ndarray_args.py
+++ b/numba_dpex/tests/kernel_tests/test_usm_ndarray_args.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import dpctl.tensor as dpt
+import numpy
+import pytest
+
+import numba_dpex.experimental as dpex
+from numba_dpex.tests._helper import get_all_dtypes
+
+list_of_dtype = get_all_dtypes(
+    no_bool=True, no_float16=True, no_none=True, no_complex=True
+)
+
+
+@pytest.fixture(params=list_of_dtype)
+def dtype(request):
+    return request.param
+
+
+list_of_usm_type = [
+    "shared",
+    "device",
+    "host",
+]
+
+
+@pytest.fixture(params=list_of_usm_type)
+def usm_type(request):
+    return request.param
+
+
+def test_consuming_usm_ndarray(dtype, usm_type):
+    @dpex.kernel
+    def data_parallel_sum(item, a, b, c):
+        """
+        Vector addition using the ``kernel`` decorator.
+        """
+        i = item.get_id(0)
+        j = item.get_id(1)
+        c[i, j] = a[i, j] + b[i, j]
+
+    N = 1000
+    global_size = N * N
+
+    a = dpt.arange(global_size, dtype=dtype, usm_type=usm_type)
+    a = dpt.reshape(a, shape=(N, N))
+
+    b = dpt.arange(global_size, dtype=dtype, usm_type=usm_type)
+    b = dpt.reshape(b, shape=(N, N))
+
+    c = dpt.empty_like(a)
+
+    dpex.call_kernel(data_parallel_sum, dpex.Range(N, N), a, b, c)
+
+    na = dpt.asnumpy(a)
+    nb = dpt.asnumpy(b)
+    nc = dpt.asnumpy(c)
+
+    assert numpy.array_equal(nc, na + nb)


### PR DESCRIPTION
- [ ] Have you provided a meaningful PR description?
The PR adds versions of existing kernel unit tests to the `numba_dpex.experimental.kernel`. The work is a prerequisite to identify gaps before migrating features from `numba_dpex.experimental` to the top-level `numba-dpex` module.

Matrix of existing kernel unit tests


| Test name  | Status | Notes|
| ------------- | ------------- |------|
| `test_atomic_op`  | *Not applicable* | Superseded by new `AtomicRef` tests in experimental module.|
| `test_barrier`  | **_TODO_** | Experimental needs a test for `group_barrier` with work-group scope.|
| `test_caching`  | *Not applicable* |The feature is redundant as experimental module uses Numba's function overload caching.|
| `test_complex_array` | **Done** |Renamed to `test_complex_array_kernel_arg` |
| `test_dpnp_ndarray_args` | **Done** | |
| `test_dump_kernel_llvm` | **_TODO_** | Tests for all configuration flags should be added in one place. |
| `test_func_qualname_disambiguation` | **Done** | |
| `test_func_specialization` | **Done**| #1398 |
| `test_func` | **Done** | |
| `test_invalid_kernel_args` | **Done** | |
| `test_kernel_has_return_value_error` | **DONE**. | #1394|
| `test_kernel_launch_params` | *Not applicable* | Experimental does need some negative tests for `call_kernel` |
| `test_kernel_specialization` | **Done** | |
| `test_math_functions` | **Done** | The number of existing tests is very inadequate.|
| `test_ndrange_exceptions` | **_TODO_** | The test should be moved to tests/kernel_api and rewritten as a `NdRange` constructor test |
| `test_print` | **_FAILS_** | `printimpl` not yet added to new target context |
| `test_private_memory_allocation` | *Not applicable* | superseded by tests for `kapi.PrivateArray` |
| `test_scalar_arg` | **Done** |  |
| `test_sycl_usm_array_iface_interop` | *Not applicable* | ``__SYCL_USM_ARRAY_INTERFACE__`` support is slotted to be removed and for the time being only `dpnp.ndarray` and `dpctl.tensor.usm_ndarray` are valid arrya inputs. Interop is implemented indirectly using `__dlpack__` conversion via dpnp/dpctl.tensor. |
| `test_usm_ndarray_interop` | **Done** | Renamed to `test_usm_ndarray_args` |



- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
