### PR TITLE
Migrate parfor to SPIRVKernelDispatcher

### DIFF
--- a/numba_dpex/core/descriptor.py
+++ b/numba_dpex/core/descriptor.py
@@ -48,6 +48,8 @@ class DpexTargetOptions(CPUTargetOptions):
     no_compile = _option_mapping("no_compile")
     inline_threshold = _option_mapping("inline_threshold")
     _compilation_mode = _option_mapping("_compilation_mode")
+    # TODO: create separate parfor kernel target
+    _parfor_body_args = _option_mapping("_parfor_body_args")
 
     def finalize(self, flags, options):
         super().finalize(flags, options)
@@ -63,6 +65,7 @@ class DpexTargetOptions(CPUTargetOptions):
         _inherit_if_not_set(
             flags, options, "_compilation_mode", CompilationMode.KERNEL
         )
+        _inherit_if_not_set(flags, options, "_parfor_body_args", None)
 
 
 class DpexKernelTarget(TargetDescriptor):

--- a/numba_dpex/core/parfors/kernel_templates/kernel_template_iface.py
+++ b/numba_dpex/core/parfors/kernel_templates/kernel_template_iface.py
@@ -30,13 +30,9 @@ class KernelTemplateInterface(metaclass=abc.ABCMeta):
     def dump_kernel_string(self):
         raise NotImplementedError
 
-    @abc.abstractmethod
-    def dump_kernel_ir(self):
-        raise NotImplementedError
-
     @property
     @abc.abstractmethod
-    def kernel_ir(self):
+    def py_func(self):
         raise NotImplementedError
 
     @property

--- a/numba_dpex/core/parfors/kernel_templates/range_kernel_template.py
+++ b/numba_dpex/core/parfors/kernel_templates/range_kernel_template.py
@@ -5,7 +5,6 @@
 import sys
 
 import dpnp
-from numba.core import compiler
 
 import numba_dpex as dpex
 
@@ -51,7 +50,7 @@ class RangeKernelTemplate:
         self._param_dict = param_dict
 
         self._kernel_txt = self._generate_kernel_stub_as_string()
-        self._kernel_ir = self._generate_kernel_ir()
+        self._py_func = self._generate_kernel_ir()
 
     def _generate_kernel_stub_as_string(self):
         """Generates a stub dpex kernel for the parfor as a string.
@@ -109,17 +108,15 @@ class RangeKernelTemplate:
         globls = {"dpnp": dpnp, "dpex": dpex}
         locls = {}
         exec(self._kernel_txt, globls, locls)
-        kernel_fn = locls[self._kernel_name]
-
-        return compiler.run_frontend(kernel_fn)
+        return locls[self._kernel_name]
 
     @property
-    def kernel_ir(self):
-        """Returns the Numba IR generated for a RangeKernelTemplate.
-
-        Returns: The Numba functionIR object for the compiled kernel_txt string.
+    def py_func(self):
+        """Returns the python function generated for a
+            TreeReduceIntermediateKernelTemplate.
+        Returns: The python function object for the compiled kernel_txt string.
         """
-        return self._kernel_ir
+        return self._py_func
 
     @property
     def kernel_string(self):
@@ -134,7 +131,3 @@ class RangeKernelTemplate:
         """Helper to print the kernel function string."""
         print(self._kernel_txt)
         sys.stdout.flush()
-
-    def dump_kernel_ir(self):
-        """Helper to dump the Numba IR for the RangeKernelTemplate."""
-        self._kernel_ir.dump()

--- a/numba_dpex/core/parfors/kernel_templates/reduction_template.py
+++ b/numba_dpex/core/parfors/kernel_templates/reduction_template.py
@@ -6,7 +6,6 @@ import operator
 import sys
 
 import dpnp
-from numba.core import compiler
 
 import numba_dpex.kernel_api as kapi
 
@@ -48,7 +47,7 @@ class TreeReduceIntermediateKernelTemplate(KernelTemplateInterface):
         self._typemap = typemap
 
         self._kernel_txt = self._generate_kernel_stub_as_string()
-        self._kernel_ir = self._generate_kernel_ir()
+        self._py_func = self._generate_kernel_ir()
 
     def _generate_kernel_stub_as_string(self):
         """Generate reduction main kernel template"""
@@ -161,18 +160,15 @@ class TreeReduceIntermediateKernelTemplate(KernelTemplateInterface):
         globls = {"dpnp": dpnp, "kapi": kapi}
         locls = {}
         exec(self._kernel_txt, globls, locls)
-        kernel_fn = locls[self._kernel_name]
-
-        return compiler.run_frontend(kernel_fn)
+        return locls[self._kernel_name]
 
     @property
-    def kernel_ir(self):
-        """Returns the Numba IR generated for a
+    def py_func(self):
+        """Returns the python function generated for a
             TreeReduceIntermediateKernelTemplate.
-
-        Returns: The Numba functionIR object for the compiled kernel_txt string.
+        Returns: The python function object for the compiled kernel_txt string.
         """
-        return self._kernel_ir
+        return self._py_func
 
     @property
     def kernel_string(self):
@@ -189,11 +185,6 @@ class TreeReduceIntermediateKernelTemplate(KernelTemplateInterface):
         """Helper to print the kernel function string."""
         print(self._kernel_txt)
         sys.stdout.flush()
-
-    def dump_kernel_ir(self):
-        """Helper to dump the Numba IR for a
-        TreeReduceIntermediateKernelTemplate."""
-        self._kernel_ir.dump()
 
 
 class RemainderReduceIntermediateKernelTemplate(KernelTemplateInterface):
@@ -234,7 +225,7 @@ class RemainderReduceIntermediateKernelTemplate(KernelTemplateInterface):
         self._reductionKernelVar = reductionKernelVar
 
         self._kernel_txt = self._generate_kernel_stub_as_string()
-        self._kernel_ir = self._generate_kernel_ir()
+        self._py_func = self._generate_kernel_ir()
 
     def _generate_kernel_stub_as_string(self):
         """Generate reduction remainder kernel template"""
@@ -320,18 +311,15 @@ class RemainderReduceIntermediateKernelTemplate(KernelTemplateInterface):
         globls = {"dpnp": dpnp, "kapi": kapi}
         locls = {}
         exec(self._kernel_txt, globls, locls)
-        kernel_fn = locls[self._kernel_name]
-
-        return compiler.run_frontend(kernel_fn)
+        return locls[self._kernel_name]
 
     @property
-    def kernel_ir(self):
-        """Returns the Numba IR generated for a
-            RemainderReduceIntermediateKernelTemplate.
-
-        Returns: The Numba functionIR object for the compiled kernel_txt string.
+    def py_func(self):
+        """Returns the python function generated for a
+            TreeReduceIntermediateKernelTemplate.
+        Returns: The python function object for the compiled kernel_txt string.
         """
-        return self._kernel_ir
+        return self._py_func
 
     @property
     def kernel_string(self):
@@ -349,9 +337,3 @@ class RemainderReduceIntermediateKernelTemplate(KernelTemplateInterface):
 
         print(self._kernel_txt)
         sys.stdout.flush()
-
-    def dump_kernel_ir(self):
-        """Helper to dump the Numba IR for the
-        RemainderReduceIntermediateKernelTemplate."""
-
-        self._kernel_ir.dump()

--- a/numba_dpex/core/parfors/parfor_lowerer.py
+++ b/numba_dpex/core/parfors/parfor_lowerer.py
@@ -31,9 +31,6 @@ from .reduction_kernel_builder import (
     create_reduction_remainder_kernel_for_parfor,
 )
 
-# A global list of kernels to keep the objects alive indefinitely.
-keep_alive_kernels = []
-
 
 def _getvar(lowerer, x):
     """Returns the LLVM Value corresponding to a Numba IR variable.
@@ -154,19 +151,15 @@ class ParforLowerImpl:
         kernel_fn: ParforKernel,
         global_range,
         local_range,
+        debug=False,
     ):
         """
         Adds a call to submit a kernel function into the function body of the
         current Numba JIT compiled function.
         """
-        # Ensure that the Python arguments are kept alive for the duration of
-        # the kernel execution
-        keep_alive_kernels.append(kernel_fn.kernel)
         kl_builder = KernelLaunchIRBuilder(
             lowerer.context, lowerer.builder, kernel_dmm
         )
-
-        queue_ref = kl_builder.get_queue(exec_queue=kernel_fn.queue)
 
         kernel_args = []
         for i, arg in enumerate(kernel_fn.kernel_args):
@@ -188,24 +181,23 @@ class ParforLowerImpl:
             else:
                 kernel_args.append(_getvar(lowerer, arg))
 
-        kernel_ref_addr = kernel_fn.kernel.addressof_ref()
-        kernel_ref = lowerer.builder.inttoptr(
-            lowerer.context.get_constant(types.uintp, kernel_ref_addr),
-            cgutils.voidptr_t,
-        )
-
-        kl_builder.set_kernel(kernel_ref)
-        kl_builder.set_queue(queue_ref)
         kl_builder.set_range(global_range, local_range)
         kl_builder.set_arguments(
             kernel_fn.kernel_arg_types, kernel_args=kernel_args
         )
+        kl_builder.set_queue_from_arguments()
         kl_builder.set_dependent_events([])
+        kl_builder.set_kernel_from_spirv(
+            kernel_fn.kernel_module,
+            debug=debug,
+        )
+
         event_ref = kl_builder.submit()
 
         sycl.dpctl_event_wait(lowerer.builder, event_ref)
         sycl.dpctl_event_delete(lowerer.builder, event_ref)
-        sycl.dpctl_queue_delete(lowerer.builder, queue_ref)
+
+        return kl_builder.arguments.sycl_queue_ref
 
     def _reduction_codegen(
         self,
@@ -263,8 +255,6 @@ class ParforLowerImpl:
             loop_ranges,
             parfor,
             typemap,
-            flags,
-            bool(alias_map),
             reductionKernelVar,
             parfor_reddict,
         )
@@ -278,13 +268,12 @@ class ParforLowerImpl:
             parfor_kernel,
             global_range,
             local_range,
+            debug=flags.debuginfo,
         )
 
         parfor_kernel = create_reduction_remainder_kernel_for_parfor(
             parfor,
             typemap,
-            flags,
-            bool(alias_map),
             reductionKernelVar,
             parfor_reddict,
             reductionHelperList,
@@ -292,14 +281,16 @@ class ParforLowerImpl:
 
         global_range, local_range = self._remainder_ranges(lowerer)
 
-        self._submit_parfor_kernel(
+        # TODO: find better way to pass queue
+        queue_ref = self._submit_parfor_kernel(
             lowerer,
             parfor_kernel,
             global_range,
             local_range,
+            debug=flags.debuginfo,
         )
 
-        reductionKernelVar.copy_final_sum_to_host(parfor_kernel)
+        reductionKernelVar.copy_final_sum_to_host(queue_ref)
 
     def _lower_parfor_as_kernel(self, lowerer, parfor):
         """Lowers a parfor node created by the dpjit compiler to a
@@ -400,9 +391,7 @@ class ParforLowerImpl:
                     lowerer,
                     parfor,
                     typemap,
-                    flags,
                     loop_ranges,
-                    bool(alias_map),
                     parfor.races,
                     parfor_output_arrays,
                 )
@@ -418,9 +407,8 @@ class ParforLowerImpl:
                 parfor_kernel,
                 global_range,
                 local_range,
+                debug=flags.debuginfo,
             )
-
-        # TODO: free the kernel at this point
 
         # Restore the original typemap of the function that was replaced
         # temporarily at the beginning of this function.

--- a/numba_dpex/core/parfors/parfor_sentinel_replace_pass.py
+++ b/numba_dpex/core/parfors/parfor_sentinel_replace_pass.py
@@ -1,0 +1,110 @@
+# SPDX-FileCopyrightText: 2024 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import NamedTuple, Union
+
+from numba.core import config
+from numba.core.compiler_machinery import FunctionPass, register_pass
+from numba.core.ir_utils import (
+    add_offset_to_labels,
+    get_name_var_table,
+    get_unused_var_name,
+    mk_unique_var,
+    remove_dels,
+    rename_labels,
+    replace_var_names,
+)
+
+
+class ParforBodyArguments(NamedTuple):
+    """
+    Arguments containing information to inject parfor code inside kernel.
+    """
+
+    loop_body: any
+    param_dict: any
+    legal_loop_indices: any
+
+
+def _print_block(block):
+    for i, inst in enumerate(block.body):
+        print("    ", i, inst)
+
+
+def _print_body(body_dict):
+    """Pretty-print a set of IR blocks."""
+    for label, block in body_dict.items():
+        print("label: ", label)
+        _print_block(block)
+
+
+@register_pass(mutates_CFG=True, analysis_only=False)
+class ParforSentinelReplacePass(FunctionPass):
+    _name = "sentinel_inject"
+
+    def __init__(self):
+        FunctionPass.__init__(self)
+
+    def _get_parfor_body_args(self, flags) -> Union[ParforBodyArguments, None]:
+        if not hasattr(flags, "_parfor_body_args"):
+            return None
+
+        return flags._parfor_body_args
+
+    def run_pass(self, state):
+        flags = state["flags"]
+
+        args = self._get_parfor_body_args(flags)
+
+        if args is None:
+            return True
+
+        # beginning
+        kernel_ir = state["func_ir"]
+        loop_body = args.loop_body
+
+        if config.DEBUG_ARRAY_OPT:
+            print("kernel_ir dump ", type(kernel_ir))
+            kernel_ir.dump()
+            print("loop_body dump ", type(loop_body))
+            _print_body(loop_body)
+
+        # Determine the unique names of the scheduling and kernel functions.
+        loop_body_var_table = get_name_var_table(loop_body)
+        sentinel_name = get_unused_var_name("__sentinel__", loop_body_var_table)
+
+        # rename all variables in kernel_ir afresh
+        var_table = get_name_var_table(kernel_ir.blocks)
+        new_var_dict = {}
+        reserved_names = (
+            [sentinel_name]
+            + list(args.param_dict.values())
+            + args.legal_loop_indices
+        )
+        for name, _ in var_table.items():
+            if not (name in reserved_names):
+                new_var_dict[name] = mk_unique_var(name)
+
+        replace_var_names(kernel_ir.blocks, new_var_dict)
+
+        kernel_stub_last_label = max(kernel_ir.blocks.keys()) + 1
+        loop_body = add_offset_to_labels(loop_body, kernel_stub_last_label)
+
+        # new label for splitting sentinel block
+        new_label = max(loop_body.keys()) + 1
+
+        from .kernel_builder import update_sentinel  # circular
+
+        update_sentinel(kernel_ir, sentinel_name, loop_body, new_label)
+
+        # FIXME: Why rename and remove dels causes the partial_sum array update
+        # instructions to be removed.
+        kernel_ir.blocks = rename_labels(kernel_ir.blocks)
+        remove_dels(kernel_ir.blocks)
+
+        if config.DEBUG_ARRAY_OPT:
+            print("kernel_ir after remove dead")
+            kernel_ir.dump()
+
+        return True

--- a/numba_dpex/core/parfors/reduction_helper.py
+++ b/numba_dpex/core/parfors/reduction_helper.py
@@ -275,12 +275,14 @@ class ReductionKernelVariables:
         param_dict = _legalize_names_with_typemap(parfor_params, typemap)
         ind_dict = _legalize_names_with_typemap(loop_indices, typemap)
         self._parfor_reddict = parfor_reddict
+        # output of reduction
         self._parfor_redvars = parfor_redvars
         self._redvars_legal_dict = legalize_names(parfor_redvars)
         # Compute a new list of legal loop index names.
         legal_loop_indices = [ind_dict[v] for v in loop_indices]
 
         tmp1 = []
+        # output of reduction computed on device
         self._final_sum_names = []
         self._parfor_redvars_to_redarrs = {}
         for ele1 in reductionHelperList:
@@ -397,16 +399,8 @@ class ReductionKernelVariables:
     def work_group_size(self):
         return self._work_group_size
 
-    def copy_final_sum_to_host(self, parfor_kernel):
+    def copy_final_sum_to_host(self, queue_ref):
         lowerer = self.lowerer
-        kl_builder = KernelLaunchIRBuilder(
-            lowerer.context, lowerer.builder, kernel_dmm
-        )
-
-        # Create a local variable storing a pointer to a DPCTLSyclQueueRef
-        # pointer.
-        queue_ref = kl_builder.get_queue(exec_queue=parfor_kernel.queue)
-
         builder = lowerer.builder
         context = lowerer.context
 
@@ -448,5 +442,3 @@ class ReductionKernelVariables:
             event_ref = sycl.dpctl_queue_memcpy(builder, *args)
             sycl.dpctl_event_wait(builder, event_ref)
             sycl.dpctl_event_delete(builder, event_ref)
-
-        sycl.dpctl_queue_delete(builder, queue_ref)

--- a/numba_dpex/core/pipelines/kernel_compiler.py
+++ b/numba_dpex/core/pipelines/kernel_compiler.py
@@ -8,8 +8,12 @@ from numba.core.typed_passes import (
     IRLegalization,
     NoPythonSupportedFeatureValidation,
 )
+from numba.core.untyped_passes import InlineClosureLikes
 
 from numba_dpex.core.exceptions import UnsupportedCompilationModeError
+from numba_dpex.core.parfors.parfor_sentinel_replace_pass import (
+    ParforSentinelReplacePass,
+)
 from numba_dpex.core.passes.passes import (
     NoPythonBackend,
     QualNameDisambiguationLowering,
@@ -57,6 +61,8 @@ class _KernelPassBuilder(object):
         pm = PassManager(name)
         untyped_passes = ndpb.define_untyped_pipeline(state)
         pm.passes.extend(untyped_passes.passes)
+        # TODO: create separate parfor kernel pass
+        pm.add_pass_after(ParforSentinelReplacePass, InlineClosureLikes)
 
         typed_passes = ndpb.define_typed_pipeline(state)
         pm.passes.extend(typed_passes.passes)

--- a/numba_dpex/kernel_api_impl/spirv/dispatcher.py
+++ b/numba_dpex/kernel_api_impl/spirv/dispatcher.py
@@ -26,7 +26,7 @@ from numba.core.types import Array as NpArrayType
 from numba.core.types import void
 from numba.core.typing.typeof import Purpose, typeof
 
-from numba_dpex import config
+from numba_dpex.core import config
 from numba_dpex.core.descriptor import dpex_kernel_target
 from numba_dpex.core.exceptions import (
     ExecutionQueueInferenceError,


### PR DESCRIPTION
What was done:
- Compile parfor kernels using `SpirvDispatcher`.
- Add internal option to compile kernel with Prange support. This mode inserts prange body instead of `__seninel__ = 0`. Ideally it  must be replace to some internal dedicated function call like `numba_dpex.core.insert_parfor_body()`.
- Remove kernel allocation aside of dpjit compilation. Now parfor kernel specific SPIRV is a part of dpjit function inserted as a string constant. It unblocks dpjit function caching on disk

Checklist:
- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
