### PR TITLE
Remove dpcpp 2023 restriction workaround

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -38,10 +38,8 @@ requirements:
         - dpnp >=0.14
         - numpy >=1.24
         # TODO: temporary fix, because IGC is broken for output produced by llvm-spirv 2024.1 on windows
-        # TODO: there is no 2024 release for python 3.11
-        # - dpcpp-llvm-spirv >={{ required_compiler_version }}
-        - dpcpp-llvm-spirv >=2023.0 # [not win]
-        - dpcpp-llvm-spirv >=2023.0,<2024.1 # [win]
+        - dpcpp-llvm-spirv >={{ required_compiler_version }} # [not win]
+        - dpcpp-llvm-spirv >={{ required_compiler_version }},<2024.1 # [win]
         - wheel >=0.43
         - pip >=24.0
         - python-build >=1.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
   "dpctl>=0.16.1",
   "dpnp>=0.14.0",
   "numpy>=1.24.0",
-  "dpcpp_llvm_spirv>=2023.0"
+  "dpcpp_llvm_spirv>=2024.0"
 ]
 description = "An extension for Numba to add data-parallel offload capability"
 dynamic = ["version"]


### PR DESCRIPTION
Since `dpcpp-llvm-spirv` relase for python 3.11 in `dppy/label/dev` we can remove exception for it in package meta

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
