### PR TITLE
Remove SPIRV version restriction

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -49,15 +49,14 @@ requirements:
         {% endfor %}
         # versioneer dependency
         - tomli # [py<311]
-        # TODO: temporary fix, because IGC is broken for output produced by llvm-spirv 2024.1 on windows
-        - dpcpp-llvm-spirv >={{ required_compiler_version }} # [not win]
-        - dpcpp-llvm-spirv >={{ required_compiler_version }},<2024.1 # [win]
+        # While we don't need it for build, but install it here, so we can
+        # pin_compatible at run section.
+        - dpcpp-llvm-spirv >={{ required_compiler_version }}
     run:
         - {{ pin_compatible('dpcpp-cpp-rt', min_pin='x.x', max_pin='x') }}
         - {{ pin_compatible('intel-cmplr-lib-rt', min_pin='x.x', max_pin='x') }}
-        # TODO: temporary fix, because IGC is broken for output produced by llvm-spirv 2024.1 on windows
-        - {{ pin_compatible('dpcpp-llvm-spirv', min_pin='x.x', max_pin='x') }} # [not win]
-        - {{ pin_compatible('dpcpp-llvm-spirv', min_pin='x.x', max_pin='x', upper_bound='2024.1') }} # [win]
+        # TODO: pick up min version from dep
+        - {{ pin_compatible('dpcpp-llvm-spirv', min_pin='x.x', max_pin='x') }}
         - {{ pin_compatible('dpnp', min_pin='x.x.x', max_pin='x.x') }}
         - {{ pin_compatible('dpctl', min_pin='x.x.x', max_pin='x.x') }}
         - {{ pin_compatible('numba', min_pin='x.x.x', max_pin='x.x') }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
   "dpctl>=0.16.1",
   "dpnp>=0.14.0",
   "numpy>=1.24.0",
-  "dpcpp_llvm_spirv>=2024.0"
+  "dpcpp_llvm_spirv>=2024.1"
 ]
 description = "An extension for Numba to add data-parallel offload capability"
 dynamic = ["version"]


### PR DESCRIPTION
The issue was with IGC driver on windows. It was tested that nightly builds of drivers are passing tests.

DO NOT MERGE until allowance from INFRA team.

- [ ] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
