### PR TITLE
Port the parfor range kernel template to new API.

### DIFF
--- a/numba_dpex/core/descriptor.py
+++ b/numba_dpex/core/descriptor.py
@@ -96,6 +96,10 @@ class DpexKernelTarget(TargetDescriptor):
         """
         return self._toplevel_typing_context
 
+    @property
+    def target_name(self):
+        return self._target_name
+
 
 class DpexTarget(TargetDescriptor):
     """

--- a/numba_dpex/core/parfors/kernel_templates/range_kernel_template.py
+++ b/numba_dpex/core/parfors/kernel_templates/range_kernel_template.py
@@ -63,7 +63,7 @@ class RangeKernelTemplate:
 
         # Create the dpex kernel function.
         kernel_txt += "def " + self._kernel_name
-        kernel_txt += "(" + (", ".join(self._kernel_params)) + "):\n"
+        kernel_txt += "(item, " + (", ".join(self._kernel_params)) + "):\n"
         global_id_dim = 0
         for_loop_dim = self._kernel_rank
         global_id_dim = self._kernel_rank
@@ -71,7 +71,7 @@ class RangeKernelTemplate:
         for dim in range(global_id_dim):
             dimstr = str(dim)
             kernel_txt += (
-                f"    {self._ivar_names[dim]} = dpex.get_global_id({dimstr})\n"
+                f"    {self._ivar_names[dim]} = item.get_id({dimstr})\n"
             )
 
         for dim in range(global_id_dim, for_loop_dim):


### PR DESCRIPTION
- [X] Have you provided a meaningful PR description?
The range kernel template is used by the parfor kenrel builder to generate a range kernel from a parfor node. The PR migrates the template to the new kernel API.

- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
