### PR TITLE
Fixed ref-counting of Python object temporaries in unboxing code

### DIFF
--- a/numba_dpex/core/runtime/_dpexrt_python.c
+++ b/numba_dpex/core/runtime/_dpexrt_python.c
@@ -842,7 +842,7 @@ static int DPEXRT_sycl_usm_ndarray_from_python(PyObject *obj,
     }
 
     if (!(arystruct->meminfo = NRT_MemInfo_new_from_usmndarray(
-              arrayobj, data, nitems, itemsize, qref)))
+              (PyObject *)arrayobj, data, nitems, itemsize, qref)))
     {
         DPEXRT_DEBUG(drt_debug_print(
             "DPEXRT-ERROR: NRT_MemInfo_new_from_usmndarray failed "
@@ -855,7 +855,7 @@ static int DPEXRT_sycl_usm_ndarray_from_python(PyObject *obj,
     arystruct->sycl_queue = qref;
     arystruct->nitems = nitems;
     arystruct->itemsize = itemsize;
-    arystruct->parent = arrayobj;
+    arystruct->parent = (PyObject *)arrayobj;
 
     p = arystruct->shape_and_strides;
 
@@ -907,7 +907,7 @@ error:
         __FILE__, __LINE__));
     gstate = PyGILState_Ensure();
     // decref the python object
-    Py_XDECREF(arrayobj);
+    Py_XDECREF((PyObject *)arrayobj);
     // release the GIL
     PyGILState_Release(gstate);
 


### PR DESCRIPTION
Ref-count of `arrayobj` was not decremented after use in case `dpnp.ndarray` object was being processed.

Change the flow of managing lifetime of Python temporaries in unboxing code.
This PR replaces use of `obj` in NRT structure with use of `arrayobj`, and shifts ref-count manipulation of `obj` into `PyUSMNdArray_ARRAYOBJ`.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
