### PR TITLE
Revert 98f3b05df to see if sources are visible on coveralls.io

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -57,5 +57,28 @@ jobs:
           pytest  -q --cov --cov-report xml --pyargs numba_dpex \
             -k 'not test_1d_strided_dpnp_array_in_kernel[2]'
 
-      - name: Coveralls
-        uses: coverallsapp/github-action@v2
+      - name: Install coveralls
+        shell: bash -l {0}
+        run: |
+          pip install coveralls
+
+      - name: Upload coverage data to coveralls.io
+        run: |
+          coveralls --service=github
+        env:
+          GITHUB_TOKEN: ${{ secrets.github_token }}
+          COVERALLS_PARALLEL: true
+
+  coveralls:
+    name: Indicate completion to coveralls.io
+    needs: main
+    runs-on: ubuntu-latest
+    container: python:3-slim
+    steps:
+    - name: Coveralls Finished
+      run: |
+        pip3 install --upgrade coveralls
+        coveralls --finish
+      env:
+        GITHUB_TOKEN: ${{ secrets.github_token }}
+        COVERALLS_PARALLEL: true


### PR DESCRIPTION
- [X] Have you provided a meaningful PR description?
Reverts 98f3b05df  Coveralls.io does not display the sources for numba-dpex anymore. The PR triages if the problem is due to the official coveralls workflow.

Although not showing sources is a feature and not a bug (https://github.com/lemurheavy/coveralls-public/issues/1579), the sources are displayed for dpctl and dpnp. So, let us see what happens if we go back to what was there before.

- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
