### PR TITLE
fix windows wheels copy cmd

### DIFF
--- a/conda-recipe/bld.bat
+++ b/conda-recipe/bld.bat
@@ -41,8 +41,6 @@ for /f %%f in ('dir /b /S .\dist') do (
 
 :: Copy wheel package
 if NOT "%WHEELS_OUTPUT_FOLDER%"=="" (
-    for /f %%f in ('dir /b /S .\dist') do (
-        copy %%f %WHEELS_OUTPUT_FOLDER%
-        if %ERRORLEVEL% neq 0 exit 1
-    )
+    copy dist\numba_dpex*.whl %WHEELS_OUTPUT_FOLDER%
+    if errorlevel 1 exit 1
 )


### PR DESCRIPTION
This PR fixes the windows wheel copying by returning it to the previous cmd. We don't need to store anything in the artifacts except the wheel package. Also, for some reason, cmd does not work correctly and does not save anything in the artifacts at all and the wheel package is missing

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
