### PR TITLE
Feature/migrate parfor

### DIFF
--- a/numba_dpex/core/parfors/kernel_builder.py
+++ b/numba_dpex/core/parfors/kernel_builder.py
@@ -44,6 +44,8 @@ class ParforKernel:
         kernel_args,
         kernel_arg_types,
         queue: dpctl.SyclQueue,
+        local_accessors=None,
+        work_group_size=None,
     ):
         self.name = name
         self.kernel = kernel
@@ -51,6 +53,8 @@ class ParforKernel:
         self.kernel_args = kernel_args
         self.kernel_arg_types = kernel_arg_types
         self.queue = queue
+        self.local_accessors = local_accessors
+        self.work_group_size = work_group_size
 
 
 def _print_block(block):

--- a/numba_dpex/core/parfors/kernel_templates/reduction_template.py
+++ b/numba_dpex/core/parfors/kernel_templates/reduction_template.py
@@ -30,8 +30,8 @@ class TreeReduceIntermediateKernelTemplate(KernelTemplateInterface):
         parfor_args,
         parfor_reddict,
         redvars_dict,
+        local_accessors_dict,
         typemap,
-        work_group_size,
     ) -> None:
         self._kernel_name = kernel_name
         self._kernel_params = kernel_params
@@ -44,8 +44,8 @@ class TreeReduceIntermediateKernelTemplate(KernelTemplateInterface):
         self._parfor_args = parfor_args
         self._parfor_reddict = parfor_reddict
         self._redvars_dict = redvars_dict
+        self._local_accessors_dict = local_accessors_dict
         self._typemap = typemap
-        self._work_group_size = work_group_size
 
         self._kernel_txt = self._generate_kernel_stub_as_string()
         self._kernel_ir = self._generate_kernel_ir()
@@ -75,13 +75,6 @@ class TreeReduceIntermediateKernelTemplate(KernelTemplateInterface):
                 f"    local_size{dim} = group.get_local_range({dstr})\n"
             )
             gufunc_txt += f"    group_id{dim} = group.get_group_id({dstr})\n"
-
-        # Allocate local_sums arrays for each reduction variable.
-        for redvar in self._redvars:
-            rtyp = str(self._typemap[redvar])
-            redvar = self._redvars_dict[redvar]
-            gufunc_txt += f"    local_sums_{redvar} = \
-                dpex.local.array({self._work_group_size}, dpnp.{rtyp})\n"
 
         for dim in range(global_id_dim, for_loop_dim):
             for indent in range(1 + (dim - global_id_dim)):

--- a/numba_dpex/core/parfors/kernel_templates/reduction_template.py
+++ b/numba_dpex/core/parfors/kernel_templates/reduction_template.py
@@ -278,10 +278,13 @@ class RemainderReduceIntermediateKernelTemplate(KernelTemplateInterface):
         )
 
         for redvar in self._redvars:
+            rtyp = str(self._typemap[redvar])
             legal_redvar = self._redvars_dict[redvar]
             gufunc_txt += "        "
             gufunc_txt += legal_redvar + " = "
-            gufunc_txt += f"{self._parfor_reddict[redvar].init_val}\n"
+            gufunc_txt += (
+                f"dpnp.{rtyp}({self._parfor_reddict[redvar].init_val})\n"
+            )
 
         gufunc_txt += (
             "        "
@@ -290,32 +293,17 @@ class RemainderReduceIntermediateKernelTemplate(KernelTemplateInterface):
             + f"{self._global_size_var_name[0]} + j\n"
         )
 
-        for redvar in self._redvars:
-            rtyp = str(self._typemap[redvar])
-            redvar = self._redvars_dict[redvar]
-            gufunc_txt += (
-                "        "
-                + f"local_sums_{redvar} = "
-                + f"dpex.local.array(1, dpnp.{rtyp})\n"
-            )
-
         gufunc_txt += "        " + self._sentinel_name + " = 0\n"
-
-        for i, redvar in enumerate(self._redvars):
-            legal_redvar = self._redvars_dict[redvar]
-            gufunc_txt += (
-                "        " + f"local_sums_{legal_redvar}[0] = {legal_redvar}\n"
-            )
 
         for i, redvar in enumerate(self._redvars):
             legal_redvar = self._redvars_dict[redvar]
             redop = self._parfor_reddict[redvar].redop
             if redop == operator.iadd:
                 gufunc_txt += f"        {self._final_sum_var_name[i]}[0] +=  \
-                    local_sums_{legal_redvar}[0]\n"
+                    {legal_redvar}\n"
             elif redop == operator.imul:
                 gufunc_txt += f"        {self._final_sum_var_name[i]}[0] *=  \
-                    local_sums_{legal_redvar}[0]\n"
+                    {legal_redvar}\n"
             else:
                 raise NotImplementedError
 

--- a/numba_dpex/core/parfors/reduction_kernel_builder.py
+++ b/numba_dpex/core/parfors/reduction_kernel_builder.py
@@ -19,8 +19,10 @@ from numba.core.ir_utils import (
 )
 from numba.core.typing import signature
 
+from numba_dpex.core.parfors.reduction_helper import ReductionKernelVariables
 from numba_dpex.core.types import DpctlSyclQueue
 from numba_dpex.core.types.kernel_api.index_space_ids import NdItemType
+from numba_dpex.core.types.kernel_api.local_accessor import LocalAccessorType
 
 from .kernel_builder import _print_body  # saved for debug
 from .kernel_builder import (
@@ -41,7 +43,7 @@ def create_reduction_main_kernel_for_parfor(
     typemap,
     flags,
     has_aliases,
-    reductionKernelVar,
+    reductionKernelVar: ReductionKernelVariables,
     parfor_reddict=None,
 ):
     """
@@ -79,20 +81,35 @@ def create_reduction_main_kernel_for_parfor(
         except KeyError:
             pass
 
+    parfor_params = reductionKernelVar.parfor_params.copy()
+    parfor_legalized_params = reductionKernelVar.parfor_legalized_params.copy()
+    parfor_param_types = reductionKernelVar.param_types.copy()
+    local_accessors_dict = {}
+    for k, v in reductionKernelVar.redvars_legal_dict.items():
+        la_var = "local_sums_" + v
+        local_accessors_dict[k] = la_var
+        idx = reductionKernelVar.parfor_params.index(k)
+        arr_ty = reductionKernelVar.param_types[idx]
+        la_ty = LocalAccessorType(parfor_dim, arr_ty.dtype)
+
+        parfor_params.append(la_var)
+        parfor_legalized_params.append(la_var)
+        parfor_param_types.append(la_ty)
+
     kernel_template = TreeReduceIntermediateKernelTemplate(
         kernel_name=kernel_name,
-        kernel_params=reductionKernelVar.parfor_legalized_params,
+        kernel_params=parfor_legalized_params,
         ivar_names=reductionKernelVar.legal_loop_indices,
         sentinel_name=sentinel_name,
         loop_ranges=loop_ranges,
         param_dict=reductionKernelVar.param_dict,
         parfor_dim=parfor_dim,
         redvars=reductionKernelVar.parfor_redvars,
-        parfor_args=reductionKernelVar.parfor_params,
+        parfor_args=parfor_params,
         parfor_reddict=parfor_reddict,
         redvars_dict=reductionKernelVar.redvars_legal_dict,
+        local_accessors_dict=local_accessors_dict,
         typemap=typemap,
-        work_group_size=reductionKernelVar.work_group_size,
     )
     kernel_ir = kernel_template.kernel_ir
 
@@ -116,7 +133,7 @@ def create_reduction_main_kernel_for_parfor(
             new_var_dict[name] = mk_unique_var(name)
 
     replace_var_names(kernel_ir.blocks, new_var_dict)
-    kernel_param_types = reductionKernelVar.param_types
+    kernel_param_types = parfor_param_types
     kernel_stub_last_label = max(kernel_ir.blocks.keys()) + 1
     # Add kernel stub last label to each parfor.loop_body label to prevent
     # label conflicts.
@@ -164,13 +181,20 @@ def create_reduction_main_kernel_for_parfor(
 
     flags.noalias = old_alias
 
+    parfor_params = (
+        reductionKernelVar.parfor_params.copy()
+        + parfor_params[len(reductionKernelVar.parfor_params) :]  # noqa: $203
+    )
+
     return ParforKernel(
         name=kernel_name,
         kernel=sycl_kernel,
         signature=kernel_sig,
-        kernel_args=reductionKernelVar.parfor_params,
-        kernel_arg_types=reductionKernelVar.func_arg_types,
+        kernel_args=parfor_params,
+        kernel_arg_types=parfor_param_types,
         queue=exec_queue,
+        local_accessors=set(local_accessors_dict.values()),
+        work_group_size=reductionKernelVar.work_group_size,
     )
 
 


### PR DESCRIPTION
Get rid of `dpex.get_global_id` and `dpex.local.array` from reduction kernels

- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
