### PR TITLE
Pin sphinx-autoapi==3.0.0

### DIFF
--- a/environment/docs.yml
+++ b/environment/docs.yml
@@ -20,7 +20,7 @@ dependencies:
   - pip
   - pip:
     - sphinx
-    - sphinx-autoapi
+    - sphinx-autoapi==3.0.0
     - autodoc # there is no conda package
     - recommonmark
     - sphinx-rtd-theme


### PR DESCRIPTION
Pin `sphinx-autoapi==3.0.0`. Newer version shrinks multiple files into one that breaks doc generation.

- [x] Have you provided a meaningful PR description?
- [ ] Have you added a test, reproducer or referred to an issue with a reproducer?
- [ ] Have you tested your changes locally for CPU and GPU devices?
- [ ] Have you made sure that new changes do not introduce compiler warnings?
- [ ] If this PR is a work in progress, are you filing the PR as a draft?
