### PR TITLE
Fix test case to work with NUMBA_CAPTURED_ERRORS=new_style

### DIFF
--- a/numba_dpex/tests/dpjit_tests/dpnp/test_target_specific_overload.py
+++ b/numba_dpex/tests/dpjit_tests/dpnp/test_target_specific_overload.py
@@ -23,5 +23,5 @@ def test_dpnp_dpex_target(func):
     dpnp_func_dpjit = dpjit(dpnp_func)
 
     dpnp_func_dpjit()
-    with pytest.raises(errors.TypingError):
+    with pytest.raises((errors.TypingError, errors.UnsupportedError)):
         dpnp_func_njit()


### PR DESCRIPTION
- [X] Have you provided a meaningful PR description?
Update unit test so that it works in `new_style` Numba error capture mode.