### PR TITLE
update wheel tag with pep600

### DIFF
--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -9,6 +9,9 @@ echo "--gcc-toolchain=${BUILD_PREFIX} --sysroot=${BUILD_PREFIX}/${HOST}/sysroot 
 ICPXCFG="$(pwd)/icpx_for_conda.cfg"
 ICXCFG="$(pwd)/icpx_for_conda.cfg"
 
+read -r GLIBC_MAJOR GLIBC_MINOR <<<"$(conda list '^sysroot_linux-64$' \
+    | tail -n 1 | awk '{print $2}' | grep -oP '\d+' | head -n 2 | tr '\n' ' ')"
+
 export ICXCFG
 export ICPXCFG
 
@@ -26,7 +29,8 @@ export PATH=$CONDA_PREFIX/bin-llvm:$PATH
 # -wnx flags mean: --wheel --no-isolation --skip-dependency-check
 ${PYTHON} -m build -w -n -x
 ${PYTHON} -m wheel tags --remove --build "$GIT_DESCRIBE_NUMBER" \
-    --platform-tag manylinux_2_28_x86_64 dist/numba_dpex*.whl
+    --platform-tag "manylinux_${GLIBC_MAJOR}_${GLIBC_MINOR}_x86_64" \
+    dist/numba_dpex*.whl
 ${PYTHON} -m pip install dist/numba_dpex*.whl \
     --no-build-isolation \
     --no-deps \

--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -26,7 +26,7 @@ export PATH=$CONDA_PREFIX/bin-llvm:$PATH
 # -wnx flags mean: --wheel --no-isolation --skip-dependency-check
 ${PYTHON} -m build -w -n -x
 ${PYTHON} -m wheel tags --remove --build "$GIT_DESCRIBE_NUMBER" \
-    --platform-tag manylinux2014_x86_64 dist/numba_dpex*.whl
+    --platform-tag manylinux_2_28_x86_64 dist/numba_dpex*.whl
 ${PYTHON} -m pip install dist/numba_dpex*.whl \
     --no-build-isolation \
     --no-deps \

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -24,9 +24,10 @@ requirements:
         - {{ compiler('cxx') }}
         - {{ compiler('dpcpp') }} >={{ required_compiler_version }},!={{ excluded_compiler_version1 }},!={{ excluded_compiler_version2 }},!={{ excluded_compiler_version3 }}  # [win]
         - {{ compiler('dpcpp') }} >={{ required_compiler_version }},!={{ excluded_compiler_version1 }},!={{ excluded_compiler_version2 }}  # [linux]
-        # specific version of sysroot required by dpcpp, but 2024.0.0 package
-        # does not have it in meta data
-        - sysroot_linux-64 >=2.28  # [linux]
+        # Minimal supported version of sysroot (which is version of glibc) to
+        # have compatibility with wider range of linux distributions.
+        # 2.28 is the minimal supported version by dpcpp
+        - sysroot_linux-64 =2.28  # [linux]
     host:
         - python
         - pip >=24.0


### PR DESCRIPTION
This PR is designed to fix the problem described here: [SAT-6873](https://jira.devtools.intel.com/browse/SAT-6873). I did some experiments and found out that using pep600 wheel tag prevents the wheel from being installed on non-supported platforms

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
