### PR TITLE
Remove MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,0 @@
-include MANIFEST.in
-include README.md setup.py LICENSE
-
-include numba_dpex/_version.py
-
-recursive-include numba_dpex/examples *

--- a/conda-recipe/bld.bat
+++ b/conda-recipe/bld.bat
@@ -50,10 +50,3 @@ if NOT "%WHEELS_OUTPUT_FOLDER%"=="" (
     copy dist\numba_dpex*.whl %WHEELS_OUTPUT_FOLDER%
     if errorlevel 1 exit 1
 )
-
-REM Delete artifacts from package
-rd /s /q "%PREFIX%\__pycache__"
-del "%PREFIX%\setup.py"
-del "%PREFIX%\LICENSE"
-del "%PREFIX%\README.md"
-del "%PREFIX%\MANIFEST.in"

--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -39,10 +39,3 @@ ${PYTHON} -m pip install dist/numba_dpex*.whl \
 if [[ -v WHEELS_OUTPUT_FOLDER ]]; then
     cp dist/numba_dpex*.whl "${WHEELS_OUTPUT_FOLDER[@]}"
 fi
-
-# Delete artifacts from package
-rm -rf "${PREFIX}/__pycache__"
-rm "${PREFIX}/setup.py"
-rm "${PREFIX}/LICENSE"
-rm "${PREFIX}/README.md"
-rm "${PREFIX}/MANIFEST.in"

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@
 import re
 
 import versioneer
-from setuptools import find_packages
+from setuptools import find_namespace_packages, find_packages
 from skbuild import setup
 
 """Top level setup.py file. Uses scikit-build.
@@ -58,7 +58,8 @@ setup(
     # Must be passed vis setup.py:
     # https://github.com/scikit-build/scikit-build/issues/864
     # TODO: switch to pyproject toml after switching to scikit-build-core
-    packages=find_packages("."),
+    packages=find_packages(".")
+    + find_namespace_packages(".", include=["numba_dpex.examples.*"]),
     # Needs for examples.
     # TODO: change to false once move examples out of package.
     include_package_data=True,


### PR DESCRIPTION
Reverts #1447 and fixes root cause of the problem: Manifest was setup incorrectly, that resulted wheel to install some artifacts in the root directory. It is no longer required as it managed through the setuptools configuration directly.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
