### PR TITLE
Pin dpcpp-llvm-spirv version

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -37,9 +37,11 @@ requirements:
         - dpctl >=0.16.1
         - dpnp >=0.14
         - numpy >=1.24
+        # TODO: temporary fix, because IGC is broken for output produced by llvm-spirv 2024.1 on windows
         # TODO: there is no 2024 release for python 3.11
         # - dpcpp-llvm-spirv >={{ required_compiler_version }}
-        - dpcpp-llvm-spirv >=2023.0
+        - dpcpp-llvm-spirv >=2023.0 # [not win]
+        - dpcpp-llvm-spirv >=2023.0,<2024.1 # [win]
         - wheel >=0.43
         - pip >=24.0
         - python-build >=1.1
@@ -50,6 +52,9 @@ requirements:
         - {{ pin_compatible('dpcpp-cpp-rt', min_pin='x.x', max_pin='x') }}
         - {{ pin_compatible('intel-cmplr-lib-rt', min_pin='x.x', max_pin='x') }}
         - {{ pin_compatible('dpcpp-llvm-spirv', min_pin='x.x', max_pin='x') }}
+        # TODO: temporary fix, because IGC is broken for output produced by llvm-spirv 2024.1 on windows
+        - {{ pin_compatible('dpcpp-llvm-spirv', min_pin='x.x', max_pin='x') }} # [not win]
+        - {{ pin_compatible('dpcpp-llvm-spirv', min_pin='x.x', max_pin='x', upper_bound='2024.1') }} # [win]
         - {{ pin_compatible('dpnp', min_pin='x.x.x', max_pin='x.x') }}
         - {{ pin_compatible('dpctl', min_pin='x.x.x', max_pin='x.x') }}
         - {{ pin_compatible('numba', min_pin='x.x.x', max_pin='x.x') }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
   "dpctl>=0.16.1",
   "dpnp>=0.14.0",
   "numpy>=1.24.0",
-  "dpcpp_llvm_spirv>=2024.0"
+  "dpcpp_llvm_spirv>=2023.0"
 ]
 description = "An extension for Numba to add data-parallel offload capability"
 dynamic = ["version"]


### PR DESCRIPTION
Pin spirv version due to driver runtime bug on windows with the kernel binary produced by llvm-spirv>2024.1.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?

```
 conda search local::numba-dpex==0.23* --info
Loading channels: done
numba-dpex 0.23.0rc1 py310h2e52968_8
------------------------------------
file name   : numba-dpex-0.23.0rc1-py310h2e52968_8.tar.bz2
name        : numba-dpex
version     : 0.23.0rc1
build       : py310h2e52968_8
build number: 8
size        : 463 KB
license     : Apache-2.0
subdir      : win-64
url         : file:///C:/Users/yevhenii/scoop/apps/miniconda3/current/conda-bld/win-64/numba-dpex-0.23.0rc1-py310h2e52968_8.tar.bz2
md5         : 25c1eb70be9e3b3ea5527206ca69fc71
timestamp   : 2024-04-22 16:53:12 UTC
dependencies:
  - dpcpp-cpp-rt >=2024.1,<2025.0a0
  - dpcpp-cpp-rt >=2024.1.0,<2025.0a0
  - dpcpp-llvm-spirv >=2024.0,<2025.0a0
  - dpcpp-llvm-spirv >=2024.0.0,<2024.1
  - dpctl >=0.17.0dev0,<0.18.0a0
  - dpnp >=0.15.0dev1,<0.16.0a0
  - intel-cmplr-lib-rt >=2024.1,<2025.0a0
  - llvmlite >=0.42.0,<0.43.0a0
  - numba >=0.59.1,<0.60.0a0
  - numpy >=1.26.4,<2.0a0
  - python >=3.10,<3.11.0a0
  - python_abi 3.10.* *_cp310
  - vc >=14.1,<15
  - vc14_runtime >=14.16.27033


numba-dpex 0.23.0rc1 py311h2e52968_8
------------------------------------
file name   : numba-dpex-0.23.0rc1-py311h2e52968_8.tar.bz2
name        : numba-dpex
version     : 0.23.0rc1
build       : py311h2e52968_8
build number: 8
size        : 566 KB
license     : Apache-2.0
subdir      : win-64
url         : file:///C:/Users/yevhenii/scoop/apps/miniconda3/current/conda-bld/win-64/numba-dpex-0.23.0rc1-py311h2e52968_8.tar.bz2
md5         : dcd578a9418b70139eb882af50d1335d
timestamp   : 2024-04-22 16:59:07 UTC
dependencies:
  - dpcpp-cpp-rt >=2024.1,<2025.0a0
  - dpcpp-cpp-rt >=2024.1.0,<2025.0a0
  - dpcpp-llvm-spirv >=2023.0,<2024.0a0
  - dpcpp-llvm-spirv >=2023.0.0,<2024.1
  - dpctl >=0.17.0dev0,<0.18.0a0
  - dpnp >=0.15.0dev1,<0.16.0a0
  - intel-cmplr-lib-rt >=2024.1,<2025.0a0
  - llvmlite >=0.42.0,<0.43.0a0
  - numba >=0.59.1,<0.60.0a0
  - numpy >=1.26.4,<2.0a0
  - python >=3.11,<3.12.0a0
  - python_abi 3.11.* *_cp311
  - vc >=14.1,<15
  - vc14_runtime >=14.16.27033
```