### PR TITLE
Update example to use latest dpctl API.

### DIFF
--- a/numba_dpex/examples/kernel/matmul.py
+++ b/numba_dpex/examples/kernel/matmul.py
@@ -83,7 +83,7 @@ Y = _arange_reshaped((5, 5), dtype)
 X = dpt.asarray(X)
 Y = dpt.asarray(Y)
 device = X.device.sycl_device
-result = dpt.zeros((5, 5), dtype, device=device)
+result = dpt.zeros((5, 5), dtype=dtype, device=device)
 X_slm = kapi.LocalAccessor(shape=work_group_size, dtype=dtype)
 Y_slm = kapi.LocalAccessor(shape=work_group_size, dtype=dtype)
 


### PR DESCRIPTION
- [X] Have you provided a meaningful PR description?
The `matmul` examples fails in CI as dpctl was updated to a new API. The PR fixes the example by using latest dpctl API.
