### PR TITLE
Fix KernelHasReturnValueError inside KernelDispatcher.

### DIFF
--- a/numba_dpex/tests/experimental/test_kernel_has_return_value_error.py
+++ b/numba_dpex/tests/experimental/test_kernel_has_return_value_error.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: 2020 - 2024 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import dpnp
+import pytest
+from numba.core.errors import TypingError
+
+import numba_dpex.experimental as dpex
+from numba_dpex import int32, usm_ndarray
+from numba_dpex.core.exceptions import KernelHasReturnValueError
+from numba_dpex.core.types.kernel_api.index_space_ids import ItemType
+
+i32arrty = usm_ndarray(ndim=1, dtype=int32, layout="C")
+item_ty = ItemType(ndim=1)
+
+
+def f(item, a):
+    return a
+
+
+list_of_sig = [
+    None,
+    (i32arrty(item_ty, i32arrty)),
+]
+
+
+@pytest.fixture(params=list_of_sig)
+def sig(request):
+    return request.param
+
+
+def test_return(sig):
+    a = dpnp.arange(1024, dtype=dpnp.int32)
+
+    with pytest.raises((TypingError, KernelHasReturnValueError)) as excinfo:
+        kernel_fn = dpex.kernel(sig)(f)
+        dpex.call_kernel(kernel_fn, dpex.Range(a.size), a)
+
+    if isinstance(excinfo.type, TypingError):
+        assert "KernelHasReturnValueError" in excinfo.value.args[0]


### PR DESCRIPTION
- [X] Have you provided a meaningful PR description?
The KernelHasReturnValueError check was not working as intended in the experimental module. The PR fixes it by moving the check after compilation and using the signature as derived by the compilation result.

- [X] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
