### PR TITLE
Fix use of dpctl.device_context in tests

### DIFF
--- a/numba_dpex/tests/_helper.py
+++ b/numba_dpex/tests/_helper.py
@@ -65,15 +65,13 @@ def has_sycl_platforms():
     return False
 
 
-def is_gen12(device_type):
-    with dpctl.device_context(device_type):
-        q = dpctl.get_current_queue()
-        device = q.get_sycl_device()
-        name = device.name
-        if "Gen12" in name:
-            return True
+def is_gen12():
+    """Checks if the default device is an Intel Gen12 (Xe) GPU."""
+    device_name = dpctl.SyclDevice().name
+    if "Gen12" in device_name:
+        return True
 
-        return False
+    return False
 
 
 def platform_not_supported(device_type):

--- a/numba_dpex/tests/dpjit_tests/parfors/test_dpnp_ufuncs.py
+++ b/numba_dpex/tests/dpjit_tests/parfors/test_dpnp_ufuncs.py
@@ -23,7 +23,6 @@ from numba_dpex.core.typing.dpnpdecl import (
 from numba_dpex.tests._helper import (
     get_float_dtypes,
     get_int_dtypes,
-    has_opencl_gpu,
     is_gen12,
     num_required_arguments,
 )
@@ -154,7 +153,7 @@ def test_unary_ops(unary_op, dtype):
         pytest.xfail(reason="not supported")
 
     xfail_ops = ["sign", "log", "log2", "log10", "expm1", "arccosh"]
-    if unary_op in xfail_ops and is_gen12(dpctl.SyclDevice().filter_string):
+    if unary_op in xfail_ops and is_gen12():
         pytest.xfail(f"{unary_op} does not work on gen12")
 
     a = dpnp.array(dpnp.random.random(N), dtype)


### PR DESCRIPTION
- [X] Have you provided a meaningful PR description?
We had a left over use of `dpctl.device_context` in our test suite. Now that the `device_context` context manager has been fully removed from dpctl, the public Github CI was failing. The PR updates numba-dpex's source to not use the `device_context`.
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
