### PR TITLE
Add no optimization flags when debugging is on for experimental kernel

### DIFF
--- a/numba_dpex/experimental/launcher.py
+++ b/numba_dpex/experimental/launcher.py
@@ -220,7 +220,10 @@ def _submit_kernel(  # pylint: disable=too-many-arguments
             ty_kernel_args_tuple, ll_kernel_args_tuple
         )
         kl_builder.set_queue_from_arguments()
-        kl_builder.set_kernel_from_spirv(kernel_module)
+        kl_builder.set_kernel_from_spirv(
+            kernel_module,
+            debug=kernel_dispatcher.targetoptions.get("debug", False),
+        )
         if ty_dependent_events is None:
             kl_builder.set_dependent_events([])
         else:


### PR DESCRIPTION
Add gdb support to experimental kernel. Tests for gdb are currently broken, so nothing was added right now

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
