### PR TITLE
Pin numba to 0.59 and use windows-2019 for build

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         python: ['3.9', '3.10', '3.11']
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-2019]
 
     runs-on: ${{ matrix.os }}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ requires = [
   # We need dpctl for UsmNdArray integration for dpcpp code
   "dpctl>=0.16.1",
   # We need numba for runtime cpp headers
-  "numba>=0.59.0",
+  "numba>=0.59.0,<0.60.0a0",
   "llvmlite>=0.42.0",
   # Do we need dpnp at build time?
   "dpnp >=0.14",
@@ -38,8 +38,7 @@ classifiers = [
 dependencies = [
   # TODO: keep in sync with [build-system.requires] and /conda-recipe/meta.yaml
   # This restrictions are for dependabot, actual restrictions are set with
-  # conda.
-  # TODO: populate it during build process
+  # conda. TODO: populate it during build process
   # TODO: do we have to set sycl runtime dependencies here
   # "dpcpp-cpp-rt>=0.59.0",
   # "intel-cmplr-lib-rt>=0.59.0"


### PR DESCRIPTION
Make CI green, so we can merge dependabot PRs

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
