### PR TITLE
Required fixes to run test suite on Max GPU

### DIFF
--- a/numba_dpex/kernel_api_impl/spirv/spirv_generator.py
+++ b/numba_dpex/kernel_api_impl/spirv/spirv_generator.py
@@ -124,6 +124,7 @@ class Module:
             "--spirv-ext=+SPV_EXT_shader_atomic_float_add",
             "--spirv-ext=+SPV_EXT_shader_atomic_float_min_max",
             "--spirv-ext=+SPV_INTEL_arbitrary_precision_integers",
+            "--spirv-ext=+SPV_INTEL_variable_length_array",
         ]
         for key in list(self.context.extra_compile_options.keys()):
             if key == LLVM_SPIRV_ARGS:

--- a/numba_dpex/tests/codegen/test_intenum_literal_codegen.py
+++ b/numba_dpex/tests/codegen/test_intenum_literal_codegen.py
@@ -47,7 +47,7 @@ def test_compilation_as_literal_constant():
 
     pattern = re.compile(
         r"call spir_func i32 @\_Z.*bitwise\_or"
-        r"\_flags.*\(i64\* nonnull %.*, i64 1, i64 2\)"
+        r"\_flags.*\(i64\*\s(\w+)?\s*%.*, i64 1, i64 2\)"
     )
 
     assert re.search(pattern, llvm_ir_mod) is not None

--- a/numba_dpex/tests/debugging/gdb.py
+++ b/numba_dpex/tests/debugging/gdb.py
@@ -33,8 +33,8 @@ RE_DEVICE_ARRAY_TYPE = (
     r"layout=[A-Z],\s+"
     r"address_space=[0-4],\s+"
     r"usm_type=[a-z]+,\s+"
-    r"device=[a-z:0-9]+,\s+"
-    r"sycl_queue=[A-Za-z:0-9 ]+\)"
+    r"device=[a-z\_:0-9]+,\s+"
+    r"sycl_queue=[A-Za-z:0-9\s\_:]+\)"
 )
 
 
@@ -52,7 +52,7 @@ class gdb:
         env["NUMBA_DEBUGINFO"] = "1"
 
         self.child = pexpect.spawn(
-            "gdb-oneapi -q python", env=env, encoding="utf-8"
+            "gdb-oneapi -q python", env=env, encoding="utf-8", timeout=60
         )
         if config.TESTING_LOG_DEBUGGING:
             self.child.logfile = sys.stdout
@@ -109,7 +109,7 @@ class gdb:
         self.child.expect(r"[^\n]*\n")
 
     def expect_hit_breakpoint(self, expected_location=None):
-        expect = r"Thread [0-9A-Za-z \"]+ hit Breakpoint [0-9\.]+"
+        expect = r"Breakpoint [0-9\.]+"
         if expected_location is not None:
             # function name + args could be long, so we have to assume that
             # the message may be splitted in multiple lines. It potentially can

--- a/numba_dpex/tests/debugging/test_breakpoints.py
+++ b/numba_dpex/tests/debugging/test_breakpoints.py
@@ -58,7 +58,7 @@ def test_device_func_breakpoint(
 
     app.breakpoint(breakpoint, condition=condition)
     app.run(f"side-by-side.py --api={api}")
-    app.expect_hit_breakpoint("side-by-side.py:15")
+    app.expect_hit_breakpoint(expected_location="side-by-side.py:15")
     if exp_var is not None:
         app.print(exp_var, expected=exp_val)
 

--- a/numba_dpex/tests/debugging/test_info.py
+++ b/numba_dpex/tests/debugging/test_info.py
@@ -78,7 +78,7 @@ def test_info_args(
 ):
     app.breakpoint(breakpoint)
     app.run(script)
-    app.expect_hit_breakpoint(breakpoint)
+    app.expect_hit_breakpoint(expected_location=breakpoint)
     app.expect(expected_line, with_eol=True)
 
     if kind == "info":
@@ -99,7 +99,7 @@ def test_info_args(
 def test_info_functions(app):
     app.breakpoint("simple_sum.py:12")
     app.run("simple_sum.py")
-    app.expect_hit_breakpoint("simple_sum.py:12")
+    app.expect_hit_breakpoint(expected_location="simple_sum.py:12")
     app.expect(r"12\s+i = item.get_id\(0\)", with_eol=True)
 
     app.info_functions("data_parallel_sum")
@@ -119,7 +119,7 @@ def test_print_array_element(app, api):
 
     app.breakpoint("side-by-side-2.py:17", condition="param_a == 5")
     app.run(f"side-by-side-2.py --api={api}")
-    app.expect_hit_breakpoint("side-by-side-2.py:17")
+    app.expect_hit_breakpoint(expected_location="side-by-side-2.py:17")
 
     # We can access only c_array, not python style array
     app.print("b.data[5]", 5)
@@ -142,7 +142,7 @@ def test_print_array_element(app, api):
 def test_assignment_to_variable(app, api, assign):
     app.breakpoint("side-by-side-2.py:17", condition="param_a == 5")
     app.run(f"side-by-side-2.py --api={api}")
-    app.expect_hit_breakpoint("side-by-side-2.py:17")
+    app.expect_hit_breakpoint(expected_location="side-by-side-2.py:17")
 
     app.print("param_a", expected=5)
     if assign == "print":

--- a/numba_dpex/tests/debugging/test_stepping.py
+++ b/numba_dpex/tests/debugging/test_stepping.py
@@ -21,7 +21,7 @@ pytestmark = skip_no_gdb
 def test_next(app: gdb):
     app.breakpoint("simple_dpex_func.py:18")
     app.run("simple_dpex_func.py")
-    app.expect_hit_breakpoint("simple_dpex_func.py:18")
+    app.expect_hit_breakpoint(expected_location="simple_dpex_func.py:18")
     app.expect(r"18\s+i = item.get_id\(0\)", with_eol=True)
     app.set_scheduler_lock()
     app.next()
@@ -37,7 +37,7 @@ def test_next(app: gdb):
 def test_step(app: gdb):
     app.breakpoint("simple_dpex_func.py:19")
     app.run("simple_dpex_func.py")
-    app.expect_hit_breakpoint("simple_dpex_func.py:19")
+    app.expect_hit_breakpoint(expected_location="simple_dpex_func.py:19")
     app.expect(
         r"19\s+c_in_kernel\[i\] = func_sum\(a_in_kernel\[i\], b_in_kernel\[i\]\)",
         with_eol=True,
@@ -57,7 +57,7 @@ def test_step(app: gdb):
 def test_stepi(app: gdb, func: str):
     app.breakpoint("simple_dpex_func.py:19")
     app.run("simple_dpex_func.py")
-    app.expect_hit_breakpoint("simple_dpex_func.py:19")
+    app.expect_hit_breakpoint(expected_location="simple_dpex_func.py:19")
     app.expect(
         r"19\s+c_in_kernel\[i\] = func_sum\(a_in_kernel\[i\], b_in_kernel\[i\]\)",
         with_eol=True,


### PR DESCRIPTION
- [X] Have you provided a meaningful PR description?
 - The PR introduces changes to the gdb-oneapi unit tests to support running the tests on Intel Max GPU.
 - Updated the `test_intenum_literal_codegen.py` test case to handle a corner case that was identified during testing on Intel Max GPU.
 - Loads the `SPV_INTEL_variable_length_array` SPIR-V extension for llvm-spirv translation as it is required for supporting private arrays on Intel Max GPU.
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [X] Have you tested your changes locally for CPU and GPU devices?
- [X] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
